### PR TITLE
SDKS-4621: Add Play Services Auth dependency for FIDO on older APIs

### DIFF
--- a/foundation/oidc/build.gradle.kts
+++ b/foundation/oidc/build.gradle.kts
@@ -30,9 +30,9 @@ android {
 dependencies {
     api(project(":foundation:utils"))
     api(project(":foundation:logger"))
+    api(project(":foundation:orchestrate"))
     implementation(project(":foundation:android"))
     implementation(project(":foundation:storage"))
-    implementation(project(":foundation:orchestrate"))
     implementation(project(":foundation:network"))
 
     //Make it optional for using centralize login

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWeb.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWeb.kt
@@ -32,7 +32,7 @@ class OidcWebConfig : WorkflowConfig() {
  *
  * @param config The OIDC web configuration.
  */
-class OidcWeb(config: OidcWebConfig) {
+class OidcWeb(val config: OidcWebConfig) {
 
     private var oidcFlow = OidcFlow(config)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ junitKtx = "1.3.0"
 androidx-test-runner = "1.7.0"
 androidx-credentials = "1.5.0"
 play-services-fido = "21.2.0"
+play-services-auth = "1.5.0"
 robolectric = "4.16"
 composeBom = "2025.08.01"
 activity = "1.10.1"
@@ -78,6 +79,7 @@ androidx-datastore-core = { module = "androidx.datastore:datastore-core", versio
 androidx-datastore = { module = "androidx.datastore:datastore", version.ref = "datastore" }
 androidx-credentials = { group = "androidx.credentials", name = "credentials", version.ref = "androidx-credentials" }
 play-services-fido = { module = "com.google.android.gms:play-services-fido", version.ref = "play-services-fido" }
+play-services-auth = { module = "androidx.credentials:credentials-play-services-auth", version.ref = "play-services-auth" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }
 bcpkix-jdk18on = { module = "org.bouncycastle:bcpkix-jdk18on", version.ref = "bcpkix-jdk18on" }
 
@@ -133,7 +135,7 @@ dokka-gradlePlugin = { group = "org.jetbrains.dokka", name = "org.jetbrains.dokk
 googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 facebook-login = { module = "com.facebook.android:facebook-login", version.ref = "facebook-login" }
 androidx-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "startupRuntime" }
-com-pingidentity-signals  = { group = "com.pingidentity.signals", name = "android-sdk", version.ref = "com-pingidentity-signals" }
+com-pingidentity-signals = { group = "com.pingidentity.signals", name = "android-sdk", version.ref = "com-pingidentity-signals" }
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cameraCamera2" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraCamera2" }
 androidx-camera-view = { module = "androidx.camera:camera-view", version.ref = "cameraCamera2" }
@@ -153,7 +155,7 @@ androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "b
 androidx-biometric-ktx = { module = "androidx.biometric:biometric-ktx", version.ref = "biometric" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jose-jwt" }
 
-play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location"}
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
 google-android-recaptcha = { module = "com.google.android.recaptcha:recaptcha", version.ref = "google-android-recaptcha" }
 
 [plugins]
@@ -161,7 +163,7 @@ androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 jetbrainsKotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
-kotlinSerialization = {id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "pluginSserialization" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "pluginSserialization" }
 testLogger = { id = "com.adarshr.test-logger", version.ref = "testLogger" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexus" }

--- a/journey/src/androidTest/kotlin/com/pingidentity/journey/callback/device/binding/DeviceBindingCallbackTest.kt
+++ b/journey/src/androidTest/kotlin/com/pingidentity/journey/callback/device/binding/DeviceBindingCallbackTest.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2025 Ping Identity Corporation. All rights reserved.
+ *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
@@ -29,6 +30,7 @@ import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.time.Instant
 
 class DeviceBindingCallbackTest : BaseJourneyTest() {
 
@@ -187,7 +189,7 @@ class DeviceBindingCallbackTest : BaseJourneyTest() {
             val deviceBindingCallback = node.callbacks.first() as DeviceBindingCallback
             assertNotNull(deviceBindingCallback)
             val result = deviceBindingCallback.bind {
-                expirationTime(60)
+                expirationTime = { Instant.now().plusSeconds(60)}
                 appPinConfig {
                     pinCollector { prompt ->
                         "1234".toCharArray()

--- a/mfa/fido/README.md
+++ b/mfa/fido/README.md
@@ -57,6 +57,22 @@ dependencies {
 }
 ```
 
+### Additional Dependencies for API 33 and Older
+
+**Important:** For devices running Android API 33 (Android 13) and older, you must add the Credentials Play Services Auth dependency to ensure proper FIDO functionality:
+
+```gradle
+dependencies {
+    implementation("com.pingidentity.sdks:fido:<version>")
+    implementation("androidx.credentials:credentials-play-services-auth:1.5.0")
+    // Add other necessary dependencies here
+}
+```
+
+This dependency is required because:
+- Android Credential Manager requires additional support libraries for API 33 and below
+- It provides backward compatibility for FIDO authentication on older Android versions
+
 ### Additional Dependencies for Non-Discoverable Keys
 
 **Important:** According to the [Android Credential Manager documentation](https://developer.android.com/identity/sign-in/credential-manager), the current Credential Manager does not support non-discoverable keys.

--- a/mfa/fido/src/main/kotlin/com/pingidentity/fido/FidoClient.kt
+++ b/mfa/fido/src/main/kotlin/com/pingidentity/fido/FidoClient.kt
@@ -31,6 +31,7 @@ import com.pingidentity.fido.Constants.FIELD_TYPE
 import com.pingidentity.fido.Constants.FIELD_USER_HANDLE
 import com.pingidentity.logger.Logger
 import com.pingidentity.utils.PingDsl
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -41,7 +42,6 @@ import kotlinx.serialization.json.double
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlin.coroutines.coroutineContext
 
 /**
  * Core FIDO operations handler for Android applications.
@@ -108,7 +108,7 @@ class FidoClient(private val config: FidoClientConfig) {
             val credentialRequest = customizer.customizer(CreatePublicKeyCredentialRequest(input.toString()))
 
             val result = credentialManager.createCredential(
-                context = ContextProvider.context,
+                context = ContextProvider.currentActivity,
                 request = credentialRequest
             )
             when (result) {
@@ -122,7 +122,7 @@ class FidoClient(private val config: FidoClientConfig) {
                 else -> throw IllegalStateException("Unexpected result type: ${result::class.simpleName}")
             }
         } catch (e: Exception) {
-            coroutineContext.ensureActive()
+            currentCoroutineContext().ensureActive()
             return Result.failure(e)
         }
     }
@@ -155,7 +155,7 @@ class FidoClient(private val config: FidoClientConfig) {
         val credentialRequest = GetCredentialRequest(listOf(credentialOption))
         try {
             val result = credentialManager.getCredential(
-                context = ContextProvider.context,
+                context = ContextProvider.currentActivity,
                 request = credentialRequest
             )
             when (val credential = result.credential) {
@@ -169,7 +169,7 @@ class FidoClient(private val config: FidoClientConfig) {
                 else -> throw IllegalStateException("Unexpected result type: ${result::class.simpleName}")
             }
         } catch (e: Exception) {
-            coroutineContext.ensureActive()
+            currentCoroutineContext().ensureActive()
             return Result.failure(e)
         }
     }
@@ -230,7 +230,7 @@ class FidoClient(private val config: FidoClientConfig) {
 
             return Result.success(assertionValue)
         } catch (e: Exception) {
-            coroutineContext.ensureActive()
+            currentCoroutineContext().ensureActive()
             return Result.failure(e)
         }
     }
@@ -320,7 +320,7 @@ class FidoClient(private val config: FidoClientConfig) {
                 )
             }
         } catch (e: Exception) {
-            coroutineContext.ensureActive()
+            currentCoroutineContext().ensureActive()
             return Result.failure(e)
         }
     }

--- a/mfa/fido/src/test/kotlin/com/pingidentity/fido/FidoClientTest.kt
+++ b/mfa/fido/src/test/kotlin/com/pingidentity/fido/FidoClientTest.kt
@@ -7,6 +7,7 @@
 
 package com.pingidentity.fido
 
+import android.app.Activity
 import android.content.Context
 import androidx.credentials.CreateCredentialResponse
 import androidx.credentials.CreatePublicKeyCredentialRequest
@@ -51,16 +52,19 @@ import com.google.android.gms.fido.fido2.api.common.PublicKeyCredential as GmsPu
 class FidoClientTest {
 
     private lateinit var mockContext: Context
+    private lateinit var mockActivity: Activity
     private lateinit var mockCredentialManager: CredentialManager
     private lateinit var fidoClient: FidoClient
 
     @BeforeTest
     fun setUp() {
         mockContext = mockk<Context>(relaxed = true)
+        mockActivity = mockk<Activity>(relaxed = true)
         mockCredentialManager = mockk<CredentialManager>(relaxed = true)
 
         mockkObject(ContextProvider)
         every { ContextProvider.context } returns mockContext
+        every { ContextProvider.currentActivity } returns mockActivity
 
         mockkObject(CredentialManager.Companion)
         every { CredentialManager.create(any()) } returns mockCredentialManager
@@ -102,7 +106,7 @@ class FidoClientTest {
             val requestSlot = slot<CreatePublicKeyCredentialRequest>()
             coEvery {
                 mockCredentialManager.createCredential(
-                    context = mockContext,
+                    context = mockActivity,
                     request = capture(requestSlot)
                 )
             } returns mockCreateResponse
@@ -118,7 +122,7 @@ class FidoClientTest {
 
             coVerify {
                 mockCredentialManager.createCredential(
-                    context = mockContext,
+                    context = mockActivity,
                     request = any<CreatePublicKeyCredentialRequest>()
                 )
             }
@@ -218,7 +222,7 @@ class FidoClientTest {
         val requestSlot = slot<CreatePublicKeyCredentialRequest>()
         coEvery {
             mockCredentialManager.createCredential(
-                context = mockContext,
+                context = mockActivity,
                 request = capture(requestSlot)
             )
         } returns mockCreateResponse
@@ -246,7 +250,7 @@ class FidoClientTest {
 
         coVerify {
             mockCredentialManager.createCredential(
-                context = mockContext,
+                context = mockActivity,
                 request = any<CreatePublicKeyCredentialRequest>()
             )
         }
@@ -280,7 +284,7 @@ class FidoClientTest {
             val requestSlot = slot<GetCredentialRequest>()
             coEvery {
                 mockCredentialManager.getCredential(
-                    context = mockContext,
+                    context = mockActivity,
                     request = capture(requestSlot)
                 )
             } returns mockGetResponse
@@ -295,7 +299,7 @@ class FidoClientTest {
 
             coVerify {
                 mockCredentialManager.getCredential(
-                    context = mockContext,
+                    context = mockActivity,
                     request = any<GetCredentialRequest>()
                 )
             }
@@ -592,7 +596,7 @@ class FidoClientTest {
         val requestSlot = slot<GetCredentialRequest>()
         coEvery {
             mockCredentialManager.getCredential(
-                context = mockContext,
+                context = mockActivity,
                 request = capture(requestSlot)
             )
         } returns mockGetResponse
@@ -623,7 +627,7 @@ class FidoClientTest {
         // Verify credential manager was called
         coVerify {
             mockCredentialManager.getCredential(
-                context = mockContext,
+                context = mockActivity,
                 request = any()
             )
         }
@@ -1386,7 +1390,7 @@ class FidoClientTest {
         val requestSlot = slot<GetCredentialRequest>()
         coEvery {
             mockCredentialManager.getCredential(
-                context = mockContext,
+                context = mockActivity,
                 request = capture(requestSlot)
             )
         } returns mockGetResponse
@@ -1551,7 +1555,7 @@ class FidoClientTest {
         val credentialManagerRequestSlot = slot<GetCredentialRequest>()
         coEvery {
             mockCredentialManager.getCredential(
-                context = mockContext,
+                context = mockActivity,
                 request = capture(credentialManagerRequestSlot)
             )
         } returns mockGetResponse

--- a/samples/app/build.gradle.kts
+++ b/samples/app/build.gradle.kts
@@ -92,6 +92,7 @@ dependencies {
     // FIDO2
     //To Support nod-discoverable fido2 credential
     implementation(libs.play.services.fido)
+    implementation(libs.play.services.auth)
     implementation(project(":mfa:fido"))
 
     //Protect

--- a/samples/journeyapp/build.gradle.kts
+++ b/samples/journeyapp/build.gradle.kts
@@ -86,7 +86,8 @@ dependencies {
 
     //To Support nod-discoverable fido2 credential
     implementation(libs.play.services.fido)
-    
+    implementation(libs.play.services.auth)
+
     implementation(project(":foundation:device:device-profile"))
     implementation(project(":foundation:device:device-client"))
     implementation(project(":recaptcha-enterprise"))


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4621](https://pingidentity.atlassian.net/browse/SDKS-4621)

# Description

For devices on Android API 33 and older, the `credentials-play-services-auth` dependency is now required for FIDO functionality. This ensures backward compatibility with the Android Credential Manager.

The `FidoClient` has also been updated to use `ContextProvider.currentActivity` instead of `ContextProvider.context` to align with Android Credential Manager requirements.