### PR TITLE
SDKS-4731 Update visibility of Journey.session()

### DIFF
--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Session.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Session.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -72,7 +72,7 @@ val Session = Module.of(::SessionConfig) {
  * Function to retrieve the session token.
  * @return The session token if found, otherwise null.
  */
-internal suspend fun Journey.session(): SSOToken? {
+suspend fun Journey.session(): SSOToken? {
     sharedContext.getValue<SessionConfig>(SESSION_CONFIG)?.let {
         return it.tokenStorage.get()
     }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4731](https://pingidentity.atlassian.net/browse/SDKS-4731)

# Description

The visibility of the `Journey.session()` extension function has been changed from `internal` to public to allow external access to the session token.