### PR TITLE
SDKS-4610: Add support for legacy device identifier

### DIFF
--- a/foundation/device/device-id/README.md
+++ b/foundation/device/device-id/README.md
@@ -60,7 +60,9 @@ val deviceId = DefaultDeviceIdentifier.id
 
 The `DefaultDeviceIdentifier`:
 
-- Creates and stores a key pair in the Android KeyStore
+- First attempts to retrieve a legacy identifier from the KeyStore using the Android ID as the key
+  alias, if a legacy identifier is found, it is used for backward compatibility, if not found,
+  creates and stores a new key pair in the Android KeyStore
 - Uses the public key as the basis for the device identifier
 - Hashes the key data using SHA-256 for added security
 - Caches the result for efficient access

--- a/foundation/device/device-id/src/androidTest/kotlin/com/pingidentity/device/id/DefaultDeviceIdentifierTest.kt
+++ b/foundation/device/device-id/src/androidTest/kotlin/com/pingidentity/device/id/DefaultDeviceIdentifierTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,8 +22,9 @@ import kotlin.test.assertNotNull
 class DefaultDeviceIdentifierTest {
 
     @AfterTest
-    fun tearDown() {
+    fun tearDown() = runTest {
         KeyManager.removeKey(DefaultDeviceIdentifier.KEY_ALIAS)
+        KeyManager.removeKey(AndroidIDDeviceIdentifier.id())
     }
 
     @Test

--- a/foundation/device/device-id/src/main/kotlin/com/pingidentity/device/id/DefaultDeviceIdentifier.kt
+++ b/foundation/device/device-id/src/main/kotlin/com/pingidentity/device/id/DefaultDeviceIdentifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -34,11 +34,11 @@ object DefaultDeviceIdentifier : DeviceIdentifier {
      *
      * @return A unique identifier string for the device
      */
-    @OptIn(ExperimentalStdlibApi::class)
     override val id: suspend () -> String = {
         catch {
-            MessageDigest.getInstance(KeyProperties.DIGEST_SHA256)
-                .digest(KeyManager.identifierKey(KEY_ALIAS).encoded).toHexString()
+            LegacyDeviceIdentifier.identifier()
+                ?: MessageDigest.getInstance(KeyProperties.DIGEST_SHA256)
+                    .digest(KeyManager.identifierKey(KEY_ALIAS).encoded).toHexString()
         }
     }
 

--- a/foundation/device/device-id/src/main/kotlin/com/pingidentity/device/id/DeviceIdentifier.kt
+++ b/foundation/device/device-id/src/main/kotlin/com/pingidentity/device/id/DeviceIdentifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,8 +7,8 @@
 
 package com.pingidentity.device.id
 
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
-import kotlin.coroutines.coroutineContext
 
 /**
  * Interface for obtaining a device-specific identifier.
@@ -73,7 +73,7 @@ suspend inline fun catch(crossinline block: suspend () -> String): String {
     return try {
         block()
     } catch (e: Exception) {
-        coroutineContext.ensureActive()
+        currentCoroutineContext().ensureActive()
         throw DeviceIdentifierException("Failed to retrieve device identifier", e)
     }
 }

--- a/foundation/device/device-id/src/main/kotlin/com/pingidentity/device/id/LegacyDeviceIdentifier.kt
+++ b/foundation/device/device-id/src/main/kotlin/com/pingidentity/device/id/LegacyDeviceIdentifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -34,7 +34,11 @@ object LegacyDeviceIdentifier : DeviceIdentifier {
      *
      * @return A unique identifier string for the device
      */
-    override val id: suspend () -> String = { catch { identifier() } }
+    override val id: suspend () -> String = {
+        catch {
+            identifier() ?: DefaultDeviceIdentifier.id()
+        }
+    }
 
     /**
      * Generates the device identifier by checking for a legacy key in the KeyStore.
@@ -43,13 +47,12 @@ object LegacyDeviceIdentifier : DeviceIdentifier {
      *
      * @return A composite identifier string or the default device identifier
      */
-    @OptIn(ExperimentalStdlibApi::class)
-    private suspend fun identifier(): String {
+    internal suspend fun identifier(): String? {
         return key()?.let {
             AndroidIDDeviceIdentifier.id() + "-" +
                     MessageDigest.getInstance(KeyProperties.DIGEST_SHA1)
                         .digest(it.encoded).toHexString()
-        } ?: DefaultDeviceIdentifier.id()
+        }
     }
 
     /**

--- a/foundation/device/device-id/src/test/kotlin/com/pingidentity/device/id/DefaultDeviceIdentifierTest.kt
+++ b/foundation/device/device-id/src/test/kotlin/com/pingidentity/device/id/DefaultDeviceIdentifierTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.device.id
+
+import android.security.keystore.KeyProperties
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.security.Key
+import java.security.MessageDigest
+
+class DefaultDeviceIdentifierTest {
+
+    @Before
+    fun setUp() {
+        mockkObject(LegacyDeviceIdentifier)
+        mockkObject(KeyManager)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `id should return legacy identifier when LegacyDeviceIdentifier returns non-null`() = runTest {
+        // Given
+        val expectedLegacyId = "legacy-device-id-12345"
+        coEvery { LegacyDeviceIdentifier.identifier() } returns expectedLegacyId
+
+        // When
+        val result = DefaultDeviceIdentifier.id()
+
+        // Then
+        assertEquals(expectedLegacyId, result)
+    }
+
+    @Test
+    fun `id should generate new identifier when LegacyDeviceIdentifier returns null`() = runTest {
+        // Given
+        val mockKey = mockk<Key>()
+        val keyBytes = "mock-key-data".toByteArray()
+        val expectedHash = MessageDigest.getInstance(KeyProperties.DIGEST_SHA256)
+            .digest(keyBytes).toHexString()
+
+        coEvery { LegacyDeviceIdentifier.identifier() } returns null
+        every { mockKey.encoded } returns keyBytes
+        every { KeyManager.identifierKey(DefaultDeviceIdentifier.KEY_ALIAS) } returns mockKey
+
+        // When
+        val result = DefaultDeviceIdentifier.id()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(expectedHash, result)
+    }
+
+    @Test
+    fun `id should return hex string of SHA-256 hash when legacy identifier is null`() = runTest {
+        // Given
+        val mockKey = mockk<Key>()
+        val keyBytes = "test-key-data-123".toByteArray()
+
+        coEvery { LegacyDeviceIdentifier.identifier() } returns null
+        every { mockKey.encoded } returns keyBytes
+        every { KeyManager.identifierKey(DefaultDeviceIdentifier.KEY_ALIAS) } returns mockKey
+
+        // When
+        val result = DefaultDeviceIdentifier.id()
+
+        // Then
+        assertNotNull(result)
+        // Verify it's a valid hex string
+        assertTrue(result.matches(Regex("[0-9a-f]+")))
+        // Verify the length is correct for SHA-256 (32 bytes = 64 hex characters)
+        assertEquals(64, result.length)
+    }
+
+    @Test
+    fun `id should prefer legacy identifier over generating new one`() = runTest {
+        // Given
+        val expectedLegacyId = "legacy-id-should-be-used"
+        val mockKey = mockk<Key>()
+
+        coEvery { LegacyDeviceIdentifier.identifier() } returns expectedLegacyId
+        every { mockKey.encoded } returns "should-not-be-used".toByteArray()
+        every { KeyManager.identifierKey(DefaultDeviceIdentifier.KEY_ALIAS) } returns mockKey
+
+        // When
+        val result = DefaultDeviceIdentifier.id()
+
+        // Then
+        // Should use the legacy identifier and not generate a new one
+        assertEquals(expectedLegacyId, result)
+    }
+}
+

--- a/foundation/device/device-id/src/test/kotlin/com/pingidentity/device/id/LegacyDeviceIdentifierTest.kt
+++ b/foundation/device/device-id/src/test/kotlin/com/pingidentity/device/id/LegacyDeviceIdentifierTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.device.id
+
+import android.security.keystore.KeyProperties
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.security.Key
+import java.security.MessageDigest
+
+class LegacyDeviceIdentifierTest {
+
+    private val testAndroidId = "test-android-id-12345"
+
+    @Before
+    fun setUp() {
+        mockkObject(KeyManager)
+        mockkObject(AndroidIDDeviceIdentifier)
+        mockkObject(DefaultDeviceIdentifier)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `identifier should return composite ID when legacy key exists`() = runTest {
+        // Given
+        val mockKey = mockk<Key>()
+        val keyBytes = "mock-key-data".toByteArray()
+        val expectedHash = MessageDigest.getInstance(KeyProperties.DIGEST_SHA1)
+            .digest(keyBytes).toHexString()
+        val expectedId = "$testAndroidId-$expectedHash"
+
+        coEvery { AndroidIDDeviceIdentifier.id() } returns testAndroidId
+        every { KeyManager.containsKey(testAndroidId) } returns true
+        every { KeyManager.identifierKey(testAndroidId) } returns mockKey
+        every { mockKey.encoded } returns keyBytes
+
+        // When
+        val result = LegacyDeviceIdentifier.identifier()
+
+        // Then
+        assertNotNull(result)
+        assertEquals(expectedId, result)
+    }
+
+    @Test
+    fun `identifier should return null when legacy key does not exist`() = runTest {
+        // Given
+        coEvery { AndroidIDDeviceIdentifier.id() } returns testAndroidId
+        every { KeyManager.containsKey(testAndroidId) } returns false
+
+        // When
+        val result = LegacyDeviceIdentifier.identifier()
+
+        // Then
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun `id should return legacy identifier when key exists`() = runTest {
+        // Given
+        val mockKey = mockk<Key>()
+        val keyBytes = "test-key-bytes".toByteArray()
+        val expectedHash = MessageDigest.getInstance(KeyProperties.DIGEST_SHA1)
+            .digest(keyBytes).toHexString()
+        val expectedId = "$testAndroidId-$expectedHash"
+
+        coEvery { AndroidIDDeviceIdentifier.id() } returns testAndroidId
+        every { KeyManager.containsKey(testAndroidId) } returns true
+        every { KeyManager.identifierKey(testAndroidId) } returns mockKey
+        every { mockKey.encoded } returns keyBytes
+
+        // When
+        val result = LegacyDeviceIdentifier.id()
+
+        // Then
+        assertEquals(expectedId, result)
+    }
+
+    @Test
+    fun `id should fallback to DefaultDeviceIdentifier when legacy key does not exist`() = runTest {
+        // Given
+        val expectedDefaultId = "default-device-id"
+
+        coEvery { AndroidIDDeviceIdentifier.id() } returns testAndroidId
+        every { KeyManager.containsKey(testAndroidId) } returns false
+        coEvery { DefaultDeviceIdentifier.id() } returns expectedDefaultId
+
+        // When
+        val result = LegacyDeviceIdentifier.id()
+
+        // Then
+        assertEquals(expectedDefaultId, result)
+    }
+
+    @Test
+    fun `identifier should generate correct SHA1 hash of key`() = runTest {
+        // Given
+        val mockKey = mockk<Key>()
+        val keyBytes = "specific-test-data".toByteArray()
+        // Calculate the expected SHA-1 hash
+        val expectedHash = MessageDigest.getInstance(KeyProperties.DIGEST_SHA1)
+            .digest(keyBytes).toHexString()
+
+        coEvery { AndroidIDDeviceIdentifier.id() } returns testAndroidId
+        every { KeyManager.containsKey(testAndroidId) } returns true
+        every { KeyManager.identifierKey(testAndroidId) } returns mockKey
+        every { mockKey.encoded } returns keyBytes
+
+        // When
+        val result = LegacyDeviceIdentifier.identifier()
+
+        // Then
+        assertNotNull(result)
+        assertTrue(result!!.contains(expectedHash))
+        assertTrue(result.startsWith(testAndroidId))
+    }
+
+    @Test
+    fun `identifier should handle different Android IDs`() = runTest {
+        // Given
+        val differentAndroidId = "different-android-id"
+        val mockKey = mockk<Key>()
+        val keyBytes = "key-data".toByteArray()
+
+        coEvery { AndroidIDDeviceIdentifier.id() } returns differentAndroidId
+        every { KeyManager.containsKey(differentAndroidId) } returns true
+        every { KeyManager.identifierKey(differentAndroidId) } returns mockKey
+        every { mockKey.encoded } returns keyBytes
+
+        // When
+        val result = LegacyDeviceIdentifier.identifier()
+
+        // Then
+        assertNotNull(result)
+        assertTrue(result!!.startsWith(differentAndroidId))
+    }
+
+    @Test
+    fun `identifier should use Android ID as key alias`() = runTest {
+        // Given
+        val customAndroidId = "custom-android-id-999"
+
+        coEvery { AndroidIDDeviceIdentifier.id() } returns customAndroidId
+        every { KeyManager.containsKey(customAndroidId) } returns false
+
+        // When
+        val result = LegacyDeviceIdentifier.identifier()
+
+        // Then
+        // Should return null when key doesn't exist for the Android ID alias
+        assertEquals(null, result)
+    }
+}
+


### PR DESCRIPTION


# JIRA Ticket

[SDKS-4610](https://pingidentity.atlassian.net/browse/SDKS-4610)

# Description

This change introduces support for a legacy device identification mechanism.

The `DefaultDeviceIdentifier` now first attempts to retrieve a legacy identifier. If a legacy identifier is found, it is used. If not, it falls back to the current method of generating a new SHA-256 based identifier.

The legacy identifier is a composite ID, created by combining the Android ID with a SHA-1 hash of a legacy key stored in the KeyStore. New unit tests have been added to verify this legacy fallback logic. Additionally, a deprecated coroutine context call has been updated.