### PR TITLE
SDKS-3616: Prevent side effects on the Global Logger when configuring the DaVinci Logger

### DIFF
--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/WorkflowConfig.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/WorkflowConfig.kt
@@ -41,10 +41,6 @@ open class WorkflowConfig {
 
     // Logger for the log, default is None
     var logger = Logger.logger
-        set(value) {
-            field = value
-            Logger.logger = value
-        }
 
     // HTTP client for the engine
     lateinit var httpClient: HttpClient


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3616](https://pingidentity.atlassian.net/browse/SDKS-3616)

# Description

SDKS-3616: Prevent side effects on the Global Logger when configuring the DaVinci Logger.

Since the datastore for accesstoken and cookie storage are global defined under
com.pingidentity.oidc.OidcClientConfig and DefaultCookieStore to enable Storage log, if we want to enable log for storage, we need to use Global Logger