### PR TITLE
SDKS-3878 Release activities for Ping SDK 1.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,6 @@ updates:
       - "spetrov"
     reviewers:
       - "witrisna"
-      - "jeyanthanperiyasamy"
 
   - package-ecosystem: "gradle"
     directory: "/external-idp"
@@ -27,7 +26,6 @@ updates:
       - "spetrov"
     reviewers:
       - "witrisna"
-      - "jeyanthanperiyasamy"
 
   - package-ecosystem: "gradle"
     directory: "/foundation/davinci-plugin"
@@ -40,7 +38,6 @@ updates:
       - "spetrov"
     reviewers:
       - "witrisna"
-      - "jeyanthanperiyasamy"
 
   - package-ecosystem: "gradle"
     directory: "/foundation/oidc"
@@ -53,7 +50,6 @@ updates:
       - "spetrov"
     reviewers:
       - "witrisna"
-      - "jeyanthanperiyasamy"
 
   - package-ecosystem: "gradle"
     directory: "/foundation/orchestrate"
@@ -66,7 +62,6 @@ updates:
       - "spetrov"
     reviewers:
       - "witrisna"
-      - "jeyanthanperiyasamy"
 
   - package-ecosystem: "gradle"
     directory: "/foundation/storage"
@@ -79,4 +74,3 @@ updates:
       - "spetrov"
     reviewers:
       - "witrisna"
-      - "jeyanthanperiyasamy"

--- a/.github/workflows/bitbar-prepare-artifacts.yaml
+++ b/.github/workflows/bitbar-prepare-artifacts.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/bitbar-prepare-artifacts.yaml
+++ b/.github/workflows/bitbar-prepare-artifacts.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity Corporation. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/bitbar-results.yaml
+++ b/.github/workflows/bitbar-results.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/bitbar-run.yaml
+++ b/.github/workflows/bitbar-run.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -90,7 +90,7 @@ jobs:
 
       - uses: 8398a7/action-slack@v3
         with:
-          mention: 'stoyan.petrov,andy.witrisna,jey.periyasamy'
+          mention: 'stoyan.petrov,andy.witrisna'
           if_mention: 'failure,cancelled'
           fields: repo,author,eventName,message,job,pullRequest,took
           status: ${{ job.status }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/check-stale-prs.yaml
+++ b/.github/workflows/check-stale-prs.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/create-testrail-run.yaml
+++ b/.github/workflows/create-testrail-run.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/.github/workflows/mend-cli-scan.yaml
+++ b/.github/workflows/mend-cli-scan.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.1.0]
+
+#### Added
+- Support for PingOne Forms field types LABEL, CHECKBOX, DROPDOWN, COMBOBOX, RADIO, PASSWORD, PASSWORD_VERIFY, FLOWLINK [SDKS-3649]
+- Support for validation of PingOne Forms fields [SDKS-3649]
+- Handling default values for PingOne Forms fields [SDKS-3649]
+- Interface for access of ErrorNode with validation error [SDKS-3649]
+- Support for Social Login with Browser Redirect [SDKS-3662]
+- Support for `Accept-Language` header [SDKS-3622]
+- New `browser` module [SDKS-3662]
+- New `external-idp` module [SDKS-3662]
+- Dynamic Environment Switching in Test Sample App [SDKS-3642]
+
+#### Fixed
+- A side effect on the Global Logger when configuring the DaVinci Logger [SDKS-3616]
+
 ## [1.0.0]
 - General Availability release of the Ping SDK for Android
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Ping Identity
+Copyright (c) 2024 - 2025 Ping Identity Corporation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/AndroidLibraryConventionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/JacocoPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/JacocoPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/MavenCentralPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/MavenCentralPublishConventionPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/MavenCentralPublishConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/MavenCentralPublishConventionPlugin.kt
@@ -86,11 +86,6 @@ class MavenCentralPublishConventionPlugin : Plugin<Project> {
                                         name.set("Stoyan Petrov")
                                         email.set("stoyan.petrov@pingidentity.com")
                                     }
-                                    developer {
-                                        id.set("jey.periyasamy")
-                                        name.set("Jey Periyasamy")
-                                        email.set("jey.periyasamy@pingidentity.com")
-                                    }
                                 }
                                 scm {
                                     connection.set("https://github.com/ForgeRock/ping-android-sdk.git")

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/VersionCatalogue.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/VersionCatalogue.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/plugins/Android.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/plugins/Android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/plugins/Java.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/plugins/Java.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/build.gradle.kts
+++ b/davinci/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciAndroidTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciAndroidTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/AndroidManifest.xml
+++ b/davinci/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/DaVinci.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/DaVinci.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/Json.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/Json.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/User.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/User.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Collectors.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Collectors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/FieldCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/FieldCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/FlowCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/FlowCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Form.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Form.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MultiSelectCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MultiSelectCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Option.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Option.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PasswordCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PasswordCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PasswordPolicy.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PasswordPolicy.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/SingleSelectCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/SingleSelectCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/SingleValueCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/SingleValueCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/SubmitCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/SubmitCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/TextCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/TextCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ValidatedCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ValidatedCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ValidationError.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ValidationError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Connector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Connector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/ErrorNode.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/ErrorNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Oidc.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Oidc.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Request.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Request.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/CollectorRegistryTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/CollectorRegistryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciErrorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciErrorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/FieldCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/FieldCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/FlowCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/FlowCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/LocaleListExtensionsTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/LocaleListExtensionsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MultiSelectCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MultiSelectCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/PasswordCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/PasswordCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/PasswordPolicyTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/PasswordPolicyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/SingleSelectCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/SingleSelectCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/SubmitCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/SubmitCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/TextCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/TextCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/ValidatedCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/ValidatedCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/README.md
+++ b/external-idp/README.md
@@ -21,7 +21,7 @@ and it provides the necessary configuration to authenticate with the External ID
 ```kotlin
 dependencies {
     implementation("com.pingidentity.sdks:davinci:<version>")
-    implementation("com.pingidentity.sdks:external-idp::<version>")
+    implementation("com.pingidentity.sdks:external-idp:<version>")
 }
 ```
 

--- a/external-idp/build.gradle.kts
+++ b/external-idp/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/build.gradle.kts
+++ b/external-idp/build.gradle.kts
@@ -7,6 +7,8 @@
 
 plugins {
     id("com.pingidentity.convention.android.library")
+    id("com.pingidentity.convention.centralPublish")
+    id("com.pingidentity.convention.jacoco")
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
 }

--- a/external-idp/src/main/AndroidManifest.xml
+++ b/external-idp/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/FacebookHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/FacebookHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/GoogleHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/GoogleHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/IdpCanceledException.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/IdpCanceledException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/IdpClient.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/IdpClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/IdpHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/IdpHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/IdpResult.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/IdpResult.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/UnsupportedIdPException.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/UnsupportedIdPException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/BrowserRequestHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/BrowserRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/CollectorRegistry.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/CollectorRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/FacebookRequestHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/FacebookRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/GoogleRequestHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/GoogleRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/IdpCollector.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/IdpCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/IdpRequestHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/IdpRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/facebook/FacebookActivity.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/facebook/FacebookActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/facebook/FacebookLoginManager.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/facebook/FacebookLoginManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/journey/AppleHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/journey/AppleHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/journey/IdpCallback.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/journey/IdpCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/journey/IdpCallbackRegistry.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/journey/IdpCallbackRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/main/kotlin/com/pingidentity/idp/journey/SelectIdpCallback.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/journey/SelectIdpCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/FacebookHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/FacebookHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/GoogleHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/GoogleHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/BrowserRequestHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/BrowserRequestHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/FacebookRequestHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/FacebookRequestHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/GoogleRequestHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/GoogleRequestHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/IdpCollectorTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/IdpCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/IdpRequestHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/davinci/IdpRequestHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/android/build.gradle.kts
+++ b/foundation/android/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/android/src/main/AndroidManifest.xml
+++ b/foundation/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/foundation/android/src/main/kotlin/com/pingidentity/android/ContextProvider.kt
+++ b/foundation/android/src/main/kotlin/com/pingidentity/android/ContextProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/android/src/main/kotlin/com/pingidentity/android/InitializeProvider.kt
+++ b/foundation/android/src/main/kotlin/com/pingidentity/android/InitializeProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/android/src/main/kotlin/com/pingidentity/android/ModuleInitializer.kt
+++ b/foundation/android/src/main/kotlin/com/pingidentity/android/ModuleInitializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/build.gradle.kts
+++ b/foundation/browser/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/AndroidManifest.xml
+++ b/foundation/browser/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2025 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/kotlin/com/pingidentity/browser/BrowserCanceledException.kt
+++ b/foundation/browser/src/main/kotlin/com/pingidentity/browser/BrowserCanceledException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/kotlin/com/pingidentity/browser/BrowserLauncher.kt
+++ b/foundation/browser/src/main/kotlin/com/pingidentity/browser/BrowserLauncher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/kotlin/com/pingidentity/browser/BrowserLauncherActivity.kt
+++ b/foundation/browser/src/main/kotlin/com/pingidentity/browser/BrowserLauncherActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/kotlin/com/pingidentity/browser/CustomTabActivity.kt
+++ b/foundation/browser/src/main/kotlin/com/pingidentity/browser/CustomTabActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/kotlin/com/pingidentity/browser/IntentLauncher.kt
+++ b/foundation/browser/src/main/kotlin/com/pingidentity/browser/IntentLauncher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/main/res/values/styles.xml
+++ b/foundation/browser/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2025 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/test/java/com/pingidentity/browser/CustomTabActivityTest.kt
+++ b/foundation/browser/src/test/java/com/pingidentity/browser/CustomTabActivityTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/browser/src/test/java/com/pingidentity/browser/IntentLauncherTest.kt
+++ b/foundation/browser/src/test/java/com/pingidentity/browser/IntentLauncherTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/build.gradle.kts
+++ b/foundation/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/build.gradle.kts
+++ b/foundation/davinci-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/Collector.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/Collector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/CollectorFactory.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/CollectorFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/ContinueNodeAware.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/ContinueNodeAware.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/DaVinci.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/DaVinci.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/DaVinciAware.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/DaVinciAware.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/RequestInterceptor.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/RequestInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/davinci-plugin/src/test/kotlin/com/pingidentity/davinci/plugin/CollectorFactoryTest.kt
+++ b/foundation/davinci-plugin/src/test/kotlin/com/pingidentity/davinci/plugin/CollectorFactoryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/build.gradle.kts
+++ b/foundation/journey-plugin/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/build.gradle.kts
+++ b/foundation/journey-plugin/build.gradle.kts
@@ -7,6 +7,8 @@
 
 plugins {
     id("com.pingidentity.convention.android.library")
+    id("com.pingidentity.convention.centralPublish")
+    id("com.pingidentity.convention.jacoco")
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)
 }

--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/AbstractCallback.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/AbstractCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/Callback.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/Callback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/CallbackRegistry.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/CallbackRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/Journey.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/Journey.kt
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
-
 
 package com.pingidentity.journey.plugin
 

--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/JourneyAware.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/JourneyAware.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/RequestInterceptor.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/RequestInterceptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/journey-plugin/src/test/kotlin/com/pingidentity/journey/plugin/CallbackRegistryTest.kt
+++ b/foundation/journey-plugin/src/test/kotlin/com/pingidentity/journey/plugin/CallbackRegistryTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/logger/build.gradle.kts
+++ b/foundation/logger/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/logger/src/androidTest/kotlin/com/pingidentity/logger/CustomTestLogger.kt
+++ b/foundation/logger/src/androidTest/kotlin/com/pingidentity/logger/CustomTestLogger.kt
@@ -1,6 +1,11 @@
-package com.pingidentity.logger
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
 
-import android.util.Log
+package com.pingidentity.logger
 
 open class CustomTestLogger : Logger {
     val messages = mutableListOf<String>()

--- a/foundation/logger/src/androidTest/kotlin/com/pingidentity/logger/LoggerAndroidTest.kt
+++ b/foundation/logger/src/androidTest/kotlin/com/pingidentity/logger/LoggerAndroidTest.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.logger
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/foundation/logger/src/main/kotlin/com/pingidentity/logger/Console.kt
+++ b/foundation/logger/src/main/kotlin/com/pingidentity/logger/Console.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/logger/src/main/kotlin/com/pingidentity/logger/Logger.kt
+++ b/foundation/logger/src/main/kotlin/com/pingidentity/logger/Logger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/logger/src/main/kotlin/com/pingidentity/logger/None.kt
+++ b/foundation/logger/src/main/kotlin/com/pingidentity/logger/None.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/logger/src/main/kotlin/com/pingidentity/logger/Standard.kt
+++ b/foundation/logger/src/main/kotlin/com/pingidentity/logger/Standard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/logger/src/test/kotlin/com/pingidentity/logger/LoggerTest.kt
+++ b/foundation/logger/src/test/kotlin/com/pingidentity/logger/LoggerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/build.gradle.kts
+++ b/foundation/oidc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Agent.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Agent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/AuthCode.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/AuthCode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Json.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Json.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcError.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcUser.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcUser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OpenIdConfiguration.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OpenIdConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Pkce.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Pkce.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Token.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Token.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/User.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/User.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/agent/Browser.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/agent/Browser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/exception/AuthorizeException.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/exception/AuthorizeException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/main/res/values/strings.xml
+++ b/foundation/oidc/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/AgentTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/AgentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientConfigTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientConfigTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcErrorTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcErrorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcUserTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcUserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OpenIdConfigurationTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OpenIdConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/PkceTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/PkceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/Response.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/TokenTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/TokenTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/agent/BrowserTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/agent/BrowserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/build.gradle.kts
+++ b/foundation/orchestrate/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Action.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Action.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Closeable.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Closeable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Module.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Module.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/ModuleRegistry.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/ModuleRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Node.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Node.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Request.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Request.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Response.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Session.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Session.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Setup.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Setup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/SharedContext.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/SharedContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Workflow.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Workflow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/WorkflowConfig.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/WorkflowConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/module/Cookie.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/module/Cookie.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/module/CustomHeader.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/module/CustomHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/module/DefaultCookieStore.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/module/DefaultCookieStore.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/CookieModuleTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/CookieModuleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/CustomHeaderModuleTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/CustomHeaderModuleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/NodeTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/NodeTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/RequestTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/RequestTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/ResponseTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/ResponseTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/SessionTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/SessionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/WorkflowTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/divinci/WorkflowTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/build.gradle.kts
+++ b/foundation/storage/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/Data.kt
+++ b/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/Data.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/DataStoreStorageTest.kt
+++ b/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/DataStoreStorageTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/EncryptedDataStoreStorageStressTest.kt
+++ b/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/EncryptedDataStoreStorageStressTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/EncryptedDataStoreStorageTest.kt
+++ b/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/EncryptedDataStoreStorageTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/encrypt/SecretKeyEncryptorTest.kt
+++ b/foundation/storage/src/androidTest/kotlin/com/pingidentity/storage/encrypt/SecretKeyEncryptorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/DataStorePreferencesStorage.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/DataStorePreferencesStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/DataStoreStorage.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/DataStoreStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/DataToJsonSerializer.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/DataToJsonSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/EncryptedDataToJsonSerializer.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/EncryptedDataToJsonSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/Json.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/Json.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/MemoryStorage.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/MemoryStorage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/Storage.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/Storage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/StorageDelegate.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/StorageDelegate.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/encrypt/Encryptor.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/encrypt/Encryptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/encrypt/SecretKeyEncryptor.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/encrypt/SecretKeyEncryptor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/main/kotlin/com/pingidentity/storage/encrypt/SymmetricKey.kt
+++ b/foundation/storage/src/main/kotlin/com/pingidentity/storage/encrypt/SymmetricKey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/test/kotlin/com/pingidentity/storage/Data.kt
+++ b/foundation/storage/src/test/kotlin/com/pingidentity/storage/Data.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/test/kotlin/com/pingidentity/storage/DataStoragePreferencesTest.kt
+++ b/foundation/storage/src/test/kotlin/com/pingidentity/storage/DataStoragePreferencesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/test/kotlin/com/pingidentity/storage/DataStorageTest.kt
+++ b/foundation/storage/src/test/kotlin/com/pingidentity/storage/DataStorageTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/storage/src/test/kotlin/com/pingidentity/storage/MemoryStorageTest.kt
+++ b/foundation/storage/src/test/kotlin/com/pingidentity/storage/MemoryStorageTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/main/kotlin/com/pingidentity/test/Utils.kt
+++ b/foundation/testrail/src/main/kotlin/com/pingidentity/test/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRail.kt
+++ b/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRail.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailCase.kt
+++ b/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailCase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailClient.kt
+++ b/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailClientConfig.kt
+++ b/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailClientConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailData.kt
+++ b/foundation/testrail/src/main/kotlin/com/pingidentity/testrail/TestRailData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/testrail/src/test/java/com/pingidentity/testrail/TestRailClientTest.kt
+++ b/foundation/testrail/src/test/java/com/pingidentity/testrail/TestRailClientTest.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.testrail
 
 import org.junit.Rule

--- a/foundation/utils/build.gradle.kts
+++ b/foundation/utils/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/utils/src/main/kotlin/com/pingidentity/exception/ApiException.kt
+++ b/foundation/utils/src/main/kotlin/com/pingidentity/exception/ApiException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/utils/src/main/kotlin/com/pingidentity/utils/Annotations.kt
+++ b/foundation/utils/src/main/kotlin/com/pingidentity/utils/Annotations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/utils/src/main/kotlin/com/pingidentity/utils/JSON.kt
+++ b/foundation/utils/src/main/kotlin/com/pingidentity/utils/JSON.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/foundation/utils/src/main/kotlin/com/pingidentity/utils/Result.kt
+++ b/foundation/utils/src/main/kotlin/com/pingidentity/utils/Result.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 #
-# Copyright (c) 2024 Ping Identity. All rights reserved.
+# Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
 #
 # This software may be modified and distributed under the terms
 # of the MIT license. See the LICENSE file for details.

--- a/journey/build.gradle.kts
+++ b/journey/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/AndroidManifest.xml
+++ b/journey/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/CallbackRegistry.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/CallbackRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/Journey.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/Journey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/SSOToken.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/SSOToken.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey
 
 import com.pingidentity.orchestrate.Session

--- a/journey/src/main/kotlin/com/pingidentity/journey/User.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/User.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/AbstractValidatedCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/AbstractValidatedCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/AttributeInputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/AttributeInputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import kotlinx.serialization.json.JsonElement

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/BooleanAttributeInputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/BooleanAttributeInputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import kotlinx.serialization.json.JsonElement

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/Callbacks.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/Callbacks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/ChoiceCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/ChoiceCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/ConfirmationCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/ConfirmationCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/ConsentMappingCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/ConsentMappingCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/DerivableCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/DerivableCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 interface DerivableCallback {

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/HiddenValueCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/HiddenValueCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/KbaCreateCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/KbaCreateCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/MetadataCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/MetadataCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/NameCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/NameCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/NumberAttributeInputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/NumberAttributeInputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import kotlinx.serialization.json.JsonElement

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/PasswordCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/PasswordCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/PollingWaitCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/PollingWaitCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/StringAttributeInputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/StringAttributeInputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import kotlinx.serialization.json.JsonElement

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/SuspendedTextOutputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/SuspendedTextOutputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 class SuspendedTextOutputCallback : TextOutputCallback()

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/TextInputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/TextInputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/TextOutputCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/TextOutputCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/ValidatedPasswordCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/ValidatedPasswordCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import kotlinx.serialization.json.JsonElement

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/ValidatedUsernameCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/ValidatedUsernameCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import kotlinx.serialization.json.JsonElement

--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/WebAuthnRegistrationCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/WebAuthnRegistrationCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.journey.callback
 
 import com.pingidentity.journey.plugin.AbstractCallback

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Agent.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Agent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Oidc.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Oidc.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Session.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Session.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/SessionConfig.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/SessionConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Start.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Start.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Transform.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Transform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
+++ b/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/build.gradle.kts
+++ b/samples/app/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/build.gradle.kts
+++ b/samples/app/build.gradle.kts
@@ -72,9 +72,6 @@ dependencies {
 
     // Social Login
     implementation(project(":external-idp"))
-    //To enable Native Google Sign-In, fall back to browser if Google SDK is not available.
-    implementation(libs.googleid)
-    implementation(libs.facebook.login)
 
     implementation(libs.androidx.datastore.preferences)
 

--- a/samples/app/src/androidTest/java/com/pingidentity/samples/app/ExampleInstrumentedTest.kt
+++ b/samples/app/src/androidTest/java/com/pingidentity/samples/app/ExampleInstrumentedTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/AndroidManifest.xml
+++ b/samples/app/src/main/AndroidManifest.xml
@@ -1,9 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.
-  -->
+-->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">

--- a/samples/app/src/main/java/com/pingidentity/samples/app/Alert.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/Alert.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/AppDrawer.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/AppDrawer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/AppNavHost.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/AppNavHost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/AuthApp.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/AuthApp.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/Destinations.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/Destinations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/Error.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/Error.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/Json.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/Json.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/LogoutViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/LogoutViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/LogoutViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/LogoutViewModel.kt
@@ -16,7 +16,7 @@ class LogoutViewModel : ViewModel() {
         viewModelScope.launch {
             //If you are using DaVinci, you can use the DaVinci user object to logout
             User.user()?.logout()
+            onCompleted()
         }
-        onCompleted()
     }
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/MainActivity.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/MainViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/MainViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/PreferenceViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/PreferenceViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/Setting.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/Setting.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/User.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/User.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/centralize/Centralize.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/centralize/Centralize.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/centralize/CentralizeLoginViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/centralize/CentralizeLoginViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/centralize/CentralizeState.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/centralize/CentralizeState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinci.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinci.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinciState.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinciState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinciViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinciViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/CheckBox.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/CheckBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ComboBox.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ComboBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Dropdown.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Dropdown.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ErrorMessage.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ErrorMessage.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/FlowButton.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/FlowButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Password.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Password.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Radio.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Radio.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/SocialLoginButton.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/SocialLoginButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/SubmitButton.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/SubmitButton.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Text.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Text.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/env/Env.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/env/Env.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/env/EnvViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/env/EnvViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/theme/Color.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/theme/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/theme/Shape.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/theme/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/theme/Theme.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/theme/Theme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/theme/Type.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/theme/Type.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/token/Token.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/token/Token.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/token/TokenState.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/token/TokenState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/token/TokenViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/token/TokenViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/userprofile/UserProfile.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/userprofile/UserProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/userprofile/UserProfileState.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/userprofile/UserProfileState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/java/com/pingidentity/samples/app/userprofile/UserProfileViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/userprofile/UserProfileViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/animator/logo_animator.xml
+++ b/samples/app/src/main/res/animator/logo_animator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/samples/app/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/animated_logo.xml
+++ b/samples/app/src/main/res/drawable/animated_logo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/apple.xml
+++ b/samples/app/src/main/res/drawable/apple.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/facebook.xml
+++ b/samples/app/src/main/res/drawable/facebook.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/forgerock.xml
+++ b/samples/app/src/main/res/drawable/forgerock.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/google.xml
+++ b/samples/app/src/main/res/drawable/google.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/samples/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/samples/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/drawable/ping_logo.xml
+++ b/samples/app/src/main/res/drawable/ping_logo.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/samples/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/samples/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/values-night/themes.xml
+++ b/samples/app/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/values/colors.xml
+++ b/samples/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/values/strings.xml
+++ b/samples/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/app/src/main/res/values/themes.xml
+++ b/samples/app/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/build.gradle.kts
+++ b/samples/journeyapp/build.gradle.kts
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)

--- a/samples/journeyapp/src/main/AndroidManifest.xml
+++ b/samples/journeyapp/src/main/AndroidManifest.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+  ~
+  ~ This software may be modified and distributed under the terms
+  ~ of the MIT license. See the LICENSE file for details.
+-->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Alert.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Alert.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/AppDrawer.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/AppDrawer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/AppNavHost.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/AppNavHost.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/AuthApp.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/AuthApp.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Destinations.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Destinations.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Error.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Error.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Json.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/Json.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/LogoutViewModel.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/LogoutViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/MainActivity.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/MainViewModel.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/MainViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/PreferenceViewModel.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/PreferenceViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/Journey.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/Journey.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/JourneyRoute.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/JourneyRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/JourneyState.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/JourneyState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/JourneyViewModel.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/JourneyViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ContinueNode.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ContinueNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/IdPCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/IdPCallback.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.samples.journeyapp.journey.callback
 
 import androidx.compose.foundation.layout.Column

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/NameCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/NameCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PasswordCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PasswordCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/SelectIdpCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/SelectIdpCallback.kt
@@ -1,9 +1,10 @@
 /*
- * Copyright (c) 2024 PingIdentity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+
 
 package com.pingidentity.samples.journeyapp.journey.callback
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Color.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Color.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Shape.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Shape.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Theme.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Theme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Type.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/theme/Type.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/token/Token.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/token/Token.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/token/TokenState.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/token/TokenState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/token/TokenViewModel.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/token/TokenViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/userprofile/UserProfile.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/userprofile/UserProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/userprofile/UserProfileState.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/userprofile/UserProfileState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/userprofile/UserProfileViewModel.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/userprofile/UserProfileViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/animator/logo_animator.xml
+++ b/samples/journeyapp/src/main/res/animator/logo_animator.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable-v24/ic_launcher_foreground.xml
+++ b/samples/journeyapp/src/main/res/drawable-v24/ic_launcher_foreground.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/animated_logo.xml
+++ b/samples/journeyapp/src/main/res/drawable/animated_logo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/apple.xml
+++ b/samples/journeyapp/src/main/res/drawable/apple.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/facebook.xml
+++ b/samples/journeyapp/src/main/res/drawable/facebook.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/forgerock.xml
+++ b/samples/journeyapp/src/main/res/drawable/forgerock.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/google.xml
+++ b/samples/journeyapp/src/main/res/drawable/google.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/ic_launcher_background.xml
+++ b/samples/journeyapp/src/main/res/drawable/ic_launcher_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/samples/journeyapp/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/drawable/ping_logo.xml
+++ b/samples/journeyapp/src/main/res/drawable/ping_logo.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/samples/journeyapp/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/samples/journeyapp/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/values-night/themes.xml
+++ b/samples/journeyapp/src/main/res/values-night/themes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/values/colors.xml
+++ b/samples/journeyapp/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/values/strings.xml
+++ b/samples/journeyapp/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/main/res/values/themes.xml
+++ b/samples/journeyapp/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2024 Ping Identity. All rights reserved.
+  ~ Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
   ~
   ~ This software may be modified and distributed under the terms
   ~ of the MIT license. See the LICENSE file for details.

--- a/samples/journeyapp/src/test/java/com/pingidentity/samples/journeyapp/ExampleUnitTest.kt
+++ b/samples/journeyapp/src/test/java/com/pingidentity/samples/journeyapp/ExampleUnitTest.kt
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
 package com.pingidentity.samples.journeyapp
 
 import org.junit.Test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3878](https://pingidentity.atlassian.net/browse/SDKS-3878) Release activities for Ping SDK 1.1.0

# Description
- Updated `CHANGELOG.md` for the 1.1.0 release.
- Updated `build.gradle.kts` of `external-idp` module to publish the library along with the other ones. 
- Updated `build.gradle.kts` of `journey-plugin` module to publish the library along with the other ones. 