### PR TITLE
SDKS-4584: Preserve all original JSON fields in ContinueNode request

### DIFF
--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Transform.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Transform.kt
@@ -38,7 +38,6 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 
 internal val NodeTransform =
@@ -108,15 +107,20 @@ private fun transform(
         return object : ContinueNode(context, journey, json, callbacks) {
             private fun asJson(): JsonObject {
                 return buildJsonObject {
-                    put(AUTH_ID, json[AUTH_ID]?.jsonPrimitive?.content ?: "")
-                    putJsonArray(CALLBACKS) {
-                        callbacks.forEach {
-                            if (it.payload().isNotEmpty()) {
-                                add(it.payload())
+                    json.forEach { (key, value) ->
+                        if (key == CALLBACKS) {
+                            putJsonArray(CALLBACKS) {
+                                callbacks.forEach {
+                                    if (it.payload().isNotEmpty()) {
+                                        add(it.payload())
+                                    }
+                                }
                             }
+                        } else {
+                            put(key, value)
                         }
                     }
-                }
+               }
             }
 
             override fun asRequest(): Request {

--- a/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
+++ b/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
@@ -206,7 +206,7 @@ class JourneyTest {
 
         var node = journey.start("myLogin") // Return first Node
         assertTrue(node is ContinueNode)
-        assertTrue { node.callbacks.size == 2 }
+        assertEquals(2, node.callbacks.size)
 
         (node.callbacks[0] as? NameCallback)?.name = "My First Name"
         (node.callbacks[1] as? PasswordCallback)?.password = "My Password"
@@ -256,7 +256,7 @@ class JourneyTest {
 
         var node = journey.start("myLogin") // Return first Node
         assertTrue(node is ContinueNode)
-        assertTrue { node.callbacks.size == 2 }
+        assertEquals(2, node.callbacks.size)
 
         (node.callbacks[0] as? NameCallback)?.name = "My First Name"
         (node.callbacks[1] as? PasswordCallback)?.password = "My Password"
@@ -456,7 +456,7 @@ class JourneyTest {
                 noSession = true
             }
             assertTrue(node is ContinueNode)
-            assertTrue { node.callbacks.size == 2 }
+            assertEquals(2, node.callbacks.size)
 
             node = node.next()
             assertTrue(node is SuccessNode)
@@ -722,5 +722,155 @@ class JourneyTest {
         val ssoToken = node.session as SSOToken
         assertEquals("/enduser/?realm=/alpha", ssoToken.successUrl)
         assertEquals("/alpha", ssoToken.realm)
+    }
+
+    @Test
+    fun `ContinueNode preserves all original JSON fields in request body`() = runTest {
+        val journey = Journey {
+            serverUrl = "http://localhost/am"
+            logger = Logger.CONSOLE
+            httpClient = HttpClient(mockEngine) {
+                followRedirects = false
+            }
+            module(Session) {
+                storage = { MemoryStorage() }
+            }
+        }
+
+        val node = journey.start("myLogin")
+        assertTrue(node is ContinueNode)
+        assertEquals(2, node.callbacks.size)
+
+        // Set callback values
+        (node.callbacks[0] as? NameCallback)?.name = "TestUser"
+        (node.callbacks[1] as? PasswordCallback)?.password = "TestPassword"
+
+        // Continue to next node
+        node.next()
+
+        // Verify the request preserves all original fields
+        val authenticateRequest = mockEngine.requestHistory[1]
+        val requestBody = (authenticateRequest.body as TextContent).text
+        val requestJson = Json.parseToJsonElement(requestBody).jsonObject
+
+        // Verify authId is preserved from original response
+        assertEquals("authIdValue", requestJson["authId"]?.jsonPrimitive?.content)
+
+        // Verify callbacks are updated with new values
+        val callbacks = requestJson["callbacks"]?.jsonArray
+        assertNotNull(callbacks)
+        assertEquals(2, callbacks.size)
+
+        // Verify callback values are updated
+        val nameValue = callbacks[0].jsonObject["input"]
+            ?.jsonArray?.get(0)?.jsonObject?.get("value")?.jsonPrimitive?.content
+        val passwordValue = callbacks[1].jsonObject["input"]
+            ?.jsonArray?.get(0)?.jsonObject?.get("value")?.jsonPrimitive?.content
+
+        assertEquals("TestUser", nameValue)
+        assertEquals("TestPassword", passwordValue)
+    }
+
+    @Test
+    fun `ContinueNode preserves additional JSON fields beyond authId and callbacks`() = runTest {
+        // Create a mock engine that returns a response with extra fields
+        val customMockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/am/json/realms/root/authenticate" -> {
+                    if (request.body is TextContent) {
+                        val bodyText = (request.body as TextContent).text
+                        val bodyJson = Json.parseToJsonElement(bodyText).jsonObject
+                        // If request has callbacks, return success response
+                        if (bodyJson["callbacks"]?.jsonArray?.isNotEmpty() == true) {
+                            respond(sessionResponse(), HttpStatusCode.OK, authenticateHeader)
+                        } else {
+                            // First request without callbacks
+                            respond(
+                                ByteReadChannel(
+                                    """{
+                                        "authId": "testAuthId",
+                                        "stage": "UsernamePassword",
+                                        "header": "Sign In",
+                                        "description": "Please enter your credentials",
+                                        "customField": "customValue",
+                                        "callbacks": [
+                                            {
+                                                "type": "NameCallback",
+                                                "output": [{"name": "prompt", "value": "User Name"}],
+                                                "input": [{"name": "IDToken1", "value": ""}],
+                                                "_id": 0
+                                            }
+                                        ]
+                                    }"""
+                                ),
+                                HttpStatusCode.OK,
+                                authenticateHeader
+                            )
+                        }
+                    } else {
+                        respond(
+                            ByteReadChannel(
+                                """{
+                                    "authId": "testAuthId",
+                                    "stage": "UsernamePassword",
+                                    "header": "Sign In",
+                                    "description": "Please enter your credentials",
+                                    "customField": "customValue",
+                                    "callbacks": [
+                                        {
+                                            "type": "NameCallback",
+                                            "output": [{"name": "prompt", "value": "User Name"}],
+                                            "input": [{"name": "IDToken1", "value": ""}],
+                                            "_id": 0
+                                        }
+                                    ]
+                                }"""
+                            ),
+                            HttpStatusCode.OK,
+                            authenticateHeader
+                        )
+                    }
+                }
+                else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val journey = Journey {
+            serverUrl = "http://localhost/am"
+            logger = Logger.CONSOLE
+            httpClient = HttpClient(customMockEngine) {
+                followRedirects = false
+            }
+            module(Session) {
+                storage = { MemoryStorage() }
+            }
+        }
+
+        val node = journey.start()
+        assertTrue(node is ContinueNode)
+        assertEquals(1, node.callbacks.size)
+        (node.callbacks[0] as? NameCallback)?.name = "TestUser"
+
+        // Continue to next node
+        node.next()
+
+        // Verify the request preserves all original fields including custom ones
+        val authenticateRequest = customMockEngine.requestHistory[1]
+        val requestBody = (authenticateRequest.body as TextContent).text
+        val requestJson = Json.parseToJsonElement(requestBody).jsonObject
+
+        // Verify all original fields are preserved
+        assertEquals("testAuthId", requestJson["authId"]?.jsonPrimitive?.content)
+        assertEquals("UsernamePassword", requestJson["stage"]?.jsonPrimitive?.content)
+        assertEquals("Sign In", requestJson["header"]?.jsonPrimitive?.content)
+        assertEquals("Please enter your credentials", requestJson["description"]?.jsonPrimitive?.content)
+        assertEquals("customValue", requestJson["customField"]?.jsonPrimitive?.content)
+
+        // Verify callbacks are updated
+        val callbacks = requestJson["callbacks"]?.jsonArray
+        assertNotNull(callbacks)
+        assertEquals(1, callbacks.size)
+
+        customMockEngine.close()
     }
 }


### PR DESCRIPTION
The `ContinueNode`'s request body construction has been updated to preserve all 
# JIRA Ticket

[SDKS-4584](https://pingidentity.atlassian.net/browse/SDKS-4584)

# Description

fields from the original JSON response. Previously, it only retained the `authId` and `callbacks`. Now, it iterates over the original JSON and includes all keys, ensuring that custom or additional fields are correctly sent in subsequent requests.

New tests have been added to verify that `authId` and other custom fields are preserved in the request body after a `ContinueNode` is processed. Additionally, existing test assertions were updated from `assertTrue` to `assertEquals` for better clarity.
