### PR TITLE
SDKS-3425 Handle Sign out with ID Token for PingOne Platform.

### DIFF
--- a/davinci/src/test/kotlin/com/pingidentity/davinci/FlowCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/FlowCollectorTest.kt
@@ -5,7 +5,6 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import com.pingidentity.davinci.collector.FieldCollector
 import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
@@ -27,13 +26,6 @@ class FlowCollectorTest {
     fun testInitialization() {
         val flowCollector = FlowCollector()
         assertNotNull(flowCollector)
-    }
-
-    @TestRailCase(22145)
-    @Test
-    fun testInheritance() {
-        val flowCollector = FlowCollector()
-        assertTrue(flowCollector is FieldCollector)
     }
 
     @TestRailCase(22146)

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/SubmitCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/SubmitCollectorTest.kt
@@ -5,7 +5,6 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import com.pingidentity.davinci.collector.FieldCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
@@ -27,10 +26,4 @@ class SubmitCollectorTest {
         assertNotNull(submitCollector)
     }
 
-    @TestRailCase(22561)
-    @Test
-    fun testInheritance() {
-        val submitCollector = SubmitCollector()
-        assertTrue(submitCollector is FieldCollector)
-    }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/TextCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/TextCollectorTest.kt
@@ -5,7 +5,6 @@
  * of the MIT license. See the LICENSE file for details.
  */
 
-import com.pingidentity.davinci.collector.FieldCollector
 import com.pingidentity.davinci.collector.TextCollector
 import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
@@ -27,13 +26,6 @@ class TextCollectorTest {
     fun testInitialization() {
         val textCollector = TextCollector()
         assertNotNull(textCollector)
-    }
-
-    @TestRailCase(22556)
-    @Test
-    fun testInheritance() {
-        val textCollector = TextCollector()
-        assertTrue(textCollector is FieldCollector)
     }
 
     @TestRailCase(22557)

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/agent/Browser.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/agent/Browser.kt
@@ -15,8 +15,7 @@ import com.pingidentity.oidc.OidcConfig
 import com.pingidentity.utils.PingDsl
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.Url
+import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
 import net.openid.appauth.AppAuthConfiguration
 
@@ -61,29 +60,14 @@ var browser =
                 }
                 val response = oidcConfig.oidcClientConfig.httpClient.get(endpoint) {
                     headers {
-                        append("Accept", "application/json")
+                        append(HttpHeaders.Accept, "application/json")
                     }
                     url {
                         parameters.append(ID_TOKEN_HINT, idToken)
                         parameters.append(CLIENT_ID, oidcConfig.oidcClientConfig.clientId)
                     }
                 }
-                if (response.status.isSuccess()) {
-                    return true
-                } else {
-                    if (response.status == HttpStatusCode.Found) {
-                        response.headers["location"]?.let {
-                            val error = Url(it).parameters["error"]
-                            if (error != null) {
-                                oidcConfig.oidcClientConfig.logger.w("Error during end session: $error")
-                                return false
-                            } else {
-                                return true
-                            }
-                        }
-                    }
-                    return false
-                }
+                return response.status.isSuccess()
             }
         }
 

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
@@ -316,9 +316,7 @@ class OidcClientTest {
                         }
 
                         "/idp/signoff" -> {
-                            respond("", HttpStatusCode.Found,
-                                headersOf("location" to listOf("http://localhost/signoff"))
-                            )
+                            respond("", HttpStatusCode.NoContent)
                         }
 
                         else -> {

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/agent/BrowserTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/agent/BrowserTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024 PingIdentity. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.oidc.agent
+
+import com.pingidentity.oidc.OidcClientConfig
+import com.pingidentity.oidc.OidcConfig
+import com.pingidentity.oidc.OpenIdConfiguration
+import com.pingidentity.oidc.Token
+import com.pingidentity.storage.MemoryStorage
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class BrowserTest {
+
+    @Test
+    fun `browser end session with pingEndIdpSessionEndpoint`() = runTest {
+        val mockEngine =
+            MockEngine {
+                return@MockEngine respond(
+                    content =
+                    ByteReadChannel(""),
+                    status = HttpStatusCode.NoContent
+                )
+            }
+
+        val mock = HttpClient(mockEngine)
+
+        val oidcClientConfig = OidcClientConfig().apply {
+            httpClient = mock
+            openId = OpenIdConfiguration(
+                authorizationEndpoint = "http://localhost/openid-configuration",
+                tokenEndpoint = "http://localhost/token",
+                userinfoEndpoint = "http://localhost/userinfo",
+                endSessionEndpoint = "http://localhost/end-session",
+                pingEndIdpSessionEndpoint = "http://localhost/ping-end-idp-session",
+                revocationEndpoint = "http://localhost/revocation"
+            )
+            storage = MemoryStorage<Token>()
+            clientId = "test-client-id"
+        }
+
+        val result = browser.endSession(OidcConfig(browser.config()(), oidcClientConfig), "dummy-id-token")
+        val request = mockEngine.requestHistory[0]
+        assertTrue(result)
+        // Ensure that the pingEndIdpSessionEndpoint is used
+        assertEquals("http://localhost/ping-end-idp-session?id_token_hint=dummy-id-token&client_id=test-client-id", request.url.toString())
+        assertEquals("GET", request.method.value)
+        assertEquals("application/json", request.headers[HttpHeaders.Accept])
+    }
+
+    @Test
+    fun `browser end session with endSessionEndpoint`() = runTest {
+        val mockEngine =
+            MockEngine {
+                return@MockEngine respond(
+                    content =
+                    ByteReadChannel(""),
+                    status = HttpStatusCode.NoContent
+                )
+            }
+
+        val mock = HttpClient(mockEngine)
+
+        // The pingone custom end session endpoint is not defined, e.g AIC server
+        val oidcClientConfig = OidcClientConfig().apply {
+            httpClient = mock
+            openId = OpenIdConfiguration(
+                authorizationEndpoint = "http://localhost/openid-configuration",
+                tokenEndpoint = "http://localhost/token",
+                userinfoEndpoint = "http://localhost/userinfo",
+                endSessionEndpoint = "http://localhost/end-session",
+                pingEndIdpSessionEndpoint = "", //This is empty
+                revocationEndpoint = "http://localhost/revocation"
+            )
+            storage = MemoryStorage<Token>()
+            clientId = "test-client-id"
+        }
+
+        val result = browser.endSession(OidcConfig(browser.config()(), oidcClientConfig), "dummy-id-token")
+        val request = mockEngine.requestHistory[0]
+        assertTrue(result)
+        // Ensure that the endSessionEndpoint is used
+        assertEquals("http://localhost/end-session?id_token_hint=dummy-id-token&client_id=test-client-id", request.url.toString())
+        assertEquals("GET", request.method.value)
+        assertEquals("application/json", request.headers[HttpHeaders.Accept])
+    }
+}

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/ModuleRegistry.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/ModuleRegistry.kt
@@ -16,7 +16,7 @@ import androidx.annotation.VisibleForTesting
  * @param config The configuration for the module.
  * @param setup A function that sets up the module.
  */
-@VisibleForTesting
+@VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
 class ModuleRegistry<Config : Any> internal constructor(
     val module: Module<Config>,
     val priority: Int,


### PR DESCRIPTION
# JIRA Ticket

Please link jira ticket here

# Description

Handle Sign out with ID Token for PingOne Platform.

PingOne Platform Client Configuration:

Enable Terminate User Session By ID Token

Make sure do not use signOutRedirectUri
```kotlin
val pingTest =
    OidcClient {

        updateAgent(browser)
        clientId = "3172d977-8fdc-4e8b-b3c5-4f3a34cb7262"
        discoveryEndpoint =
            "https://auth.test-one-pingone.com/0c6851ed-0f12-4c9a-a174-9b1bf8b438ae/as/.well-known/openid-configuration"
        scopes = mutableSetOf("openid", "email", "address")
        // Make sure adding the redirectUri to the Signoff URLs console
        redirectUri = "com.pingidentity.demo://oauth2redirect"
        //signOutRedirectUri = "com.pingidentity.demo://oauth2redirect"
    }
```

When signOutRedirectUri is configured, the SDK will use browser to handle the logout.

