### PR TITLE
Fix: Make Location properties nullable for better flexibility

### DIFF
--- a/foundation/device/device-client/src/main/kotlin/com/pingidentity/device/client/Device.kt
+++ b/foundation/device/device-client/src/main/kotlin/com/pingidentity/device/client/Device.kt
@@ -6,7 +6,6 @@
 
 package com.pingidentity.device.client
 
-import android.annotation.SuppressLint
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -135,6 +134,10 @@ data class ProfileDevice(
 /**
  * Data class for device location.
  */
-@SuppressLint("UnsafeOptInUsageError")
+@OptIn(ExperimentalSerializationApi::class)
+@JsonIgnoreUnknownKeys
 @Serializable
-data class Location(val latitude: Double, val longitude: Double)
+data class Location(
+    var latitude: Double? = null,
+    var longitude: Double? = null,
+)


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4490](https://pingidentity.atlassian.net/browse/SDKS-4490)

# Description

The Device client call was failing because the Profile device had an error with the Location fields being null or empty. This fixes an issue with the server response in case the device profile has nullable location field.