### PR TITLE
SDKS-4386: Update `remember` calls in sample apps for Jetpack Compose

### DIFF
--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinciViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinciViewModel.kt
@@ -35,7 +35,7 @@ class DaVinciViewModel : ViewModel() {
         viewModelScope.launch {
             val next = current.next()
             state.update {
-                it.copy(node = next)
+                it.copy(node = next, counter = it.counter + 1)
             }
             loading.update {
                 false
@@ -53,7 +53,7 @@ class DaVinciViewModel : ViewModel() {
             val next = daVinci.start()
 
             state.update {
-                it.copy(node = next)
+                it.copy(node = next, counter = it.counter + 1)
             }
             loading.update {
                 false

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/CheckBox.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/CheckBox.kt
@@ -27,7 +27,7 @@ import com.pingidentity.davinci.collector.MultiSelectCollector
 
 @Composable
 fun CheckBox(field: MultiSelectCollector, onNodeUpdated: () -> Unit) {
-    val selectedOptions= remember { mutableStateMapOf<String, Boolean>() }
+    val selectedOptions= remember(field) { mutableStateMapOf<String, Boolean>() }
 
     LaunchedEffect(field) {
         field.options.forEach { item ->
@@ -35,7 +35,7 @@ fun CheckBox(field: MultiSelectCollector, onNodeUpdated: () -> Unit) {
         }
     }
 
-    var isValid by remember {
+    var isValid by remember(field) {
         mutableStateOf(true)
     }
 

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ComboBox.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ComboBox.kt
@@ -36,10 +36,10 @@ import com.pingidentity.davinci.collector.MultiSelectCollector
 @Composable
 fun ComboBox(field: MultiSelectCollector, onNodeUpdated: () -> Unit) {
     val options = field.options.map { it.value }
-    var expanded by remember { mutableStateOf(false) }
-    val selectedOptions = remember { mutableStateListOf<String>() }
+    var expanded by remember(field) { mutableStateOf(false) }
+    val selectedOptions = remember(field) { mutableStateListOf<String>() }
 
-    var isValid by remember {
+    var isValid by remember(field) {
         mutableStateOf(true)
     }
 

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/DeviceAuthentication.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/DeviceAuthentication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -39,7 +39,7 @@ fun DeviceAuthentication(
     onNext: () -> Unit,
 ) {
 
-    var selectedId by remember { mutableStateOf<String?>(null) }
+    var selectedId by remember(field) { mutableStateOf<String?>(null) }
 
     OutlinedCard (
         modifier = Modifier

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/DeviceRegistration.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/DeviceRegistration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -38,7 +38,7 @@ fun DeviceRegistration(
     field: DeviceRegistrationCollector,
     onNext: () -> Unit,
 ) {
-    var selectedType by remember { mutableStateOf<String?>(null) }
+    var selectedType by remember(field) { mutableStateOf<String?>(null) }
 
     OutlinedCard (
         modifier = Modifier

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Dropdown.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Dropdown.kt
@@ -29,10 +29,10 @@ import com.pingidentity.davinci.collector.SingleSelectCollector
 @Composable
 fun Dropdown(field: SingleSelectCollector, onNodeUpdated: () -> Unit) {
     val options = listOf("") + field.options.map { it.value }
-    var expanded by remember { mutableStateOf(false) }
-    var selectedOption by remember { mutableStateOf(field.value) }
+    var expanded by remember(field) { mutableStateOf(false) }
+    var selectedOption by remember(field) { mutableStateOf(field.value) }
 
-    var isValid by remember {
+    var isValid by remember(field) {
         mutableStateOf(true)
     }
 

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Password.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Password.kt
@@ -7,7 +7,6 @@
 
 package com.pingidentity.samples.app.davinci.collector
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,19 +28,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.collector.InvalidLength
-import com.pingidentity.davinci.collector.MaxRepeat
-import com.pingidentity.davinci.collector.MinCharacters
 import com.pingidentity.davinci.collector.PasswordCollector
-import com.pingidentity.davinci.collector.UniqueCharacter
-import com.pingidentity.davinci.collector.ValidationError
-import com.pingidentity.samples.app.theme.md_theme_light_primary
-import com.pingidentity.utils.Result
 
 @Composable
 fun Password(
@@ -49,11 +40,11 @@ fun Password(
     onNodeUpdated: () -> Unit,
 ) {
 
-    var isValid by remember {
+    var isValid by remember(field) {
         mutableStateOf(true)
     }
-    var verify by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf(field.value) }
+    var verify by remember(field) { mutableStateOf("") }
+    var password by remember(field) { mutableStateOf(field.value) }
 
 
     LaunchedEffect(field) {
@@ -121,7 +112,7 @@ fun Password(
                 .padding(4.dp)
                 .fillMaxWidth(),
         ) {
-            var passwordVisibility by remember { mutableStateOf(false) }
+            var passwordVisibility by remember(field) { mutableStateOf(false) }
 
 
             Spacer(modifier = Modifier.weight(1f, true))

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/PhoneNumber.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/PhoneNumber.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity. All rights reserved.
+ * Copyright (c) 2025 - 2025 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -36,17 +36,17 @@ import com.pingidentity.davinci.collector.PhoneNumberCollector
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PhoneNumber(field: PhoneNumberCollector, onNodeUpdated: () -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
-    var selectedCountryCode by remember {
+    var expanded by remember(field) { mutableStateOf(false) }
+    var selectedCountryCode by remember(field) {
         val codeToUse = field.countryCode.ifEmpty { field.defaultCountryCode }
         mutableStateOf(
             countryCodes.firstOrNull { it.countryCode == codeToUse }
                 ?: countryCodes.first()
         )
     }
-    var phone by remember { mutableStateOf(field.phoneNumber) }
+    var phone by remember(field) { mutableStateOf(field.phoneNumber) }
 
-    var isValid by remember {
+    var isValid by remember(field) {
         mutableStateOf(true)
     }
 

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Text.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Text.kt
@@ -29,10 +29,10 @@ fun Text(
     onNodeUpdated: () -> Unit,
 ) {
 
-    var isValid by remember {
+    var isValid by remember(field) {
         mutableStateOf(true)
     }
-    var text by remember { mutableStateOf(field.value) }
+    var text by remember(field) { mutableStateOf(field.value) }
 
     Row(
         modifier =

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/BooleanAttributeInputCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/BooleanAttributeInputCallback.kt
@@ -25,7 +25,7 @@ import com.pingidentity.journey.callback.BooleanAttributeInputCallback
 @Composable
 fun BooleanAttributeInputCallback(callback: BooleanAttributeInputCallback, onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(callback.value)
     }
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ChoiceCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ChoiceCallback.kt
@@ -28,8 +28,8 @@ import com.pingidentity.journey.callback.ChoiceCallback
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ChoiceCallback(callback: ChoiceCallback,  onNodeUpdated: () -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
-    var selectedItem by remember {
+    var expanded by remember(callback) { mutableStateOf(false) }
+    var selectedItem by remember(callback) {
         mutableStateOf(callback.choices[callback.defaultChoice])
     }
 
@@ -80,4 +80,3 @@ fun ChoiceCallback(callback: ChoiceCallback,  onNodeUpdated: () -> Unit) {
         }
     }
 }
-

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ConsentMappingCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ConsentMappingCallback.kt
@@ -8,7 +8,6 @@
 package com.pingidentity.samples.journeyapp.journey.callback
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -24,12 +23,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.pingidentity.journey.callback.ConsentMappingCallback
-import com.pingidentity.journey.callback.TermsAndConditionsCallback
 
 @Composable
 fun ConsentMappingCallback(callback: ConsentMappingCallback, onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(false)
     }
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/KbaCreateCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/KbaCreateCallback.kt
@@ -30,13 +30,13 @@ import com.pingidentity.journey.callback.KbaCreateCallback
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun KbaCreateCallback(callback: KbaCreateCallback,  onNodeUpdated: () -> Unit) {
-    var expanded by remember { mutableStateOf(false) }
-    var selectedItem by remember {
+    var expanded by remember(callback) { mutableStateOf(false) }
+    var selectedItem by remember(callback) {
         mutableStateOf(callback.predefinedQuestions[0])
     }
-    var isCustomQuestion by remember { mutableStateOf(false) }
-    var customQuestion by remember { mutableStateOf("") }
-    var answer by remember {
+    var isCustomQuestion by remember(callback) { mutableStateOf(false) }
+    var customQuestion by remember(callback) { mutableStateOf("") }
+    var answer by remember(callback) {
         mutableStateOf("")
     }
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/NameCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/NameCallback.kt
@@ -29,7 +29,7 @@ fun NameCallback(
     onNodeUpdated: () -> Unit,
 ) {
 
-    var text by remember { mutableStateOf(field.name) }
+    var text by remember(field) { mutableStateOf(field.name) }
 
     Row(
         modifier =

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/NumberAttributeInputCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/NumberAttributeInputCallback.kt
@@ -15,20 +15,18 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.core.text.isDigitsOnly
-import com.pingidentity.journey.callback.AttributeInputCallback
 import com.pingidentity.journey.callback.NumberAttributeInputCallback
 
 @Composable
 fun NumberAttributeInputCallback(callback: NumberAttributeInputCallback,  onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(callback.value.toString() ?: "")
     }
 
@@ -60,4 +58,3 @@ fun NumberAttributeInputCallback(callback: NumberAttributeInputCallback,  onNode
         )
     }
 }
-

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PasswordCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PasswordCallback.kt
@@ -43,8 +43,8 @@ fun PasswordCallback(
             .padding(4.dp)
             .fillMaxWidth(),
     ) {
-        var passwordVisibility by remember { mutableStateOf(false) }
-        var password by remember { mutableStateOf("") }
+        var passwordVisibility by remember(field) { mutableStateOf(false) }
+        var password by remember(field) { mutableStateOf("") }
 
         Spacer(modifier = Modifier.weight(1f, true))
 
@@ -80,4 +80,3 @@ fun PasswordCallback(
         Spacer(modifier = Modifier.weight(1f, true))
     }
 }
-

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PingOneProtectEvaluation.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PingOneProtectEvaluation.kt
@@ -7,9 +7,23 @@
 
 package com.pingidentity.samples.journeyapp.journey.callback
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -23,10 +37,10 @@ fun PingOneProtectEvaluation(
     onNext: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
-    var isLoading by remember { mutableStateOf(true) }
+    var isLoading by remember(field) { mutableStateOf(true) }
 
     // Execute the loading task when the composable is first composed
-    LaunchedEffect(key1 = true) {
+    LaunchedEffect(key1 = field) {
         scope.launch {
             try {
                 val startTime = System.currentTimeMillis()

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PingOneProtectInitialize.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/PingOneProtectInitialize.kt
@@ -7,9 +7,23 @@
 
 package com.pingidentity.samples.journeyapp.journey.callback
 
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -23,10 +37,10 @@ fun PingOneProtectInitialize(
     onNext: () -> Unit,
 ) {
     val scope = rememberCoroutineScope()
-    var isLoading by remember { mutableStateOf(true) }
+    var isLoading by remember(field) { mutableStateOf(true) }
 
     // Execute the loading task when the composable is first composed
-    LaunchedEffect(key1 = true) {
+    LaunchedEffect(key1 = field) {
         scope.launch {
             try {
                 val startTime = System.currentTimeMillis()

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/StringAttributeInputCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/StringAttributeInputCallback.kt
@@ -25,7 +25,7 @@ import com.pingidentity.journey.callback.StringAttributeInputCallback
 @Composable
 fun StringAttributeInputCallback(callback: StringAttributeInputCallback, onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(callback.value)
     }
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/TermsAndConditionsCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/TermsAndConditionsCallback.kt
@@ -8,7 +8,6 @@
 package com.pingidentity.samples.journeyapp.journey.callback
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -28,7 +27,7 @@ import com.pingidentity.journey.callback.TermsAndConditionsCallback
 @Composable
 fun TermsAndConditionsCallback(callback: TermsAndConditionsCallback, onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(false)
     }
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/TextInputCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/TextInputCallback.kt
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2024 ForgeRock. All rights reserved.
+ * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
  *
- *  This software may be modified and distributed under the terms
- *  of the MIT license. See the LICENSE file for details.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
  */
 
 package com.pingidentity.samples.journeyapp.journey.callback
@@ -24,7 +24,7 @@ import com.pingidentity.journey.callback.TextInputCallback
 @Composable
 fun TextInputCallback(textInputCallback: TextInputCallback, onNodeUpdated: () -> Unit) {
 
-    var text by remember {
+    var text by remember(textInputCallback) {
         mutableStateOf(textInputCallback.defaultText)
     }
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ValidatedPasswordCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ValidatedPasswordCallback.kt
@@ -32,14 +32,12 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import com.pingidentity.journey.callback.StringAttributeInputCallback
 import com.pingidentity.journey.callback.ValidatedPasswordCallback
-import com.pingidentity.journey.callback.ValidatedUsernameCallback
 
 @Composable
 fun ValidatedPasswordCallback(callback: ValidatedPasswordCallback, onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(callback.password)
     }
 
@@ -49,7 +47,7 @@ fun ValidatedPasswordCallback(callback: ValidatedPasswordCallback, onNodeUpdated
                 .padding(4.dp)
                 .fillMaxWidth(),
     ) {
-        var passwordVisibility by remember { mutableStateOf(false) }
+        var passwordVisibility by remember(callback) { mutableStateOf(false) }
 
         Spacer(modifier = Modifier.weight(1f, true))
 

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ValidatedUsernameCallback.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ValidatedUsernameCallback.kt
@@ -25,7 +25,7 @@ import com.pingidentity.journey.callback.ValidatedUsernameCallback
 @Composable
 fun ValidatedUsernameCallback(callback: ValidatedUsernameCallback, onNodeUpdated: () -> Unit) {
 
-    var input by remember {
+    var input by remember(callback) {
         mutableStateOf(callback.username)
     }
 


### PR DESCRIPTION

# JIRA Ticket

[SDKS-4386](https://pingidentity.atlassian.net/browse/SDKS-4386)

# Description

This commit updates the `remember` calls in various composable functions within the sample applications. The `key` parameter is now explicitly provided, typically using the `callback` or `field` object. This ensures that the state is correctly recomposed and reset when the underlying data (`callback` or `field`) changes.
