### PR TITLE
SDKS-4198 Refactor PhoneNumberCollector to support new JSON structure

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PhoneNumberCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PhoneNumberCollector.kt
@@ -14,6 +14,9 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 
+private const val COUNTRY_CODE = "countryCode"
+private const val PHONE_NUMBER = "phoneNumber"
+
 /**
  * A collector for phone number.
  */
@@ -38,7 +41,14 @@ class PhoneNumberCollector : FieldCollector<JsonObject>(), Validator {
     }
 
     override fun init(input: JsonElement) {
-        phoneNumber = input.jsonPrimitive.content
+        if (input is JsonObject) {
+            // New structure with phoneNumber and countryCode
+            phoneNumber = input[PHONE_NUMBER]?.jsonPrimitive?.content ?: ""
+            countryCode = input[COUNTRY_CODE]?.jsonPrimitive?.content ?: ""
+        } else {
+            // Legacy structure - simple string
+            phoneNumber = input.jsonPrimitive.content
+        }
     }
 
     override fun payload(): JsonObject? {
@@ -46,8 +56,8 @@ class PhoneNumberCollector : FieldCollector<JsonObject>(), Validator {
             null
         } else {
             buildJsonObject {
-                put("countryCode", countryCode)
-                put("phoneNumber", phoneNumber)
+                put(COUNTRY_CODE, countryCode)
+                put(PHONE_NUMBER, phoneNumber)
             }
         }
     }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/PhoneNumberCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/PhoneNumberCollectorTest.kt
@@ -10,6 +10,7 @@ package com.pingidentity.davinci
 
 import com.pingidentity.davinci.collector.PhoneNumberCollector
 import com.pingidentity.davinci.collector.Required
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -158,4 +159,19 @@ class PhoneNumberCollectorTest {
 
         assertTrue(errors.isEmpty())
     }
+
+    @Test
+    fun `init with new structure sets phoneNumber and countryCode`() {
+        val input = buildJsonObject {
+            put("phoneNumber", "CA-1-+17783186380-7783186380")
+            put("countryCode", "CA")
+        }
+        val collector = PhoneNumberCollector()
+
+        collector.init(input as JsonElement)
+
+        assertEquals("CA-1-+17783186380-7783186380", collector.phoneNumber)
+        assertEquals("CA", collector.countryCode)
+    }
+
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/PhoneNumber.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/PhoneNumber.kt
@@ -38,8 +38,11 @@ import com.pingidentity.davinci.collector.PhoneNumberCollector
 fun PhoneNumber(field: PhoneNumberCollector, onNodeUpdated: () -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     var selectedCountryCode by remember {
-        mutableStateOf(countryCodes.firstOrNull { it.countryCode == field.defaultCountryCode }
-            ?: countryCodes.first())
+        val codeToUse = field.countryCode.ifEmpty { field.defaultCountryCode }
+        mutableStateOf(
+            countryCodes.firstOrNull { it.countryCode == codeToUse }
+                ?: countryCodes.first()
+        )
     }
 
     var isValid by remember {
@@ -148,4 +151,3 @@ val countryCodes = listOf(
     Country("HK", "Hong Kong", "852"),
     // Add more countries as needed
 )
-


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4198](https://pingidentity.atlassian.net/browse/SDKS-4198)

# Description

The PhoneNumberCollector has been updated to handle a new JSON input structure that includes separate `phoneNumber` and `countryCode` fields, while maintaining backward compatibility with the legacy string format.

- Modified `init()` method to differentiate between the new JsonObject structure and the legacy JsonPrimitive string.
- Added constants for `COUNTRY_CODE` and `PHONE_NUMBER` keys.
- Updated `payload()` to use these constants.
- Added a new unit test `init with new structure sets phoneNumber and countryCode` to verify the handling of the new JSON format.