### PR TITLE
SDKS-4593 Update device-id, device-profile, and device-root gradle files for Ping SDK 2.0.0 beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Added new `fido` module [SDKS-4134]
 - Added new `device-binding`, `device-binding-ui` and `device-binding-migration` modules [SDKS-4115]
 - Added new `device-id` module [SDKS-4120]
+- Added new `device-client` module [SDKS-4190]
+- Added new `device-profile` module [SDKS-4300]
 - Added new `device-root` module [SDKS-4365]
 - Added new `recaptcha-enterprise` module [SDKS-4422]
 

--- a/foundation/device/device-id/build.gradle.kts
+++ b/foundation/device/device-id/build.gradle.kts
@@ -9,7 +9,7 @@ description = "Device Id library"
 
 plugins {
     id("com.pingidentity.convention.android.library")
-    // id("com.pingidentity.convention.centralPublish") // we are not publishing this module for now
+     id("com.pingidentity.convention.centralPublish")
     id("com.pingidentity.convention.jacoco")
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)

--- a/foundation/device/device-profile/build.gradle.kts
+++ b/foundation/device/device-profile/build.gradle.kts
@@ -9,7 +9,7 @@ description = "Device Profile library"
 
 plugins {
     id("com.pingidentity.convention.android.library")
-    // id("com.pingidentity.convention.centralPublish") // we are not publishing this module for now
+    id("com.pingidentity.convention.centralPublish")
     id("com.pingidentity.convention.jacoco")
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)

--- a/foundation/device/device-profile/src/main/kotlin/com/pingidentity/device/profile/collector/TelephonyCollector.kt
+++ b/foundation/device/device-profile/src/main/kotlin/com/pingidentity/device/profile/collector/TelephonyCollector.kt
@@ -58,7 +58,6 @@ val TelephonyCollector by lazy {
  *   Returns null if not available or if the device doesn't support telephony.
  *   Examples: "Verizon", "AT&T", "Rogers", "Vodafone"
  *
- * @sample
  * ```kotlin
  * val telephonyInfo = TelephonyInfo(
  *     networkCountryIso = "US",

--- a/foundation/device/device-root/build.gradle.kts
+++ b/foundation/device/device-root/build.gradle.kts
@@ -8,7 +8,7 @@ description = "Device Root Detection library"
 
 plugins {
     id("com.pingidentity.convention.android.library")
-    // id("com.pingidentity.convention.centralPublish") // we are not publishing this module for now
+    id("com.pingidentity.convention.centralPublish")
     id("com.pingidentity.convention.jacoco")
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinAndroid)


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4593](https://pingidentity.atlassian.net/browse/SDKS-4593) Release activities for Ping SDK 2.0.0 Beta

# Description

- Updated `device-id`, `device-profile`, and `device-root` gradle file, so we can publish the packages to maven central repo
- Updated CHANGELOG.md to list these new modules for the 2.0.0 release as well... 