### PR TITLE
SDKS-4679 & SDKS-4681: Add Polling and QR Code collectors for DaVinci flows

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -16,6 +16,8 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
@@ -57,6 +59,9 @@ internal class CollectorRegistry : ModuleInitializer() {
         CollectorFactory.register("DEVICE_REGISTRATION", ::DeviceRegistrationCollector)
         CollectorFactory.register("DEVICE_AUTHENTICATION", ::DeviceAuthenticationCollector)
         CollectorFactory.register("PHONE_NUMBER", ::PhoneNumberCollector)
+
+        CollectorFactory.register("POLLING", ::PollingCollector)
+        CollectorFactory.register("QR_CODE", ::QRCodeCollector)
 
         // AGREEMENT fields use inputType "READ_ONLY_TEXT" which is the factory lookup key
         CollectorFactory.register("READ_ONLY_TEXT", ::AgreementCollector)

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PollingCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/PollingCollector.kt
@@ -1,0 +1,429 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import com.pingidentity.davinci.plugin.DaVinci
+import com.pingidentity.davinci.plugin.DaVinciAware
+import com.pingidentity.davinci.plugin.Submittable
+import com.pingidentity.orchestrate.Closeable
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.ContinueNodeAware
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.yield
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+// JSON field constants for polling configuration and status
+
+/** Event type identifier for polling collectors */
+private const val POLLING = "polling"
+
+/** JSON key for the polling interval in milliseconds between requests */
+private const val POLL_INTERVAL = "pollInterval"
+
+/** JSON key for the maximum number of polling retry attempts */
+private const val POLL_RETRIES = "pollRetries"
+
+/** JSON key indicating whether to actively poll for challenge status */
+private const val POLL_CHALLENGE_STATUS = "pollChallengeStatus"
+
+/** JSON key for the status field in payloads and responses */
+private const val STATUS = "status"
+
+/** JSON key for the challenge identifier used in polling URLs */
+private const val CHALLENGE = "challenge"
+
+/** JSON key in server responses indicating if a challenge is complete */
+private const val IS_CHALLENGE_COMPLETE = "isChallengeComplete"
+
+/** JSON key in error responses identifying the type of service error */
+private const val SERVICE_NAME = "serviceName"
+
+/** The serviceName value returned by the server when the challenge has expired */
+private const val CHALLENGE_EXPIRED = "challengeExpired"
+
+/**
+ * Sealed class representing the status of a polling operation.
+ */
+sealed class PollingStatus {
+    /**
+     * Indicates that polling is in progress.
+     * @param retryCount The current retry count.
+     * @param maxRetries The maximum number of retries.
+     */
+    data class Continue(val retryCount: Int, val maxRetries: Int) : PollingStatus()
+
+    /**
+     * Indicates that polling has expired (max retries reached).
+     */
+    data object TimedOut : PollingStatus()
+
+    /**
+     * Indicates that the challenge has expired because the server returned a non-200 HTTP response.
+     * Polling stops immediately when this status is emitted.
+     */
+    data object Expired : PollingStatus()
+
+    /**
+     * Indicates that an error occurred during polling.
+     * @param exception The exception that occurred.
+     */
+    data class Error(val exception: Exception) : PollingStatus()
+
+    /**
+     * Indicates that polling has completed successfully.
+     */
+    data class Complete(val status: String) : PollingStatus()
+}
+
+/**
+ * A collector that handles asynchronous polling operations in DaVinci authentication flows.
+ *
+ * The PollingCollector is used for authentication scenarios that require waiting for user actions
+ * on another device or channel, such as:
+ * - Push notification authentication
+ * - QR code scanning
+ * - Email verification
+ * - Out-of-band (OOB) authentication
+ *
+ * ## Polling Modes
+ *
+ * ### Simple Polling Mode
+ * When [pollChallengeStatus] is `false` or [challenge] is empty, performs a simple delay-based
+ * polling without actively checking server status. After each delay:
+ * - Decrements [retriesAllowed]
+ * - Emits [PollingStatus.Continue] if retries remain
+ * - Emits [PollingStatus.TimedOut] when retries reach 0
+ *
+ * This mode is useful for basic waiting periods where the client simply needs to wait before
+ * checking again.
+ *
+ * ### Challenge Status Polling Mode
+ * When [pollChallengeStatus] is `true` and [challenge] is not empty, actively polls a server
+ * endpoint to check the status of an authentication challenge. The polling continues until:
+ * - The challenge is completed successfully ([PollingStatus.Complete])
+ * - Maximum retries are reached ([PollingStatus.TimedOut])
+ * - The server returns a non-200 HTTP response ([PollingStatus.Expired])
+ * - An error occurs ([PollingStatus.Error])
+ *
+ * **Polling Endpoint:** `{baseUrl}/davinci/user/credentials/challenge/{challenge}/status`
+ *
+ * ## Flow-based API
+ *
+ * The [pollStatus] method returns a Flow that emits [PollingStatus] updates throughout the polling
+ * lifecycle, providing real-time feedback to the application for UI updates.
+ *
+ * **Flow Interception:** The flow automatically intercepts each emission using `onEach` to set
+ * the [value] property before the caller receives it. This ensures [value] is always synchronized
+ * with the emitted status.
+ *
+ * ```
+ *
+ * ## Value Assignment
+ *
+ * The [value] property is automatically set via flow interception based on the polling outcome:
+ * - [PollingStatus.Complete] → Server status value (e.g., "approved")
+ * - [PollingStatus.TimedOut] → "timedOut"
+ * - [PollingStatus.Expired] → "expired"
+ * - [PollingStatus.Error] → "error"
+ * - [PollingStatus.Continue] → "continue"
+ *
+ * This value is submitted as part of the form data when continuing to the next node in the flow.
+ *
+ * @see PollingStatus
+ * @see poll
+ */
+class PollingCollector : SingleValueCollector(), Submittable, ContinueNodeAware, DaVinciAware,
+    Closeable {
+
+    /**
+     * The continue node for the DaVinci flow.
+     * Used to extract configuration and context for the polling operation.
+     */
+    override lateinit var continueNode: ContinueNode
+
+    /**
+     * The DaVinci workflow instance.
+     * Provides access to HTTP client and logger for polling operations.
+     */
+    override lateinit var davinci: DaVinci
+
+    /**
+     * Polling interval in milliseconds between each polling attempt.
+     * Default value is "2000" (2 seconds).
+     */
+    lateinit var pollInterval: String
+        private set
+
+    /**
+     * Maximum number of polling attempts before timing out.
+     * Default value is "60".
+     */
+    lateinit var pollRetries: String
+        private set
+
+    /**
+     * Whether to actively poll for challenge status.
+     * When `false`, performs simple delay polling.
+     * When `true`, polls the server endpoint for challenge completion.
+     */
+    var pollChallengeStatus = false
+        private set
+
+    /**
+     * The challenge identifier to poll for.
+     * Used to construct the polling endpoint URL.
+     */
+    lateinit var challenge: String
+        private set
+
+
+    override fun eventType(): String = POLLING
+
+    /**
+     * The number of polling attempts remaining before timeout in simple polling mode.
+     *
+     * This property is only used in simple polling mode (when [pollChallengeStatus] is false).
+     * It is initialized to [pollRetries] value and decremented after each polling interval.
+     * When it reaches 0, [PollingStatus.TimedOut] is emitted.
+     *
+     * For challenge status polling mode, this value is maintained but not actively used
+     * in the polling logic.
+     */
+    var retriesAllowed: Int = 0
+
+    /**
+     * Initializes the PollingCollector with configuration from the input JSON.
+     *
+     * Extracts and sets the following parameters:
+     * - [pollInterval]: Polling interval in milliseconds (default: "2000")
+     * - [pollRetries]: Maximum number of retries (default: "60")
+     * - [pollChallengeStatus]: Whether to poll for challenge status (default: false)
+     * - [challenge]: Challenge identifier for polling (default: "")
+     *
+     * @param input JSON object containing the collector configuration
+     * @return This PollingCollector instance for method chaining
+     *
+     * @see SingleValueCollector.init
+     */
+    override fun init(input: JsonObject): PollingCollector {
+        super.init(input)
+        // Extract polling configuration from input JSON with sensible defaults
+        pollInterval = input[POLL_INTERVAL]?.jsonPrimitive?.content ?: "2000" // Default: 2 seconds
+        pollRetries = input[POLL_RETRIES]?.jsonPrimitive?.content ?: "60" // Default: 60 attempts
+        pollChallengeStatus =
+            input[POLL_CHALLENGE_STATUS]?.jsonPrimitive?.boolean ?: false // Default: simple polling
+        challenge = input[CHALLENGE]?.jsonPrimitive?.content ?: "" // Default: no challenge ID
+
+        // Initialize remaining retries counter for simple polling mode
+        retriesAllowed = pollRetries.toInt()
+        return this
+    }
+
+    /**
+     * Polls for the challenge status and emits the current polling status.
+     *
+     * This method returns a Flow that emits [PollingStatus] updates throughout the polling lifecycle.
+     * The polling behavior depends on the configuration set during [init]:
+     *
+     * ## Challenge Status Polling Mode
+     * When [pollChallengeStatus] is `true` and [challenge] is not empty:
+     *
+     * 1. **Extracts configuration** from [continueNode].input:
+     *    - `_links.next.href`: Used to construct base URL
+     *    - `interactionId`: Required header for polling requests
+     *
+     * 2. **Constructs polling URL**:
+     *    `{baseUrl}/davinci/user/credentials/challenge/{challenge}/status`
+     *
+     * 3. **Polling loop** (repeats up to [pollRetries] times):
+     *    - Delays for [pollInterval] milliseconds
+     *    - Makes HTTP POST request with `interactionId` header
+     *    - Parses JSON response for `isChallengeComplete` field
+     *    - **If HTTP error (status ≠ 200)**: Emits [PollingStatus.Expired] and stops polling
+     *    - **If challenge complete**: Emits [PollingStatus.Complete] with server status and exits
+     *    - **If not complete**: Emits [PollingStatus.Continue] and continues polling
+     *    - **If exception occurs**: Emits [PollingStatus.Error] and exits
+     *
+     * 4. **If max retries reached**: Emits [PollingStatus.TimedOut]
+     *
+     * 5. **If configuration missing**: Emits [PollingStatus.Error] immediately
+     *
+     * ## Simple Polling Mode
+     * When [pollChallengeStatus] is `false` or [challenge] is empty:
+     *
+     * 1. **Validates [pollInterval]** (must be > 0)
+     * 2. **Delays** for [pollInterval] milliseconds
+     * 3. **Decrements [retriesAllowed]**
+     * 4. **If retries remain**: Emits [PollingStatus.Continue] with remaining retries
+     * 5. **If retries exhausted**: Emits [PollingStatus.TimedOut]
+     * 6. **If invalid interval**: Emits [PollingStatus.Error]
+     *
+     * ## Flow Interception
+     *
+     * After emission but before the caller receives it, the flow uses `onEach` to set
+     * the [value] property based on the emitted status:
+     *
+     * | Status Type | Value Set |
+     * |-------------|-----------|
+     * | [PollingStatus.Complete] | Server status (e.g., "approved") |
+     * | [PollingStatus.TimedOut] | "timedOut" |
+     * | [PollingStatus.Expired] | "expired" |
+     * | [PollingStatus.Error] | "error" |
+     * | [PollingStatus.Continue] | "continue" |
+     *
+     * @return A Flow of [PollingStatus] that emits status updates throughout the polling operation.
+     *         The Flow completes naturally when polling finishes (Complete, TimedOut, Expired, or Error).
+     *
+     * @throws IllegalStateException if [continueNode] or [davinci] are not initialized (challenge mode only)
+     *
+     * @see PollingStatus
+     * @see PollingStatus.Continue
+     * @see PollingStatus.Complete
+     * @see PollingStatus.TimedOut
+     * @see PollingStatus.Expired
+     * @see PollingStatus.Error
+     */
+    fun pollStatus(): Flow<PollingStatus> = flow {
+        // Determine polling mode based on configuration
+        if (pollChallengeStatus && challenge.isNotEmpty()) {
+            // --- Challenge Status Polling Mode ---
+            // Actively polls the server to check if a challenge has been completed
+
+            // Extract polling configuration from the continue node input
+            val links = continueNode.input["_links"]?.jsonObject
+            val selfHref = links?.get("self")?.jsonObject?.get("href")?.jsonPrimitive?.content
+            val interactionId = continueNode.input["interactionId"]?.jsonPrimitive?.content
+
+            if (selfHref != null && interactionId != null) {
+                // Construct the polling endpoint URL
+                // Example: https://auth.pingone.ca/env-id/davinci/user/credentials/challenge/abc123/status
+                val baseUrl = selfHref.substringBefore("/davinci/connections")
+                val pollingUrl = "$baseUrl/davinci/user/credentials/challenge/$challenge/status"
+
+                val httpClient = davinci.config.httpClient
+                val maxRetries = pollRetries.toIntOrNull() ?: 60
+                val interval = pollInterval.toLongOrNull() ?: 2000L
+
+                var retryCount = 0
+                var shouldContinuePolling = true
+
+                // Poll repeatedly until challenge is complete, max retries reached, or error occurs
+                while (retryCount < maxRetries && shouldContinuePolling) {
+                    // Wait before making the next polling request
+                    delay(interval)
+
+                    try {
+                        // Make HTTP POST request to check challenge status
+                        val response = httpClient.request {
+                            url = pollingUrl
+                            header("interactionId", interactionId)
+                            post()
+                        }
+
+                        // Handle non-200 HTTP responses
+                        if (response.status != 200) {
+                            val errorBody: String = response.body()
+                            davinci.config.logger.i("Server returned non-200 response: ${response.status}, $errorBody")
+                            val errorJson = runCatching {
+                                Json.parseToJsonElement(errorBody).jsonObject
+                            }.getOrNull()
+                            val serviceName = errorJson?.get(SERVICE_NAME)?.jsonPrimitive?.content
+                            if (serviceName == CHALLENGE_EXPIRED) {
+                                emit(PollingStatus.Expired)
+                            } else {
+                                emit(PollingStatus.Error(IllegalStateException("Server error: ${response.status}, $errorBody")))
+                            }
+                            shouldContinuePolling = false
+                        } else {
+                            // Parse the JSON response to check challenge completion status
+                            val responseBody: String = response.body()
+                            val jsonResponse = Json.parseToJsonElement(responseBody).jsonObject
+                            val challengeComplete =
+                                jsonResponse[IS_CHALLENGE_COMPLETE]?.jsonPrimitive?.boolean ?: false
+
+                            if (challengeComplete) {
+                                // Challenge successfully completed - emit Complete with status from server
+                                val statusValue = jsonResponse[STATUS]?.jsonPrimitive?.content ?: ""
+                                emit(PollingStatus.Complete(statusValue))
+                                shouldContinuePolling = false // Exit the polling loop
+                            } else {
+                                // Challenge not yet complete - emit Continue status with current retry count
+                                emit(PollingStatus.Continue(retryCount + 1, maxRetries))
+                            }
+                        }
+                    } catch (e: Exception) {
+                        // Handle network errors, JSON parsing errors, or other exceptions
+                        currentCoroutineContext().ensureActive()
+                        davinci.config.logger.w("Error polling challenge status", e)
+                        emit(PollingStatus.Error(e))
+                        shouldContinuePolling = false // Exit the polling loop on exception
+                    }
+
+                    // Yield to allow coroutine cancellation between polling attempts
+                    if (shouldContinuePolling) {
+                        yield()
+                        retryCount++
+                    }
+                }
+
+                // If we exited the loop due to max retries (not due to completion or error)
+                if (shouldContinuePolling) {
+                    emit(PollingStatus.TimedOut)
+                }
+            } else {
+                // Required configuration (selfHref or interactionId) is missing
+                emit(PollingStatus.Error(IllegalStateException("Missing selfHref or interactionId")))
+            }
+        } else {
+            // --- Continue Polling Mode ---
+            // Performs a simple delay without actively checking server status
+
+            if (pollInterval.toInt() > 0) {
+                // Wait for the specified interval
+                delay(pollInterval.toLong())
+
+                // Decrement retries and emit Continue status
+                if (--retriesAllowed <= 0) {
+                    emit(PollingStatus.TimedOut)
+                } else {
+                    // Continue Polling is consider completed, but set status to server with value "continue"
+                    emit(PollingStatus.Complete("continue"))
+                }
+            } else {
+                // Invalid polling interval - emit error
+                emit(PollingStatus.Error(IllegalArgumentException("Invalid pollInterval: $pollInterval")))
+            }
+        }
+    }.onEach { status ->
+        // Intercept each emission and set the value property before caller receives it
+        value = when (status) {
+            is PollingStatus.Complete -> status.status
+            is PollingStatus.TimedOut -> "timedOut"
+            is PollingStatus.Error -> "error"
+            is PollingStatus.Continue -> "continue"
+            is PollingStatus.Expired -> "expired"
+        }
+    }
+
+    /**
+     * Clears the collector's value property.
+     * @see Closeable.close
+     */
+    override fun close() {
+        value = ""
+    }
+}

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/QRCodeCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/QRCodeCollector.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import com.pingidentity.davinci.plugin.Collector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.io.encoding.Base64
+
+/**
+ * A collector that handles QR code display in DaVinci authentication flows.
+ *
+ * The QRCodeCollector is used to display QR codes to users for authentication scenarios such as:
+ * - Device pairing
+ * - Multi-factor authentication setup
+ * - Out-of-band authentication
+ * - Cross-device authentication flows
+ *
+ * The QR code content is typically provided as a Base64-encoded image string that can be
+ * decoded and displayed as a bitmap.
+ *
+ * ## Content Format
+ *
+ * The [content] field typically contains a data URI string with Base64-encoded image data:
+ * ```
+ * data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...
+ * ```
+ *
+ * @see Collector
+ * @see bitmap
+ */
+class QRCodeCollector : Collector<Nothing> {
+
+    /**
+     * The QR code content as a Base64-encoded data URI string.
+     *
+     * This typically contains the full data URI including the MIME type and Base64 prefix:
+     * `data:image/png;base64,{base64-encoded-data}`
+     *
+     * The [bitmap] method extracts and decodes this content to create a displayable bitmap.
+     */
+    lateinit var content: String
+        private set
+
+    /**
+     * Fallback text to display when the QR code cannot be rendered.
+     *
+     * This text provides an alternative way for users to complete the authentication
+     * if the QR code cannot be displayed or scanned. It may contain:
+     * - A manual entry code
+     * - Instructions for alternative authentication methods
+     * - Error or help information
+     */
+    lateinit var fallbackText: String
+        private set
+
+    /**
+     * Initializes the QRCodeCollector with configuration from the input JSON.
+     *
+     * Extracts and sets the following parameters:
+     * - [content]: QR code content as Base64-encoded data URI (default: "")
+     * - [fallbackText]: Alternative text if QR code cannot be displayed (default: "")
+     *
+     * @param input JSON object containing the collector configuration with fields:
+     *              - `content`: The Base64-encoded QR code image data
+     *              - `fallbackText`: Alternative text for display
+     * @return This QRCodeCollector instance for method chaining
+     *
+     * @see Collector.init
+     */
+    override fun init(input: JsonObject): QRCodeCollector {
+        super.init(input)
+        content = input["content"]?.jsonPrimitive?.content ?: ""
+        fallbackText = input["fallbackText"]?.jsonPrimitive?.content ?: ""
+        return this
+    }
+
+    /**
+     * Converts the Base64-encoded QR code content to a displayable Bitmap.
+     *
+     * This method:
+     * 1. Extracts the Base64 data from the [content] string (after "base64,")
+     * 2. Decodes the Base64 string to a byte array
+     * 3. Converts the byte array to a Bitmap using BitmapFactory
+     *
+     * ## Content Format
+     *
+     * The method expects [content] to be in data URI format:
+     * ```
+     * data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...
+     * ```
+     *
+     * The substring after "base64," is extracted and decoded.
+     *
+     * @return A Bitmap representation of the QR code, or `null` if decoding fails
+     *
+     * @see content
+     * @see fallbackText
+     */
+    fun bitmap(): Bitmap? {
+        return try {
+            // Decode Base64 content and convert to Bitmap
+            val decodedBytes = Base64.decode(content.substringAfter("base64,"))
+            BitmapFactory.decodeByteArray(decodedBytes, 0, decodedBytes.size)
+        } catch (e: Exception) {
+            // Return null if decoding fails
+            null
+        }
+    }
+}

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -11,8 +11,10 @@ import com.pingidentity.davinci.collector.Form
 import com.pingidentity.davinci.plugin.Collector
 import com.pingidentity.davinci.plugin.CollectorFactory
 import com.pingidentity.davinci.plugin.DaVinci
+import com.pingidentity.davinci.plugin.collectors
 import com.pingidentity.exception.ApiException
 import com.pingidentity.oidc.exception.AuthorizeException
+import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.orchestrate.ErrorNode
 import com.pingidentity.orchestrate.FailureNode
 import com.pingidentity.orchestrate.FlowContext
@@ -114,6 +116,22 @@ private fun transform(
                         ?: throw AuthorizeException("Authorization code is missing.")
             },
         )
+    }
+
+    val eventName = json["eventName"]?.jsonPrimitive?.content
+    if (eventName == "rewindStateToLastRenderedUI" || eventName == "rewindStateToSpecificRenderedUI") {
+        val existing = context.flowContext.getValue<ContinueNode>(CONTINUE_NODE)
+            ?: return FailureNode(IllegalStateException("Rewind state to last rendered UI failed."))
+        // Create a new Connector instance with the same so that Jetpack Compose
+        // sees a different object reference and triggers recomposition and its collectors.
+        return Connector(
+            existing.context,
+            (existing as Connector).daVinci,
+            existing.input,
+            existing.collectors,
+        ).apply {
+            CollectorFactory.inject(this)
+        }
     }
 
     val collectors = mutableListOf<Collector<*>>()

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/CollectorRegistryTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/CollectorRegistryTest.kt
@@ -1,15 +1,20 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
 
 import com.pingidentity.davinci.CollectorRegistry
+import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
+import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
+import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -61,9 +66,15 @@ class CollectorRegistryTest {
             add(buildJsonObject { put("inputType", "SINGLE_SELECT") })
             add(buildJsonObject { put("inputType", "MULTI_SELECT") })
             add(buildJsonObject { put("inputType", "MULTI_SELECT") })
+            add(buildJsonObject { put("inputType", "DEVICE_REGISTRATION") })
+            add(buildJsonObject { put("inputType", "DEVICE_AUTHENTICATION") })
+            add(buildJsonObject { put("inputType", "PHONE_NUMBER") })
+            add(buildJsonObject { put("type", "POLLING") })
+            add(buildJsonObject { put("type", "QR_CODE") })
         }
 
         val collectors = CollectorFactory.collector(mockk(), jsonArray)
+        assertEquals(16, collectors.size)
         assertEquals(TextCollector::class.java, collectors[0]::class.java)
         assertEquals(PasswordCollector::class.java, collectors[1]::class.java)
         assertEquals(PasswordCollector::class.java, collectors[2]::class.java)
@@ -75,6 +86,11 @@ class CollectorRegistryTest {
         assertEquals(SingleSelectCollector::class.java, collectors[8]::class.java)
         assertEquals(MultiSelectCollector::class.java, collectors[9]::class.java)
         assertEquals(MultiSelectCollector::class.java, collectors[10]::class.java)
+        assertEquals(DeviceRegistrationCollector::class.java, collectors[11]::class.java)
+        assertEquals(DeviceAuthenticationCollector::class.java, collectors[12]::class.java)
+        assertEquals(PhoneNumberCollector::class.java, collectors[13]::class.java)
+        assertEquals(PollingCollector::class.java, collectors[14]::class.java)
+        assertEquals(QRCodeCollector::class.java, collectors[15]::class.java)
     }
 
     @TestRailCase(21280)
@@ -88,10 +104,11 @@ class CollectorRegistryTest {
             add(buildJsonObject { put("type", "SUBMIT_BUTTON") })
             add(buildJsonObject { put("inputType", "ACTION") })
             add(buildJsonObject { put("type", "UNKNOWN") })
+            add(buildJsonObject { put("type", "QR_CODE") })
         }
 
         val collectors = CollectorFactory.collector(mockk(), jsonArray)
-        assertEquals(4, collectors.size)
+        assertEquals(5, collectors.size)
     }
 
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
@@ -203,6 +203,20 @@ fun customHTMLTemplateWithInvalidPassword() = ByteReadChannel(
 )
 
 
+fun rewindStateToLastRenderedUIResponse() =
+    ByteReadChannel(
+        "{\n" +
+                "    \"eventName\": \"rewindStateToLastRenderedUI\"\n" +
+                "}",
+    )
+
+fun rewindStateToSpecificRenderedUIResponse() =
+    ByteReadChannel(
+        "{\n" +
+                "    \"eventName\": \"rewindStateToSpecificRenderedUI\"\n" +
+                "}",
+    )
+
 fun tokeErrorResponse() =
     ByteReadChannel(
         "{\n" +

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
@@ -59,6 +59,7 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -551,4 +552,92 @@ class DaVinciTest {
             "expires_in": 60
         }
         """.trimIndent()
+
+    @Test
+    fun `DaVinci rewindStateToLastRenderedUI returns previous ContinueNode`() = runTest {
+        // Override the mock engine so /customHTMLTemplate returns a rewind event
+        mockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/.well-known/openid-configuration" ->
+                    respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                "/authorize" ->
+                    respond(authorizeResponse(), HttpStatusCode.OK, authorizeResponseHeaders)
+                "/customHTMLTemplate" ->
+                    respond(rewindStateToLastRenderedUIResponse(), HttpStatusCode.OK, customHTMLTemplateHeaders)
+                else ->
+                    respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val daVinci = DaVinci {
+            httpClient = KtorHttpClient(HttpClient(mockEngine))
+            module(Oidc) {
+                clientId = "test"
+                discoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+                scopes = mutableSetOf("openid", "email", "address")
+                redirectUri = "http://localhost:8080"
+                storage = { MemoryStorage() }
+            }
+            module(Cookie) {
+                storage = { MemoryStorage() }
+            }
+        }
+
+        // start() stores the returned ContinueNode in FlowContext via the ContinueNode module
+        val firstNode = daVinci.start()
+        assertTrue(firstNode is ContinueNode)
+
+        // next() receives rewindStateToLastRenderedUI → transform retrieves the stored ContinueNode
+        val rewindNode = firstNode.next()
+
+        assertTrue(rewindNode is ContinueNode)
+        // Must be the exact same instance that was stored in FlowContext
+        assertNotSame(firstNode, rewindNode)
+        assertEquals(firstNode.id, rewindNode.id)
+        assertEquals(firstNode.name, rewindNode.name)
+    }
+
+    @Test
+    fun `DaVinci rewindStateToSpecificRenderedUI returns previous ContinueNode`() = runTest {
+        // Override the mock engine so /customHTMLTemplate returns a rewind event
+        mockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/.well-known/openid-configuration" ->
+                    respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                "/authorize" ->
+                    respond(authorizeResponse(), HttpStatusCode.OK, authorizeResponseHeaders)
+                "/customHTMLTemplate" ->
+                    respond(rewindStateToSpecificRenderedUIResponse(), HttpStatusCode.OK, customHTMLTemplateHeaders)
+                else ->
+                    respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val daVinci = DaVinci {
+            httpClient = KtorHttpClient(HttpClient(mockEngine))
+            module(Oidc) {
+                clientId = "test"
+                discoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+                scopes = mutableSetOf("openid", "email", "address")
+                redirectUri = "http://localhost:8080"
+                storage = { MemoryStorage() }
+            }
+            module(Cookie) {
+                storage = { MemoryStorage() }
+            }
+        }
+
+        // start() stores the returned ContinueNode in FlowContext via the ContinueNode module
+        val firstNode = daVinci.start()
+        assertTrue(firstNode is ContinueNode)
+
+        // next() receives rewindStateToSpecificRenderedUI → transform retrieves the stored ContinueNode
+        val rewindNode = firstNode.next()
+
+        assertTrue(rewindNode is ContinueNode)
+        // Must be the exact same instance that was stored in FlowContext
+        assertNotSame(firstNode, rewindNode)
+        assertEquals(firstNode.id, rewindNode.id)
+        assertEquals(firstNode.name, rewindNode.name)
+    }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/PollingCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/PollingCollectorTest.kt
@@ -1,0 +1,655 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.PollingStatus
+import com.pingidentity.davinci.plugin.DaVinci
+import com.pingidentity.logger.Logger
+import com.pingidentity.network.ktor.KtorHttpClient
+import com.pingidentity.orchestrate.Action
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.FlowContext
+import com.pingidentity.orchestrate.SharedContext
+import com.pingidentity.orchestrate.Workflow
+import com.pingidentity.orchestrate.WorkflowConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.test.BeforeTest
+import com.pingidentity.network.HttpRequest as Request
+
+class PollingCollectorTest {
+
+    private lateinit var daVinci: DaVinci
+    private lateinit var config: WorkflowConfig
+    private lateinit var logger: Logger
+
+    @BeforeTest
+    fun setUp() {
+        logger = mockk(relaxed = true)
+        config = mockk(relaxed = true)
+        daVinci = mockk(relaxed = true)
+        every { daVinci.config } returns config
+        every { config.logger } returns logger
+    }
+
+    @Test
+    fun testInitialization() {
+        val pollingCollector = PollingCollector()
+        assertNotNull(pollingCollector)
+    }
+
+    @Test
+    fun `should initialize with default values from JsonObject`() {
+        val pollingCollector = PollingCollector()
+        val jsonObject = buildJsonObject {
+            put("pollInterval", "3000")
+            put("pollRetries", "30")
+            put("pollChallengeStatus", false)
+            put("challenge", "testChallenge")
+        }
+
+        pollingCollector.init(jsonObject)
+
+        assertEquals("3000", pollingCollector.pollInterval)
+        assertEquals("30", pollingCollector.pollRetries)
+        assertFalse(pollingCollector.pollChallengeStatus)
+        assertEquals("testChallenge", pollingCollector.challenge)
+    }
+
+    @Test
+    fun `should initialize with default values when fields are missing`() {
+        val pollingCollector = PollingCollector()
+        val jsonObject = buildJsonObject {}
+
+        pollingCollector.init(jsonObject)
+
+        assertEquals("2000", pollingCollector.pollInterval)
+        assertEquals("60", pollingCollector.pollRetries)
+        assertFalse(pollingCollector.pollChallengeStatus)
+        assertEquals("", pollingCollector.challenge)
+    }
+
+    @Test
+    fun `should initialize with pollChallengeStatus true`() {
+        val pollingCollector = PollingCollector()
+        val jsonObject = buildJsonObject {
+            put("pollChallengeStatus", true)
+            put("challenge", "testChallengeValue")
+        }
+
+        pollingCollector.init(jsonObject)
+
+        assertTrue(pollingCollector.pollChallengeStatus)
+        assertEquals("testChallengeValue", pollingCollector.challenge)
+    }
+
+    @Test
+    fun `should return eventType as polling`() {
+        val pollingCollector = PollingCollector()
+        assertEquals("polling", pollingCollector.eventType())
+    }
+
+    @Test
+    fun `should execute simple polling without challenge status`() = runTest {
+        val pollingCollector = PollingCollector()
+        val jsonObject = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "5")
+            put("pollChallengeStatus", false)
+        }
+
+        pollingCollector.init(jsonObject)
+        pollingCollector.davinci = daVinci
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value) // Value set via interception
+        assertEquals(4, pollingCollector.retriesAllowed)
+    }
+
+    @Test
+    fun `should poll challenge status and complete when isChallengeComplete is true`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        // Create mock response
+        val mockEngine = MockEngine { request ->
+            // Verify the request
+            assertTrue(request.url.encodedPath.contains("/davinci/user/credentials/challenge"))
+            assertTrue(request.url.encodedPath.endsWith("/status"))
+            assertEquals("test-interaction-id", request.headers["interactionId"])
+
+            // Return successful challenge completion
+            respond(
+                content = """{"isChallengeComplete": true, "status": "approved"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        every { daVinci.config.httpClient } returns httpClient
+
+        // Create test input
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "5")
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-123")
+            put("interactionId", "test-interaction-id")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/test-env-id/davinci/connections/test-connection/capabilities/test")
+                }
+            }
+        }
+
+        // Create a minimal ContinueNode
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("approved", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("approved", pollingCollector.value) // Value set via interception
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should continue polling when isChallengeComplete is false`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        var requestCount = 0
+        val maxRetries = 3
+
+        // Create mock response that returns false for first 2 calls, then true
+        val mockEngine = MockEngine { request ->
+            requestCount++
+
+            val isComplete = requestCount >= maxRetries
+            respond(
+                content = """{"isChallengeComplete": $isComplete, "status": "approved"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+
+        every { daVinci.config.httpClient } returns httpClient
+
+        // Create test input
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", maxRetries.toString())
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-456")
+            put("interactionId", "test-interaction-id-2")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/env-123/davinci/connections/conn-456/capabilities/test")
+                }
+            }
+        }
+
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        // Should emit Continue status for first 2 attempts, then Complete
+        assertEquals(maxRetries, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Continue)
+        assertTrue(statuses[1] is PollingStatus.Continue)
+        assertTrue(statuses[2] is PollingStatus.Complete)
+
+        // Verify retry counts
+        assertEquals(1, (statuses[0] as PollingStatus.Continue).retryCount)
+        assertEquals(2, (statuses[1] as PollingStatus.Continue).retryCount)
+
+        assertEquals("approved", pollingCollector.value) // Value set from last emission
+        assertEquals(maxRetries, requestCount)
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should reach max retries when challenge never completes`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        var requestCount = 0
+        val maxRetries = 3
+
+        // Create mock response that always returns false
+        val mockEngine = MockEngine { request ->
+            requestCount++
+            respond(
+                content = """{"isChallengeComplete": false}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+
+        every { daVinci.config.httpClient } returns httpClient
+
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", maxRetries.toString())
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-789")
+            put("interactionId", "test-interaction-id-3")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/env-999/davinci/connections/conn-888/capabilities/test")
+                }
+            }
+        }
+
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        // Should emit Continue status for all retries, then TimeOut
+        assertEquals(maxRetries + 1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Continue)
+        assertTrue(statuses[1] is PollingStatus.Continue)
+        assertTrue(statuses[2] is PollingStatus.Continue)
+        assertTrue(statuses[3] is PollingStatus.TimedOut)
+
+        assertEquals("timedOut", pollingCollector.value) // Value set via interception
+        assertEquals(maxRetries, requestCount)
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should emit Expired status when server returns non-200 response with challengeExpired serviceName`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        var requestCount = 0
+        val maxRetries = 3
+
+        // Create mock response that returns a non-200 status with challengeExpired serviceName
+        val mockEngine = MockEngine { request ->
+            requestCount++
+            respond(
+                content = """{"cause":{"message":"Challenge Expired"},"logLevel":"error","serviceName":"challengeExpired","correlationId":"c4d740ca-138f-4047-8391-da312b4e1027"}""",
+                status = HttpStatusCode.InternalServerError,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+
+        every { daVinci.config.httpClient } returns httpClient
+
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", maxRetries.toString())
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-error")
+            put("interactionId", "test-interaction-id-error")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/env-error/davinci/connections/conn-error/capabilities/test")
+                }
+            }
+        }
+
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        // Non-200 response emits Expired immediately and stops polling (only 1 request made)
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Expired)
+        assertEquals("expired", pollingCollector.value) // Value set via interception
+        assertEquals(1, requestCount) // Polling stops after first non-200 response
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should emit Error status when server returns non-200 response without challengeExpired serviceName`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        var requestCount = 0
+
+        // Create mock response that returns a non-200 status with an unrecognized serviceName
+        val mockEngine = MockEngine { request ->
+            requestCount++
+            respond(
+                content = """{"cause":{"message":"Internal Server Error"},"logLevel":"error","serviceName":"internalError","correlationId":"abc-123"}""",
+                status = HttpStatusCode.InternalServerError,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+
+        every { daVinci.config.httpClient } returns httpClient
+
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "3")
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-error")
+            put("interactionId", "test-interaction-id-error")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/env-error/davinci/connections/conn-error/capabilities/test")
+                }
+            }
+        }
+
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        // Non-200 without challengeExpired serviceName emits Error and stops polling
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Error)
+        assertEquals("error", pollingCollector.value)
+        assertEquals(1, requestCount)
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should emit Expired status when server returns 401 Unauthorized`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        var requestCount = 0
+
+        val mockEngine = MockEngine { request ->
+            requestCount++
+            respond(
+                content = """{"cause":{"message":"Challenge Expired"},"logLevel":"error","serviceName":"challengeExpired","correlationId":"c4d740ca-138f-4047-8391-da312b4e1027"}""",
+                status = HttpStatusCode.Unauthorized,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+
+        every { daVinci.config.httpClient } returns httpClient
+
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "5")
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-401")
+            put("interactionId", "test-interaction-id-401")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/env-401/davinci/connections/conn-401/capabilities/test")
+                }
+            }
+        }
+
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Expired)
+        assertEquals("expired", pollingCollector.value)
+        assertEquals(1, requestCount)
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should emit Error status when JSON parsing fails`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        var requestCount = 0
+
+        // Create mock response that returns invalid JSON
+        val mockEngine = MockEngine { request ->
+            requestCount++
+            respond(
+                content = """This is not valid JSON!""",
+                status = HttpStatusCode.OK,
+                headers = headersOf("Content-Type", "text/plain")
+            )
+        }
+
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+
+        every { daVinci.config.httpClient } returns httpClient
+
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "3")
+            put("pollChallengeStatus", true)
+            put("challenge", "test-challenge-parse-error")
+            put("interactionId", "test-interaction-id-parse-error")
+            putJsonObject("_links") {
+                putJsonObject("self") {
+                    put("href", "https://auth.pingone.ca/env-parse/davinci/connections/conn-parse/capabilities/test")
+                }
+            }
+        }
+
+        val continueNode = object : ContinueNode(
+            FlowContext(SharedContext(mutableMapOf())),
+            Workflow {},
+            inputJson,
+            emptyList<Action>()
+        ) {
+            override fun asRequest(): Request = daVinci.config.httpClient.request()
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+        pollingCollector.continueNode = continueNode
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        // Should emit Error status on JSON parsing failure
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Error)
+        assertEquals("error", pollingCollector.value) // Value set via interception
+        assertEquals(1, requestCount)
+
+        mockEngine.close()
+        httpClient.close()
+    }
+
+    @Test
+    fun `should not poll when pollChallengeStatus is false`() = runTest {
+        val pollingCollector = PollingCollector()
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollChallengeStatus", false)
+            put("challenge", "test-challenge")
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value) // Value set via interception
+    }
+
+    @Test
+    fun `should not poll when challenge is empty`() = runTest {
+        val pollingCollector = PollingCollector()
+
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollChallengeStatus", true)
+            put("challenge", "")
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value) // Value set via interception
+    }
+
+    @Test
+    fun `should emit TimeOut when simple polling retries reach 0`() = runTest {
+        val pollingCollector = PollingCollector()
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "1") // Only 1 retry
+            put("pollChallengeStatus", false)
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.TimedOut)
+        assertEquals("timedOut", pollingCollector.value) // Value set via interception
+        assertEquals(0, pollingCollector.retriesAllowed)
+    }
+
+    @Test
+    fun `should emit Complete with continue on each poll call and TimedOut when retries exhausted`() = runTest {
+        val pollingCollector = PollingCollector()
+        val inputJson = buildJsonObject {
+            put("pollInterval", "10")
+            put("pollRetries", "3")
+            put("pollChallengeStatus", false)
+        }
+
+        pollingCollector.init(inputJson)
+        pollingCollector.davinci = daVinci
+
+        // First poll: retriesAllowed 3 → 2
+        var statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value)
+        assertEquals(2, pollingCollector.retriesAllowed)
+
+        // Second poll: retriesAllowed 2 → 1
+        statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value)
+        assertEquals(1, pollingCollector.retriesAllowed)
+
+        // Third poll: retriesAllowed 1 → 0, emits TimedOut
+        statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.TimedOut)
+        assertEquals("timedOut", pollingCollector.value)
+        assertEquals(0, pollingCollector.retriesAllowed)
+    }
+}
+

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/QRCodeCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/QRCodeCollectorTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.QRCodeCollector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.io.encoding.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class QRCodeCollectorTest {
+
+    @Test
+    fun initializesContentAndFallbackTextWithProvidedValues() {
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg")
+            put("fallbackText", "Scan this QR code")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("data:image/png;base64,iVBORw0KGgoAAAANSUhEUg", collector.content)
+        assertEquals("Scan this QR code", collector.fallbackText)
+    }
+
+    @Test
+    fun initializesWithEmptyStringsWhenNoValuesProvided() {
+        val input = JsonObject(emptyMap())
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("", collector.content)
+        assertEquals("", collector.fallbackText)
+    }
+
+    @Test
+    fun initializesContentWithEmptyStringWhenContentIsNull() {
+        val input = buildJsonObject {
+            put("fallbackText", "Use manual code")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("", collector.content)
+        assertEquals("Use manual code", collector.fallbackText)
+    }
+
+    @Test
+    fun initializesFallbackTextWithEmptyStringWhenFallbackTextIsNull() {
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,abc123")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("data:image/png;base64,abc123", collector.content)
+        assertEquals("", collector.fallbackText)
+    }
+
+    @Test
+    fun returnsNullForInvalidBase64Data() {
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,ThisIsNotValidBase64!!!")
+            put("fallbackText", "Use alternative method")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val bitmap = collector.bitmap()
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun returnsNullForValidBase64ButInvalidImageData() {
+        val invalidImageBytes = byteArrayOf(0x01, 0x02, 0x03, 0x04, 0x05)
+        val base64Content = Base64.encode(invalidImageBytes)
+
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,$base64Content")
+            put("fallbackText", "Fallback option")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val bitmap = collector.bitmap()
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun returnsNullWhenContentDoesNotContainBase64Prefix() {
+        val input = buildJsonObject {
+            put("content", "iVBORw0KGgoAAAANSUhEUg")
+            put("fallbackText", "No base64 prefix")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val bitmap = collector.bitmap()
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun returnsNullForEmptyContent() {
+        val input = buildJsonObject {
+            put("content", "")
+            put("fallbackText", "Empty content")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val bitmap = collector.bitmap()
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun returnsNullWhenContentOnlyContainsBase64Prefix() {
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,")
+            put("fallbackText", "Only prefix")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val bitmap = collector.bitmap()
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun extractsBase64DataAfterBase64PrefixRegardlessOfMimeType() {
+        val invalidImageBytes = byteArrayOf(0x01, 0x02, 0x03)
+        val base64Content = Base64.encode(invalidImageBytes)
+
+        val input = buildJsonObject {
+            put("content", "data:image/jpeg;base64,$base64Content")
+            put("fallbackText", "JPEG mime type")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val bitmap = collector.bitmap()
+        assertNull(bitmap)
+    }
+
+    @Test
+    fun initReturnsCollectorInstanceForMethodChaining() {
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,abc")
+            put("fallbackText", "Test")
+        }
+        val collector = QRCodeCollector()
+        val result = collector.init(input)
+
+        assertEquals(collector, result)
+    }
+}

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinci.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/DaVinci.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -96,24 +97,27 @@ fun DaVinci(
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
-            .fillMaxSize().verticalScroll(scroll)
-   ) {
+            .fillMaxSize()
+            .verticalScroll(scroll)
+    ) {
         if (loading) {
             CircularProgressIndicator()
         }
 
         Column(
             modifier =
-            Modifier
-                .padding(8.dp)
-                .fillMaxSize()
+                Modifier
+                    .padding(8.dp)
+                    .fillMaxSize()
         ) {
             Logo(modifier = Modifier)
 
             when (val node = state.node) {
                 is ContinueNode -> {
-                    Render(node = node, onNodeUpdated, onStart) {
-                        onNext(node)
+                    key(node) {
+                        Render(node = node, onNodeUpdated, onStart) {
+                            onNext(node)
+                        }
                     }
                 }
 
@@ -148,26 +152,26 @@ fun DaVinci(
 fun Render(node: FailureNode) {
     Row(
         modifier =
-        Modifier
-            .padding(16.dp)
-            .fillMaxWidth(),
+            Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
     ) {
         Card(
             elevation =
-            CardDefaults.cardElevation(
-                defaultElevation = 10.dp,
-            ),
+                CardDefaults.cardElevation(
+                    defaultElevation = 10.dp,
+                ),
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
             shape = MaterialTheme.shapes.medium,
         ) {
             Row(
                 modifier =
-                Modifier
-                    .padding(16.dp)
-                    .fillMaxWidth(),
+                    Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
             ) {
                 Icon(Icons.Filled.Error, null)
                 Spacer(Modifier.width(8.dp))
@@ -194,29 +198,29 @@ fun Render(node: ErrorNode) {
 
     Row(
         modifier =
-        Modifier
-            .padding(16.dp)
-            .fillMaxWidth(),
+            Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
     ) {
         Card(
             elevation =
-            CardDefaults.cardElevation(
-                defaultElevation = 10.dp,
-            ),
+                CardDefaults.cardElevation(
+                    defaultElevation = 10.dp,
+                ),
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
-                .clickable {
-                    showAlert = true
-                },
+                Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+                    .clickable {
+                        showAlert = true
+                    },
             shape = MaterialTheme.shapes.medium,
         ) {
             Row(
                 modifier =
-                Modifier
-                    .padding(16.dp)
-                    .fillMaxWidth(),
+                    Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
             ) {
                 Icon(Icons.Filled.Error, null)
                 Spacer(Modifier.width(8.dp))
@@ -245,20 +249,20 @@ fun Render(
 private fun Logo(modifier: Modifier) {
     Row(
         modifier =
-        Modifier
-            .fillMaxWidth()
-            .then(modifier),
+            Modifier
+                .fillMaxWidth()
+                .then(modifier),
     ) {
         Spacer(modifier = Modifier.weight(1f, true))
         Icon(
             painterResource(R.drawable.ping_logo),
             contentDescription = null,
             modifier =
-            Modifier
-                .height(100.dp)
-                .padding(8.dp)
-                .wrapContentWidth(Alignment.CenterHorizontally)
-                .then(modifier),
+                Modifier
+                    .height(100.dp)
+                    .padding(8.dp)
+                    .wrapContentWidth(Alignment.CenterHorizontally)
+                    .then(modifier),
             tint = Color.Unspecified,
         )
         Spacer(modifier = Modifier.weight(1f, true))

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
@@ -30,6 +30,8 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
@@ -123,6 +125,9 @@ fun ContinueNode(
                 is PhoneNumberCollector -> PhoneNumber(it, onNodeUpdated)
                 is ProtectCollector -> Protect(it, onNodeUpdated)
                 is BooleanCollector -> SingleCheckbox(it, onNodeUpdated)
+                is PollingCollector -> Polling(it, onNext)
+                is QRCodeCollector -> QRCode(it)
+
             }
             if (it is Submittable) {
                 hasAction = true

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Polling.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Polling.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.app.davinci.collector
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.PollingStatus
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+@Composable
+fun Polling(
+    field: PollingCollector,
+    onNext: () -> Unit,
+) {
+    var isPolling by remember { mutableStateOf(true) }
+    var statusMessage by remember { mutableStateOf("Polling...") }
+    var pollingJob: Job? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(field) {
+        pollingJob = launch {
+            field.pollStatus().collect { status ->
+                when (status) {
+                    is PollingStatus.Continue -> {
+                        statusMessage = "Polling... (${status.retryCount}/${status.maxRetries})"
+                    }
+                    is PollingStatus.Complete -> {
+                        isPolling = false
+                        onNext()
+                    }
+                    is PollingStatus.TimedOut -> {
+                        isPolling = false
+                        statusMessage = "Polling timedOut"
+                        onNext()
+                    }
+                    is PollingStatus.Error -> {
+                        isPolling = false
+                        statusMessage = "Error: ${status.exception.message}"
+                        onNext()
+                    }
+
+                    is PollingStatus.Expired -> {
+                        isPolling = false
+                        statusMessage = "Polling Expired"
+                        onNext()
+                    }
+
+                }
+            }
+        }
+    }
+
+    // Cancel polling when the composable is disposed
+    DisposableEffect(field) {
+        onDispose {
+            pollingJob?.cancel()
+            isPolling = false
+        }
+    }
+
+    if (isPolling) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = statusMessage,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/QRCode.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/QRCode.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.app.davinci.collector
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.QRCodeCollector
+
+@Composable
+fun QRCode(
+    field: QRCodeCollector,
+) {
+    val qrCodeBitmap = remember(field.content) {
+        field.bitmap()
+    }
+
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Display QR Code image
+        qrCodeBitmap?.let { bitmap ->
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = "QR Code",
+                modifier = Modifier.size(256.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Display fallback text
+        if (field.fallbackText.isNotEmpty()) {
+            Text(
+                text = field.fallbackText,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinci.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinci.kt
@@ -40,6 +40,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -51,7 +52,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.pingidentity.davinci.plugin.DaVinci
 import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.orchestrate.ErrorNode
 import com.pingidentity.orchestrate.FailureNode
@@ -145,8 +145,10 @@ fun DaVinci(
 
                 when (val node = state.node) {
                     is ContinueNode -> {
-                        Render(node = node, onNodeUpdated, onStart) {
-                            onNext(node)
+                        key(node) {
+                            Render(node = node, onNodeUpdated, onStart) {
+                                onNext(node)
+                            }
                         }
                     }
 

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
@@ -30,6 +30,8 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
@@ -122,6 +124,9 @@ fun DaVinciContinueNode(
                 is FidoAuthenticationCollector -> FidoAuthentication(it, onStart, onNext)
                 is PhoneNumberCollector -> PhoneNumber(it, onNodeUpdated)
                 is ProtectCollector -> Protect(it, onNodeUpdated)
+                is PollingCollector -> Polling(it, onNext)
+                is QRCodeCollector -> QRCode(it)
+
                 is BooleanCollector -> SingleCheckbox(it, onNodeUpdated)
             }
             if (it is Submittable) {

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Polling.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Polling.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.PollingStatus
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+@Composable
+fun Polling(
+    field: PollingCollector,
+    onNext: () -> Unit,
+) {
+    var isPolling by remember { mutableStateOf(true) }
+    var statusMessage by remember { mutableStateOf("Polling...") }
+    var pollingJob: Job? by remember { mutableStateOf(null) }
+
+    LaunchedEffect(field) {
+        pollingJob = launch {
+            field.pollStatus().collect { status ->
+                when (status) {
+                    is PollingStatus.Continue -> {
+                        statusMessage = "Polling... (${status.retryCount}/${status.maxRetries})"
+                    }
+                    is PollingStatus.Complete -> {
+                        isPolling = false
+                        onNext()
+                    }
+                    is PollingStatus.TimedOut -> {
+                        isPolling = false
+                        statusMessage = "Polling timedOut"
+                        onNext()
+                    }
+                    is PollingStatus.Error -> {
+                        isPolling = false
+                        statusMessage = "Error: ${status.exception.message}"
+                        onNext()
+                    }
+
+                    is PollingStatus.Expired -> {
+                        isPolling = false
+                        statusMessage = "Polling Expired"
+                        onNext()
+                    }
+
+                }
+            }
+        }
+    }
+
+    // Cancel polling when the composable is disposed
+    DisposableEffect(field) {
+        onDispose {
+            pollingJob?.cancel()
+            isPolling = false
+        }
+    }
+
+    if (isPolling) {
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .fillMaxWidth(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(48.dp)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = statusMessage,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+    }
+}
+

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/QRCode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/QRCode.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.QRCodeCollector
+
+@Composable
+fun QRCode(
+    field: QRCodeCollector,
+) {
+    val qrCodeBitmap = remember(field.content) {
+        field.bitmap()
+    }
+
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        // Display QR Code image
+        qrCodeBitmap?.let { bitmap ->
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = "QR Code",
+                modifier = Modifier.size(256.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Display fallback text
+        if (field.fallbackText.isNotEmpty()) {
+            Text(
+                text = field.fallbackText,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4679](https://pingidentity.atlassian.net/browse/SDKS-4679)
[SDKS-4681](https://pingidentity.atlassian.net/browse/SDKS-4681)

# Description

- Implement `PollingCollector` to handle asynchronous operations like push notifications and OOB authentication, supporting both simple delays and active challenge status polling.
- Implement `QRCodeCollector` to handle Base64-encoded QR code images for device pairing and MFA setup.
- Add Compose UI components (`Polling.kt`, `QRCode.kt`) and integrate them into `ContinueNode`.
- Register new collectors in `CollectorRegistry`.
- Add comprehensive unit tests for `PollingCollector` and `QRCodeCollector` logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polling collector with retry/status lifecycle and QR code display with automatic decoding and fallback text
  * State-rewind support to navigate back to previously rendered UI states
  * Sample apps: polling progress UI and QR code rendering components

* **Tests**
  * Comprehensive unit tests added for polling behavior, QR code handling, and rewind scenarios

* **Improvements**
  * Compose rendering keyed to improve UI identity/recomposition handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->