### PR TITLE
SDKS-4626 Update DeviceTamperingPolicy and minor change to PushStorage default implementation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,11 +59,10 @@ kotlin-playservices-coroutine = "1.10.2"
 barcodeScanning = "17.3.0"
 cameraCamera2 = "1.4.2"
 lifecycleRuntimeKtx = "2.9.3"
-firebase-messaging = "25.0.0"
 playServicesAuthBlockstore = "16.4.0"
 kotlinxCoroutinesPlayServices = "1.10.2"
 googleServicesPlugin = "4.4.3"
-firebaseBom = "32.7.4"
+firebaseBom = "33.7.0"
 osmdroidAndroid = "6.1.20"
 biometric = "1.4.0-alpha02"
 nimbus-jose-jwt = "10.5"
@@ -150,7 +149,7 @@ commons-codec = { group = "commons-codec", name = "commons-codec", version = "1.
 barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref = "barcodeScanning" }
 play-services-auth-blockstore = { module = "com.google.android.gms:play-services-auth-blockstore", version.ref = "playServicesAuthBlockstore" }
 kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
-firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebase-messaging" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 osmdroid-android = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroidAndroid" }
 androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }

--- a/mfa/commons/build.gradle.kts
+++ b/mfa/commons/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(project(":foundation:android"))
     implementation(project(":foundation:storage"))
     implementation(project(":foundation:network"))
+    implementation(project(":foundation:device:device-root"))
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/mfa/commons/src/main/kotlin/com/pingidentity/mfa/commons/policy/DeviceTamperingPolicy.kt
+++ b/mfa/commons/src/main/kotlin/com/pingidentity/mfa/commons/policy/DeviceTamperingPolicy.kt
@@ -11,13 +11,13 @@ import android.content.Context
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import com.pingidentity.device.analyze
 
 /**
  * Policy that checks for device tampering indicators.
- * 
- * This is currently a placeholder implementation that always returns true.
- * In the future, this will be updated to use actual device tampering detection
- * library similar to the legacy FRRootDetector with threshold scoring.
+ *
+ * Uses the TamperDetector module to analyze the device for signs of rooting or tampering
+ * and compares the result against a configurable threshold.
  * 
  * JSON format: {"deviceTampering": {"score": 0.8}}
  * 
@@ -27,27 +27,18 @@ import kotlinx.serialization.json.jsonPrimitive
 object DeviceTamperingPolicy : MfaPolicy() {
     
     const val POLICY_NAME = "deviceTampering"
-    private const val DEFAULT_THRESHOLD = 0.5
+    private const val DEFAULT_THRESHOLD = 0.8
     
     override fun getName(): String {
         return POLICY_NAME
     }
     
     override suspend fun evaluate(context: Context, data: JsonObject?): Boolean {
-        // TODO: Replace with actual device tampering detection
-        // This is a placeholder implementation that always returns true
-        
         // Get the threshold from policy configuration data
         val threshold = data?.get("score")?.jsonPrimitive?.doubleOrNull ?: DEFAULT_THRESHOLD
         
-        // Placeholder: simulate device tampering score calculation
-        // In real implementation, this would check for:
-        // - Root detection
-        // - Debug mode detection
-        // - Emulator detection
-        // - Hook framework detection
-        // - Other tampering indicators
-        val deviceTamperingScore = 0.0 // Always safe for now
+        // Use a device tampering detection library to get the score
+        val deviceTamperingScore = analyze()
         
         // Return true if device tampering score is below threshold
         return deviceTamperingScore < threshold

--- a/mfa/push/build.gradle.kts
+++ b/mfa/push/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(libs.sqlcipher)
 
     // Firebase Cloud Messaging for push notifications
+    implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.messaging)
 
     // Testing dependencies

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/storage/SQLPushStorage.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/storage/SQLPushStorage.kt
@@ -627,13 +627,15 @@ class SQLPushStorage private constructor(
     /**
      * Retrieve all pending push notifications.
      *
-     * @return A list of pending Push notifications.
+     * @return A list of pending Push notifications that have not expired.
      * @throws MfaStorageException if the notifications cannot be retrieved.
      */
     override suspend fun getPendingPushNotifications(): List<PushNotification> {
         try {
             val dataList = retrievePendingPushNotificationsData()
-            return dataList.mapNotNull { createPushNotificationFromData(it) }
+            return dataList
+                .mapNotNull { createPushNotificationFromData(it) }
+                .filterNot { it.expired }
         } catch (e: Exception) {
             coroutineContext.ensureActive()
             throw MfaStorageException("Failed to retrieve pending Push notifications", e)

--- a/samples/authenticatorapp/build.gradle.kts
+++ b/samples/authenticatorapp/build.gradle.kts
@@ -28,6 +28,11 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // Enable 16 KB page size support for Android 15+
+        ndk {
+            abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64"))
+        }
     }
 
     buildTypes {
@@ -63,6 +68,14 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        force("com.google.android.gms:play-services-basement:18.4.0")
+        force("com.google.android.gms:play-services-tasks:18.2.0")
+        force("com.google.android.gms:play-services-base:18.5.0")
     }
 }
 

--- a/samples/authenticatorapp/build.gradle.kts
+++ b/samples/authenticatorapp/build.gradle.kts
@@ -28,11 +28,6 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-
-        // Enable 16 KB page size support for Android 15+
-        ndk {
-            abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64"))
-        }
     }
 
     buildTypes {

--- a/samples/authenticatorapp/src/main/AndroidManifest.xml
+++ b/samples/authenticatorapp/src/main/AndroidManifest.xml
@@ -26,11 +26,6 @@
             android:supportsRtl="true"
             android:theme="@style/Theme.PingIdentityAuthenticator"
             android:name="com.pingidentity.authenticatorapp.AuthenticatorApp">
-
-        <!-- 16KB page size support for Android 15+ -->
-        <property
-            android:name="android.app.16kb_page_support"
-            android:value="true" />
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/samples/authenticatorapp/src/main/AndroidManifest.xml
+++ b/samples/authenticatorapp/src/main/AndroidManifest.xml
@@ -26,6 +26,11 @@
             android:supportsRtl="true"
             android:theme="@style/Theme.PingIdentityAuthenticator"
             android:name="com.pingidentity.authenticatorapp.AuthenticatorApp">
+
+        <!-- 16KB page size support for Android 15+ -->
+        <property
+            android:name="android.app.16kb_page_support"
+            android:value="true" />
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4626](https://pingidentity.atlassian.net/browse/SDKS-4626) Update DeviceTamperingPolicy and minor change to PushStorage default implementation

# Description
Summary of changes included in this PR:
1. Updated placeholder implementation of `DeviceTamperingPolicy` to use the `device-root` module
2. Updated `getPendingPushNotifications` from the default `PushStorage` to align with iOS implementation
3. Fixed dependency conflicts with Firebase Messaging