### PR TITLE
[SDKS-3465] Execute integration tests on device farm

### DIFF
--- a/.github/workflows/bitbar-prepare-artifacts.yaml
+++ b/.github/workflows/bitbar-prepare-artifacts.yaml
@@ -1,0 +1,111 @@
+#
+# Copyright (c) 2024 Ping Identity. All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+#
+
+name: Prepare BitBar Artifacts
+on:
+  workflow_call:
+    secrets:
+      SIGNING_KEYSTORE:
+        description: 'Needed for signing the apk artifacts'
+        required: true
+      SIGNING_ALIAS:
+        description: 'Needed for signing the apk artifacts'
+        required: true
+      SIGNING_KEYSTORE_PASSWORD:
+        description: 'Needed for signing the apk artifacts'
+        required: true
+      SIGNING_KEY_PASSWORD:
+        description: 'Needed for signing the apk artifacts'
+        required: true
+      SLACK_WEBHOOK:
+        description: Slack Notifier Incoming Webhook
+        required: true
+jobs:
+  prepare-device-farm-artifacts:
+    runs-on: macos-latest
+
+    steps:
+      # Clone the repo
+      - name: Clone the repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          fetch-depth: 0
+
+      # Setup JDK and cache and restore dependencies.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+
+      # Build apk files
+      - name: Prepare device farm artifacts
+        run: ./gradlew assembleDebugAndroidTest --stacktrace --no-daemon
+
+      # List the available build tools versions see https://github.com/r0adkll/sign-android-release/issues/84
+      - name: List build tools versions
+        run: ls /Users/runner/Library/Android/sdk/build-tools/
+
+      # Sign app-debug-androidTest.apk
+      - name: Sign app-debug-androidTest.apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: samples/app/build/outputs/apk/androidTest/debug
+          signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE }}
+          alias: ${{ secrets.SIGNING_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "35.0.0"
+
+      # Sign davinci-debug-androidTest.apk
+      - name: Sign davinci-debug-androidTest.apk
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: davinci/build/outputs/apk/androidTest/debug
+          signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE }}
+          alias: ${{ secrets.SIGNING_ALIAS }}
+          keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
+          keyPassword: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "35.0.0"
+
+      # Publish the signed APKs as build artifacts
+      - name: Publish app-debug-androidTest.apk
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: app-debug-androidTest-signed.apk
+          path: samples/app/build/outputs/apk/androidTest/debug/app-debug-androidTest-signed.apk
+
+      - name: Publish davinci-debug-androidTest.apk
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: davinci-debug-androidTest-signed.apk
+          path: davinci/build/outputs/apk/androidTest/debug/davinci-debug-androidTest-signed.apk
+
+      # Send slack notification ONLY if any of the steps above fail
+      - name: Send slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: all
+          custom_payload: |
+            {
+              attachments: [{
+                title: ':no_entry: Failed to prepare BitBar test artifacts',
+                color: 'danger',
+                text: `\nWorkflow: ${process.env.AS_WORKFLOW} -> ${process.env.AS_JOB}\nPull request: ${process.env.AS_PULL_REQUEST}\nCommit: ${process.env.AS_COMMIT} by ${process.env.AS_AUTHOR}`, 
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()

--- a/.github/workflows/bitbar-results.yaml
+++ b/.github/workflows/bitbar-results.yaml
@@ -1,0 +1,104 @@
+#
+# Copyright (c) 2024 Ping Identity. All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+#
+
+name: BitBar Test Results
+
+on:
+  workflow_call:
+    inputs:
+      bitbar-project-id:
+        description: BitBar Project ID
+        type: string
+        required: true
+      bitbar-run-id:
+        description: BitBar Run ID
+        type: string
+        required: true
+    outputs:
+      bitbar-run-url:
+        description: "The BitBar run URL"
+        value: ${{ jobs.bitbar-run.outputs.bitbar_run_url }}
+    secrets:
+      BITBAR_API_KEY:
+        description: BitBar API Key
+        required: true
+      SLACK_WEBHOOK:
+        description: Slack Notifier Incoming Webhook
+        required: true
+
+jobs:
+  bitbar-results:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Workflow inputs:"
+        run: |
+          echo "Project ID - ${{ inputs.bitbar-project-id }}"
+          echo "Run ID - ${{ inputs.bitbar-run-id }}"
+
+      - name: Wait for BitBar test run to finish...
+        timeout-minutes: 60
+        run: |
+          (
+            until [ "$(curl -s -u ${{ secrets.BITBAR_API_KEY }}: https://cloud.bitbar.com/api/me/projects/${{ inputs.bitbar-project-id }}/runs/${{ inputs.bitbar-run-id }} | jq -r '.state')" == "FINISHED" ];
+            do
+              echo "Waiting for BitBar Results. Sleeping for 10 seconds..."
+              sleep 10
+            done
+          )
+          echo "BITBAR_TEST_RUN_RESULT=$(curl -s -u ${{ secrets.BITBAR_API_KEY }}: https://cloud.bitbar.com/api/me/projects/${{ inputs.bitbar-project-id }}/runs/${{ inputs.bitbar-run-id }})" >> $GITHUB_ENV
+
+      # Get the outcome json of the test run.
+      - name: Parse test run outcome json
+        run: |
+          echo ${{ env.BITBAR_TEST_RUN_RESULT }}
+          echo "==========================================="
+          echo "projectName: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.projectName')"
+          echo "displayName: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.displayName')"
+          echo "executedTestCaseCount: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.executedTestCaseCount')"
+          echo "successfulTestCaseCount: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.successfulTestCaseCount')"
+          echo "failedTestCaseCount: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.failedTestCaseCount')"
+          echo "runningDeviceCount: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.runningDeviceCount')"
+          echo "totalDeviceCount: $(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq '.totalDeviceCount')"
+          echo "==========================================="
+          echo "BITBAR_PROJECT_NAME=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.projectName')" >> $GITHUB_ENV
+          echo "BITBAR_RUN_DISPLAY_NAME=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.displayName')" >> $GITHUB_ENV
+          echo "BITBAR_RUN_NUMBER=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.number')" >> $GITHUB_ENV
+          echo "BITBAR_EXECUTED_TESTS_COUNT=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.executedTestCaseCount')" >> $GITHUB_ENV
+          echo "BITBAR_SUCCESS_TESTS_COUNT=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.successfulTestCaseCount')" >> $GITHUB_ENV
+          echo "BITBAR_FAILED_TESTS_COUNT=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.failedTestCaseCount')" >> $GITHUB_ENV
+          echo "BITBAR_SUCCESS_RATIO=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.successRatio')" >> $GITHUB_ENV          
+          echo "BITBAR_DEVICE_COUNT=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.deviceCount')" >> $GITHUB_ENV
+          echo "BITBAR_DEVICE_GROUP_NAME=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.config.usedDeviceGroupName')" >> $GITHUB_ENV
+          echo "BITBAR_TEST_RUN_URL=$(echo '${{ env.BITBAR_TEST_RUN_RESULT }}' | jq -r '.uiLink')" >> $GITHUB_ENV
+
+      # Check for failures and set the outcome of the workflow
+      - name: Set job status
+        run: |
+          if [[ ${{env.BITBAR_FAILED_TESTS_COUNT}} != '0' ]]; then
+            exit 1
+          else
+            exit 0
+          fi
+
+      # Send slack notification with result status
+      - name: Send slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: all
+          custom_payload: |
+            {
+              attachments: [{
+                title: 'BitBar ${{ env.BITBAR_PROJECT_NAME }} - #${{ env.BITBAR_RUN_NUMBER }}',
+                title_link: '${{ env.BITBAR_TEST_RUN_URL }}',
+                color: '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                text: `\nTest summary: ${{ job.status }} in ${process.env.AS_TOOK}\nPassed: ${{ env.BITBAR_SUCCESS_TESTS_COUNT }}, Failed: ${{ env.BITBAR_FAILED_TESTS_COUNT }}\nDevice group: ${{ env.BITBAR_DEVICE_GROUP_NAME }}, Number of devices: ${{ env.BITBAR_DEVICE_COUNT }}\n\nWorkflow: ${process.env.AS_WORKFLOW} -> ${process.env.AS_JOB}\nPull request: ${process.env.AS_PULL_REQUEST}\nCommit: ${process.env.AS_COMMIT} by ${process.env.AS_AUTHOR}\nMessage: ${process.env.AS_MESSAGE}`, 
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: always()

--- a/.github/workflows/bitbar-run.yaml
+++ b/.github/workflows/bitbar-run.yaml
@@ -1,0 +1,113 @@
+#
+# Copyright (c) 2024 Ping Identity. All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+#
+
+name: Run Tests in BitBar
+on:
+  workflow_call:
+    inputs:
+      bitbar-project-id:
+        description: BitBar project id
+        type: string
+      bitbar-device-group-id:
+        description: The device group id to run tests against
+        type: string
+      bitbar-os-type:
+        description: OS Type
+        type: string
+        default: ANDROID
+      bitbar-framework-id:
+        description: The framework id
+        type: string
+        default: 252
+    outputs:
+      bitbar-run-id:
+        description: The newly created run id in BitBar
+        value: ${{ jobs.bitbar-run.outputs.bitbar_run_id }}
+    secrets:
+      BITBAR_API_KEY:
+        description: BitBar API Key
+        required: true
+      SLACK_WEBHOOK:
+        description: Slack Notifier Incoming Webhook
+        required: true
+jobs:
+  bitbar-run:
+    runs-on: ubuntu-latest
+    outputs:
+      bitbar_run_id: ${{ steps.bitbar_run_id.outputs.bitbar_run_id }}
+
+    steps:
+      # Get the test artifacts prepared in previous step
+      - name: Get the app-debug-androidTest-signed.apk BitBar artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-debug-androidTest-signed.apk
+
+      - name: Get the davinci-debug-androidTest-signed.apk BitBar artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: davinci-debug-androidTest-signed.apk
+
+      - name: Unzip app-debug-androidTest-signed.apk and davinci-debug-androidTest-signed.apk
+        run: |
+          unzip -o app-debug-androidTest-signed.apk
+          unzip -o davinci-debug-androidTest-signed.apk
+
+      - name: Upload app-debug-androidTest-signed.apk to BitBar
+        run: |
+          echo "BITBAR_APP_FILE_ID=$(curl -X POST -u ${{ secrets.BITBAR_API_KEY }}: https://cloud.bitbar.com/api/me/files -F "file=@app-debug-androidTest-signed.apk" | jq '.id')" >> $GITHUB_ENV
+
+      - name: Upload davinci-debug-androidTest-signed.apk to BitBar
+        run: |
+          echo "BITBAR_TEST_FILE_ID=$(curl -X POST -u ${{ secrets.BITBAR_API_KEY }}: https://cloud.bitbar.com/api/me/files -F "file=@davinci-debug-androidTest-signed.apk" | jq '.id')"  >> $GITHUB_ENV
+
+      - name: Prepare BitBar run configuration file
+        run: |
+          (
+            echo "{"
+            echo "\"osType\":\"${{ inputs.bitbar-os-type }}\","
+            echo "\"projectId\":${{ inputs.bitbar-project-id }},"
+            echo "\"frameworkId\":${{ inputs.bitbar-framework-id }},"
+            echo "\"deviceGroupId\":${{ inputs.bitbar-device-group-id }},"
+            echo "\"files\":["
+            echo "    {\"id\":${{ env.BITBAR_APP_FILE_ID }}, \"action\": \"INSTALL\"},"
+            echo "    {\"id\":${{ env.BITBAR_TEST_FILE_ID }}, \"action\": \"RUN_TEST\"}"
+            echo "]"
+            echo "}"
+          ) > bitbar-run-configuration.txt
+
+      - name: Display bitbar-run-configuration.txt
+        run: |
+          cat bitbar-run-configuration.txt
+
+      # Start the test run
+      - name: Start a test run
+        run: |
+          echo "BITBAR_TEST_RUN_ID=$(curl -H 'Content-Type: application/json' -u ${{ secrets.BITBAR_API_KEY }}: https://cloud.bitbar.com/api/me/runs --data-binary @bitbar-run-configuration.txt | jq '.id')"  >> $GITHUB_ENV
+
+      # Set bitbar_run_id as output of the workflow. This is needed for the next workflow to continue
+      - name: Set the bitbar_run_id output
+        id: bitbar_run_id
+        run: echo "::set-output name=bitbar_run_id::${{ env.BITBAR_TEST_RUN_ID }}"
+
+      # Send slack notification ONLY if any of the steps above fail
+      - name: Send slack notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: custom
+          fields: all
+          custom_payload: |
+            {
+              attachments: [{
+                title: ':no_entry: Failed to start BitBar test run!',
+                color: 'danger',
+                text: `\nWorkflow: ${process.env.AS_WORKFLOW} -> ${process.env.AS_JOB}\nPull request: ${process.env.AS_PULL_REQUEST}\nCommit: ${process.env.AS_COMMIT} by ${process.env.AS_AUTHOR}`, 
+              }]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+        if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,44 @@ jobs:
       runs-on: ubuntu-latest
       testrail-run-id: ${{needs.create-testrail-run.outputs.testrail-run-id}}
 
+  # Build and sign BitBar test artifacts (app-debug-androidTest-signed.apk and davinci-debug-androidTest-signed.apk)
+  # Skip this step for PRs created by dependabot
+  bitbar-prepare-artifacts:
+    name: Prepare device farm artifacts
+    uses: ./.github/workflows/bitbar-prepare-artifacts.yaml
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    needs: build-and-test
+    secrets:
+      SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE }}
+      SIGNING_ALIAS: ${{ secrets.SIGNING_ALIAS }}
+      SIGNING_KEYSTORE_PASSWORD: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
+      SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  # Execute e2e test cases in BitBar. The workflow outputs the newly created run id.
+  bitbar-run:
+    name: Run tests in BitBar
+    uses: ./.github/workflows/bitbar-run.yaml
+    needs: bitbar-prepare-artifacts
+    secrets:
+      BITBAR_API_KEY: ${{ secrets.BITBAR_API_KEY }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    with:
+      bitbar-project-id: ${{ vars.BITBAR_PROJECT_ID }}
+      bitbar-device-group-id: ${{ vars.BITBAR_DEVICE_GROUP_ID }}
+
+  # Wait for BitBar test run to finish and publish results
+  bitbar-results:
+    name: BitBar test results
+    uses: ./.github/workflows/bitbar-results.yaml
+    needs: bitbar-run
+    secrets:
+      BITBAR_API_KEY: ${{ secrets.BITBAR_API_KEY }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    with:
+      bitbar-project-id: ${{ vars.BITBAR_PROJECT_ID }} 
+      bitbar-run-id: ${{ needs.bitbar-run.outputs.bitbar-run-id }}
+
   # Run Mend CLI Scan
   mend-cli-scan:
     name: Mend CLI Scan

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciAndroidTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciAndroidTest.kt
@@ -607,7 +607,7 @@ class DavinciAndroidTest {
     }
 
     @TestRailCase(24629)
-    @Test(timeout = 20000)
+    @Test(timeout = 60000)
     fun accountLocked() = runBlocking {
         // Register a test user...
         val newUser = userFname + System.currentTimeMillis() + "@example.com"


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3465](https://pingidentity.atlassian.net/browse/SDKS-3465) Execute integration tests on device farm

# Description
- Implemented workflow that creates the required by BitBar artifacts (`bitbar-prepare-artifacts.yaml`)
- These are then submitted to BitBar via API, and then trigger the execution on a pre-configured "device group" (`bitbar-run.yaml`)
- The `bitbar-results.yaml` flow waits for the results and once they are ready, they are published to our internal slack channel (`sdk-jenkins`)

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/cc61e75a-fde9-4829-a032-f807cacd4e4f" />

<img width="789" alt="image" src="https://github.com/user-attachments/assets/fb109936-2bbd-40e9-b6cf-1222c0db1ce6" />

