### PR TITLE
SDKS-3611 Attribute refreshThreshold, signOutRedirectUri and state are missing after cloning the OidcClientConfig

### DIFF
--- a/foundation/oidc/build.gradle.kts
+++ b/foundation/oidc/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.robolectric)
     testImplementation(libs.appauth)
+    testImplementation(kotlin("reflect"))
 
     testImplementation(project(":foundation:testrail"))
 }

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
@@ -13,7 +13,6 @@ import androidx.datastore.dataStore
 import com.pingidentity.android.ContextProvider
 import com.pingidentity.exception.ApiException
 import com.pingidentity.logger.Logger
-import com.pingidentity.logger.LoggerContext
 import com.pingidentity.logger.None
 import com.pingidentity.oidc.agent.browser
 import com.pingidentity.storage.DataStoreStorage
@@ -81,7 +80,7 @@ class OidcClientConfig {
     /**
      * Logger instance for logging.
      */
-    var logger: Logger = LoggerContext.get()
+    var logger: Logger = Logger.logger
 
     /**
      * Storage delegate for storing tokens.
@@ -236,6 +235,7 @@ class OidcClientConfig {
      */
     operator fun plusAssign(other: OidcClientConfig) {
         this.openId = other.openId
+        this.refreshThreshold = other.refreshThreshold
         this.agent = other.agent
         this.logger = other.logger
         this.storage = other.storage
@@ -243,7 +243,9 @@ class OidcClientConfig {
         this.clientId = other.clientId
         this.scopes = other.scopes
         this.redirectUri = other.redirectUri
+        this.signOutRedirectUri = other.signOutRedirectUri
         this.loginHint = other.loginHint
+        this.state = other.state
         this.nonce = other.nonce
         this.display = other.display
         this.prompt = other.prompt

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientConfigTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientConfigTest.kt
@@ -13,9 +13,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.pingidentity.android.ContextProvider
 import com.pingidentity.exception.ApiException
 import com.pingidentity.logger.CONSOLE
-import com.pingidentity.logger.Console
 import com.pingidentity.logger.Logger
-import com.pingidentity.logger.Standard
 import com.pingidentity.storage.MemoryStorage
 import com.pingidentity.storage.StorageDelegate
 import com.pingidentity.testrail.TestRailCase
@@ -33,11 +31,12 @@ import org.junit.Rule
 import org.junit.rules.TestWatcher
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
@@ -179,6 +178,7 @@ class OidcClientConfigTest {
         val oidcClientConfig =
             OidcClientConfig().apply {
                 openId = OpenIdConfiguration()
+                refreshThreshold = 100
                 agent = mockk()
                 logger = mockk()
                 storage = mockk<StorageDelegate<Token>>()
@@ -186,7 +186,9 @@ class OidcClientConfigTest {
                 clientId = "clientId"
                 scope("openid")
                 redirectUri = "http://localhost/callback"
+                signOutRedirectUri = "http://localhost/signout"
                 loginHint = "loginHint"
+                state = "state"
                 nonce = "nonce"
                 display = "display"
                 prompt = "prompt"
@@ -196,9 +198,14 @@ class OidcClientConfigTest {
                 httpClient = mockk()
             }
 
+        //Ensure there are 19 properties in the class for now.
+        val clazz: KClass<OidcClientConfig> = OidcClientConfig::class
+        assertEquals(clazz.memberProperties.size, 19)
+
         val clonedConfig = oidcClientConfig.clone()
 
         assertEquals(oidcClientConfig.openId, clonedConfig.openId)
+        assertEquals(oidcClientConfig.refreshThreshold, clonedConfig.refreshThreshold)
         assertEquals(oidcClientConfig.agent, clonedConfig.agent)
         assertEquals(oidcClientConfig.logger, clonedConfig.logger)
         assertEquals(oidcClientConfig.storage, clonedConfig.storage)
@@ -206,7 +213,9 @@ class OidcClientConfigTest {
         assertEquals(oidcClientConfig.clientId, clonedConfig.clientId)
         assertEquals(oidcClientConfig.scopes, clonedConfig.scopes)
         assertEquals(oidcClientConfig.redirectUri, clonedConfig.redirectUri)
+        assertEquals(oidcClientConfig.signOutRedirectUri, clonedConfig.signOutRedirectUri)
         assertEquals(oidcClientConfig.loginHint, clonedConfig.loginHint)
+        assertEquals(oidcClientConfig.state, clonedConfig.state)
         assertEquals(oidcClientConfig.nonce, clonedConfig.nonce)
         assertEquals(oidcClientConfig.display, clonedConfig.display)
         assertEquals(oidcClientConfig.prompt, clonedConfig.prompt)


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3611](https://pingidentity.atlassian.net/browse/SDKS-3611)

# Description

SDKS-3611 Attribute refreshThreshold, signOutRedirectUri and state are missing after cloning the OidcClientConfig