### PR TITLE
SDKS-4001 Addition library com.google.android.gms:play-services-auth:1.5.0 is required for Native Google SignIn for Android 13 and below.

### DIFF
--- a/external-idp/README.md
+++ b/external-idp/README.md
@@ -192,15 +192,15 @@ app's `build.gradle.kts` file:
 ```gradle
 dependencies {
     // Google Sign-In
-    implementation("com.google.android.libraries.identity.googleid:googleid:<version>")
+    implementation("com.google.android.libraries.identity.googleid:googleid:1.1.1")
+    // optional - needed for credentials support from play services, for devices running
+    // Android 13 and below.
+    implementation("com.google.android.gms:play-services-auth:1.5.0")
 
     // Facebook Login
-    implementation("com.facebook.android:facebook-login:<version>")
+    implementation("com.facebook.android:facebook-login:18.0.3")
 }
 ```
-
-Replace `<version>` with the latest stable versions of the
-respective SDKs. You can find these on their respective developer portals or Maven Central.
 
 ### Google Developer Console Configuration for Native Integration
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ pluginSserialization = "2.0.0"
 coreKtxVersion = "1.6.1"
 junitKtx = "1.2.1"
 androidx-test-runner = "1.6.2"
-androidx-credentials = "1.3.0" #May need to use 1.2.2, seem to have issues with 1.3.0-alpha04
+androidx-credentials = "1.5.0"
 robolectric = "4.12.2"
 composeBom = "2024.12.01"
 activity = "1.9.3"
@@ -45,8 +45,7 @@ browser = "1.8.0"
 nexus = "1.3.0"
 dokka = "1.9.20"
 googleid = "1.1.1"
-facebook-login = "17.0.2"
-credentials = "1.3.0"
+facebook-login = "18.0.3"
 
 coilCompose = "2.4.0"
 
@@ -107,7 +106,6 @@ android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", ver
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 dokka-gradlePlugin = { group = "org.jetbrains.dokka", name = "org.jetbrains.dokka.gradle.plugin", version.ref = "dokka" }
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
 facebook-login = { module = "com.facebook.android:facebook-login", version.ref = "facebook-login" }
 
 [plugins]

--- a/samples/app/build.gradle.kts
+++ b/samples/app/build.gradle.kts
@@ -73,6 +73,12 @@ dependencies {
     // Social Login
     implementation(project(":external-idp"))
 
+    //To enable Native Google Sign-In, fall back to browser if Google SDK is not available.
+    implementation(libs.googleid)
+    implementation(libs.androidx.credentials.play.services.auth)
+
+    implementation(libs.facebook.login)
+
     implementation(libs.androidx.datastore.preferences)
 
     implementation(libs.compose.ui)


### PR DESCRIPTION
# JIRA Ticket

[PSDKS-4001](https://pingidentity.atlassian.net/browse/SDKS-4001)

# Description

SDKS-4001 Addition library com.google.android.gms:play-services-auth:1.5.0 is required for Native Google SignIn for Android 13 and below.