### PR TITLE
SDKS-4139 Remove currentActivity from ContextProvider, should access context with ContextProvider.context

### DIFF
--- a/external-idp/src/main/kotlin/com/pingidentity/idp/GoogleHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/GoogleHandler.kt
@@ -42,7 +42,7 @@ internal class GoogleHandler : IdpHandler {
         val credentialManager = CredentialManager.create(ContextProvider.context)
         val result = credentialManager.getCredential(
             request = request,
-            context = ContextProvider.currentActivity,
+            context = ContextProvider.context,
         )
 
         when (val credential = result.credential) {

--- a/external-idp/src/test/kotlin/com/pingidentity/idp/GoogleHandlerTest.kt
+++ b/external-idp/src/test/kotlin/com/pingidentity/idp/GoogleHandlerTest.kt
@@ -55,7 +55,6 @@ class GoogleHandlerTest {
 
         mockkObject(ContextProvider)
         every { ContextProvider.context } returns mockContext
-        every { ContextProvider.currentActivity } returns mockActivity
     }
 
     @AfterTest

--- a/foundation/android/src/main/kotlin/com/pingidentity/android/ContextProvider.kt
+++ b/foundation/android/src/main/kotlin/com/pingidentity/android/ContextProvider.kt
@@ -18,15 +18,11 @@ import android.content.Context
  * It is initialized with the application context.
  *
  * @property context The application context.
- * @property currentActivity The current activity.
  */
 @SuppressLint("StaticFieldLeak")
 object ContextProvider {
 
     lateinit var context: Context
-        internal set
-
-    lateinit var currentActivity: Activity
         internal set
 
     /**


### PR DESCRIPTION
…context with ContextProvider.context

# JIRA Ticket

[SDKS-4139](https://pingidentity.atlassian.net/browse/SDKS-4139)

# Description

SDKS-4139 Remove currentActivity from ContextProvider, should access context with ContextProvider.context