### PR TITLE
SDKS-4763 Add UI extension properties and localization support to ContinueNode

### DIFF
--- a/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/ContinueNode.kt
+++ b/foundation/journey-plugin/src/main/kotlin/com/pingidentity/journey/plugin/ContinueNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,10 @@
 package com.pingidentity.journey.plugin
 
 import com.pingidentity.orchestrate.ContinueNode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.util.Locale
 
 /**
  * Extension property for Connector class to get a list of collectors.
@@ -16,3 +20,175 @@ import com.pingidentity.orchestrate.ContinueNode
  */
 val ContinueNode.callbacks: List<Callback>
     get() = this.actions.filterIsInstance<Callback>()
+
+private const val HEADER = "header"
+private const val DESCRIPTION = "description"
+private const val STAGE = "stage"
+private const val SUBMIT_BUTTON_TEXT = "submitButtonText"
+private const val PAGE_FOOTER = "pageFooter"
+
+/**
+ * Extension property to retrieve the header text for this ContinueNode.
+ *
+ * The header text is typically displayed at the top of the authentication screen
+ * to provide context about the current step in the journey.
+ *
+ * @return The header text from the node's input, or an empty string if not present
+ */
+val ContinueNode.header: String
+    get() = this.input[HEADER]?.jsonPrimitive?.content ?: ""
+
+/**
+ * Extension property to retrieve the description text for this ContinueNode.
+ *
+ * The description provides additional context or instructions for the current
+ * authentication step, typically displayed below the header.
+ *
+ * @return The description text from the node's input, or an empty string if not present
+ *
+ */
+val ContinueNode.description: String
+    get() = this.input[DESCRIPTION]?.jsonPrimitive?.content ?: ""
+
+/**
+ * Extension property to retrieve the stage identifier for this ContinueNode.
+ *
+ * The stage field contains metadata about the current authentication step, which can include:
+ * - A simple stage name (e.g., "Login", "MFA")
+ * - A JSON string with localized UI text (e.g., `{"submitButtonText":{"en":"Submit"}}`)
+ *
+ * This property returns the raw stage value as a string. For parsed localized values,
+ * use [submitButtonText] or [pageFooter] properties instead.
+ *
+ * @return The stage identifier from the node's input, or an empty string if not present
+ *
+ */
+val ContinueNode.stage: String
+    get() = this.input[STAGE]?.jsonPrimitive?.content ?: ""
+
+/**
+ * Extension property to retrieve the localized submit button text for this ContinueNode.
+ *
+ * This property intelligently derives the button text from multiple sources in order of priority:
+ *
+ * 1. **Localized value from stage JSON**: Extracts locale-specific text from the `stage` field
+ *    ```json
+ *    {"submitButtonText":{"en":"Submit","en-gb":"Submit","fr":"Soumettre"}}
+ *    ```
+ * The localization matching follows this priority:
+ * - Exact locale match (e.g., "en_US" or "en-us")
+ * - Language-only match (e.g., "en" for "en_US")
+ * - First available value if no match found
+ *
+ * @return The localized submit button text, or an empty string if not available
+ *
+ * @see getLocalizedValueFromStage
+ * @see pageFooter
+ */
+val ContinueNode.submitButtonText: String
+    get() {
+        // First, try to get localized value from stage JSON
+        return getLocalizedValueFromStage(SUBMIT_BUTTON_TEXT) ?: ""
+    }
+
+/**
+ * Extension property to retrieve the localized page footer text for this ContinueNode.
+ *
+ * This property extracts locale-specific footer text from the `stage` field's JSON structure.
+ * The footer is typically displayed at the bottom of the authentication screen to provide
+ * additional information, legal notices, or copyright text.
+ *
+ * The `stage` field may contain:
+ * ```json
+ * {"pageFooter":{"en":"© 2026 Company","en-gb":"© 2026 Company Ltd","fr":"© 2026 Société"}}
+ * ```
+ *
+ * The localization matching follows this priority:
+ * - Exact locale match (e.g., "en_GB" or "en-gb")
+ * - Language-only match (e.g., "en" for "en_GB")
+ * - First available value if no match found
+ *
+ * @return The localized footer text, or an empty string if not available
+ *
+ * @see getLocalizedValueFromStage
+ * @see submitButtonText
+ */
+val ContinueNode.pageFooter: String
+    get() {
+        // First, try to get localized value from stage JSON
+        return getLocalizedValueFromStage(PAGE_FOOTER) ?: ""
+    }
+
+/**
+ * Attempts to extract a localized value from the `stage` field's JSON structure.
+ *
+ * The `stage` field may contain a JSON string with localized UI text:
+ * ```json
+ * {"submitButtonText":{"en":"Submit","en-gb":"Submit","fr":"Soumettre"},"pageFooter":{"en":"Footer"}}
+ * ```
+ *
+ * This method parses the JSON and returns the best matching localized value based on
+ * the user's device locale ([Locale.getDefault]). The matching algorithm follows this priority:
+ *
+ * 1. **Single value optimization**: If only one localized value exists, returns it immediately
+ * 2. **Exact locale match**: Tries to match the full locale identifier (e.g., "en_gb" or "en-gb")
+ * 3. **Hyphen/underscore variants**: Attempts both underscore and hyphen formats (en_US vs en-us)
+ * 4. **Language-only fallback**: Matches just the language code (e.g., "en" for "en_GB")
+ * 5. **First available**: Returns the first value if no locale matches
+ *
+ * All locale comparisons are case-insensitive.
+ *
+ * @param key The key to look up in the stage JSON (e.g., "submitButtonText" or "pageFooter")
+ * @return The localized string value, or `null` if:
+ *         - The `stage` field is empty or missing
+ *         - The JSON is malformed
+ *         - The specified key doesn't exist in the JSON
+ *         - The key's value is not a valid localization map
+ *
+ * @see submitButtonText
+ * @see pageFooter
+ */
+private fun ContinueNode.getLocalizedValueFromStage(key: String): String? {
+    return try {
+        val stageValue = this.input[STAGE]?.jsonPrimitive?.content
+        if (stageValue.isNullOrEmpty()) return null
+
+        val jsonObject = Json.parseToJsonElement(stageValue).jsonObject
+        val localizedDict = jsonObject[key]?.jsonObject ?: return null
+
+        // Convert JsonObject to Map<String, String>
+        val localizedMap = localizedDict.entries.associate { (k, v) ->
+            k to (v.jsonPrimitive.content)
+        }
+
+        // If there's only one value, return it
+        if (localizedMap.size == 1) {
+            return localizedMap.values.first()
+        }
+
+        // Start with the default locale
+        val defaultLocale = Locale.getDefault()
+
+        val identifier = defaultLocale.toString().lowercase()
+
+        // Try exact match first (e.g., "en_gb")
+        localizedMap[identifier]?.let { return it }
+
+        // Try with hyphen instead of underscore (e.g., "en-gb")
+        val hyphenIdentifier = identifier.replace("_", "-")
+        localizedMap[hyphenIdentifier]?.let { return it }
+
+        // Try language code only (e.g., "en" from "en_GB")
+        val languageCode = defaultLocale.language.lowercase()
+        if (languageCode.isNotEmpty()) {
+            localizedMap[languageCode]?.let { return it }
+        }
+
+        // If no match found, return the first available value
+        localizedMap.values.firstOrNull()
+    } catch (e: Exception) {
+        null
+    }
+}
+
+

--- a/foundation/journey-plugin/src/test/kotlin/com/pingidentity/journey/plugin/ContinueNodeTest.kt
+++ b/foundation/journey-plugin/src/test/kotlin/com/pingidentity/journey/plugin/ContinueNodeTest.kt
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.journey.plugin
+
+import com.pingidentity.orchestrate.Action
+import com.pingidentity.orchestrate.ContinueNode
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ContinueNodeTest {
+
+    @Test
+    fun `Should return callbacks when actions contain callback instances`() {
+        val callback1 = mockk<Callback>()
+        val callback2 = mockk<Callback>()
+        val nonCallback = mockk<Action>()
+
+        val continueNode = mockk<ContinueNode> {
+            every { actions } returns listOf<Action>(callback1, nonCallback, callback2)
+        }
+
+        val result = continueNode.callbacks
+
+        assertEquals(2, result.size)
+        assertEquals(callback1, result[0])
+        assertEquals(callback2, result[1])
+    }
+
+    @Test
+    fun `Should return empty list when actions contain no callbacks`() {
+        val continueNode = mockk<ContinueNode> {
+            every { actions } returns listOf(mockk<Action>(), mockk<Action>())
+        }
+
+        val result = continueNode.callbacks
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `Should return empty list when actions is empty`() {
+        val continueNode = mockk<ContinueNode> {
+            every { actions } returns emptyList()
+        }
+
+        val result = continueNode.callbacks
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `Should return header value when header field exists in input`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("header", "Test Header")
+            }
+        }
+
+        val result = continueNode.header
+
+        assertEquals("Test Header", result)
+    }
+
+    @Test
+    fun `Should return empty string when header field is missing`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject { }
+        }
+
+        val result = continueNode.header
+
+        assertEquals("", result)
+    }
+
+
+    @Test
+    fun `Should return description value when description field exists in input`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("description", "Test Description")
+            }
+        }
+
+        val result = continueNode.description
+
+        assertEquals("Test Description", result)
+    }
+
+    @Test
+    fun `Should return empty string when description field is missing`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject { }
+        }
+
+
+        val result = continueNode.description
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `Should return stage value when stage field exists in input`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", "AuthenticationStage")
+            }
+        }
+
+        val result = continueNode.stage
+
+        assertEquals("AuthenticationStage", result)
+    }
+
+    @Test
+    fun `Should return empty string when stage field is missing`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject { }
+        }
+
+
+        val result = continueNode.stage
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `Should handle all fields present in input`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("header", "Welcome")
+                put("description", "Please login")
+                put("stage", "Login")
+            }
+        }
+
+        assertEquals("Welcome", continueNode.header)
+        assertEquals("Please login", continueNode.description)
+        assertEquals("Login", continueNode.stage)
+    }
+
+    @Test
+    fun `Should handle empty strings in input fields`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("header", "")
+                put("description", "")
+                put("stage", "")
+            }
+        }
+
+        assertEquals("", continueNode.header)
+        assertEquals("", continueNode.description)
+        assertEquals("", continueNode.stage)
+    }
+
+    @Test
+    fun `Should return localized submitButtonText from stage JSON`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit","fr":"Soumettre"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should return empty string for submitButtonText when no data available`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject { }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `Should return single localized value when only one locale provided for submitButtonText`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertEquals("Submit", result)
+    }
+
+    @Test
+    fun `Should return localized pageFooter from stage JSON`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"pageFooter":{"en":"Footer Text","fr":"Pied de page"}}""")
+            }
+        }
+
+        val result = continueNode.pageFooter
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should return empty string for pageFooter when no data available`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject { }
+        }
+
+        val result = continueNode.pageFooter
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `Should return single localized value when only one locale provided for pageFooter`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"pageFooter":{"en":"Footer"}}""")
+            }
+        }
+
+        val result = continueNode.pageFooter
+
+        assertEquals("Footer", result)
+    }
+
+    @Test
+    fun `Should handle malformed JSON in stage field gracefully`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", "not valid json")
+            }
+        }
+
+        val submitButtonText = continueNode.submitButtonText
+        val pageFooter = continueNode.pageFooter
+
+        assertEquals("", submitButtonText)
+        assertEquals("", pageFooter)
+    }
+
+    @Test
+    fun `Should prefer exact locale match over language-only match`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit","en-gb":"Submit GB"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result in listOf("Submit", "Submit GB"))
+    }
+
+    @Test
+    fun `Should handle empty stage value for localized properties`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", "")
+            }
+        }
+
+        val submitButtonText = continueNode.submitButtonText
+        val pageFooter = continueNode.pageFooter
+
+        assertEquals("", submitButtonText)
+        assertEquals("", pageFooter)
+    }
+
+    @Test
+    fun `Should handle stage with missing localization keys`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"otherKey":"value"}""")
+            }
+        }
+
+        val submitButtonText = continueNode.submitButtonText
+        val pageFooter = continueNode.pageFooter
+
+        assertEquals("", submitButtonText)
+        assertEquals("", pageFooter)
+    }
+
+    @Test
+    fun `Should match locale with hyphen format`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en-us":"Submit US","fr-ca":"Soumettre CA"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should match locale with underscore format`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en_us":"Submit US","fr_ca":"Soumettre CA"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should fallback to language code when full locale not found`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit","de":"Einreichen"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should return first available value when no locale matches`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"zh":"提交","ja":"送信"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result in listOf("提交", "送信"))
+    }
+
+    @Test
+    fun `Should handle both submitButtonText and pageFooter in same stage JSON`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit"},"pageFooter":{"en":"Footer"}}""")
+            }
+        }
+
+        val submitButtonText = continueNode.submitButtonText
+        val pageFooter = continueNode.pageFooter
+
+        assertEquals("Submit", submitButtonText)
+        assertEquals("Footer", pageFooter)
+    }
+
+    @Test
+    fun `Should handle multiple locale options and return appropriate match`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit","en-gb":"Submit GB","en-us":"Submit US","fr":"Soumettre"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result in listOf("Submit", "Submit GB", "Submit US"))
+    }
+
+    @Test
+    fun `Should handle stage JSON with nested empty objects`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `Should handle stage JSON with null values in localization map`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit","fr":null}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should handle case sensitivity in locale matching`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"EN":"Submit","en-GB":"Submit GB"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.isNotEmpty())
+    }
+
+    @Test
+    fun `Should return different values for submitButtonText and pageFooter`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Button"},"pageFooter":{"en":"Footer"}}""")
+            }
+        }
+
+        assertEquals("Button", continueNode.submitButtonText)
+        assertEquals("Footer", continueNode.pageFooter)
+    }
+
+    @Test
+    fun `Should handle stage with special characters in localized values`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit & Continue","fr":"Soumettre & Continuer"}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertTrue(result.contains("&"))
+    }
+
+    @Test
+    fun `Should handle stage with unicode characters in localized values`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"pageFooter":{"en":"© 2026 Company","ja":"© 2026 会社"}}""")
+            }
+        }
+
+        val result = continueNode.pageFooter
+
+        assertTrue(result.contains("©"))
+    }
+
+    @Test
+    fun `Should handle whitespace in localized values`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"  Submit  "}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertEquals("  Submit  ", result)
+    }
+
+    @Test
+    fun `Should handle empty string values in localization map`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":""}}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `Should handle stage JSON with additional unrelated fields`() {
+        val continueNode = mockk<ContinueNode> {
+            every { input } returns buildJsonObject {
+                put("stage", """{"submitButtonText":{"en":"Submit"},"unrelatedField":"value","anotherField":123}""")
+            }
+        }
+
+        val result = continueNode.submitButtonText
+
+        assertEquals("Submit", result)
+    }
+}
+

--- a/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ContinueNode.kt
+++ b/samples/journeyapp/src/main/java/com/pingidentity/samples/journeyapp/journey/callback/ContinueNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -11,10 +11,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pingidentity.device.binding.journey.DeviceBindingCallback
@@ -41,6 +43,10 @@ import com.pingidentity.journey.callback.TextOutputCallback
 import com.pingidentity.journey.callback.ValidatedPasswordCallback
 import com.pingidentity.journey.callback.ValidatedUsernameCallback
 import com.pingidentity.journey.plugin.callbacks
+import com.pingidentity.journey.plugin.description
+import com.pingidentity.journey.plugin.header
+import com.pingidentity.journey.plugin.pageFooter
+import com.pingidentity.journey.plugin.submitButtonText
 import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.protect.journey.PingOneProtectEvaluationCallback
 import com.pingidentity.protect.journey.PingOneProtectInitializeCallback
@@ -58,6 +64,31 @@ fun ContinueNode(
                 .padding(4.dp)
                 .fillMaxWidth(),
     ) {
+        // Display header if available
+        if (continueNode.header.isNotEmpty()) {
+            Text(
+                text = continueNode.header,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp)
+            )
+        }
+
+        // Display description if available
+        if (continueNode.description.isNotEmpty()) {
+            Text(
+                text = continueNode.description,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+        }
+
         var showNext = true
 
         continueNode.callbacks.forEach {
@@ -141,12 +172,26 @@ fun ContinueNode(
                 }
             }
         }
+
+        // Display footer if available
+        if (continueNode.pageFooter.isNotEmpty()) {
+            Text(
+                text = continueNode.pageFooter,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 8.dp)
+            )
+        }
+
         if (showNext) {
+            val buttonText = continueNode.submitButtonText.ifEmpty { "Next" }
             Button(
                 modifier = Modifier.align(Alignment.End),
                 onClick = onNext,
             ) {
-                Text("Next")
+                Text(buttonText)
             }
         }
     }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/journey/callback/JourneyContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/journey/callback/JourneyContinueNode.kt
@@ -11,10 +11,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pingidentity.device.binding.journey.DeviceBindingCallback
@@ -41,6 +43,10 @@ import com.pingidentity.journey.callback.TextOutputCallback
 import com.pingidentity.journey.callback.ValidatedPasswordCallback
 import com.pingidentity.journey.callback.ValidatedUsernameCallback
 import com.pingidentity.journey.plugin.callbacks
+import com.pingidentity.journey.plugin.description
+import com.pingidentity.journey.plugin.header
+import com.pingidentity.journey.plugin.pageFooter
+import com.pingidentity.journey.plugin.submitButtonText
 import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.protect.journey.PingOneProtectEvaluationCallback
 import com.pingidentity.protect.journey.PingOneProtectInitializeCallback
@@ -58,6 +64,31 @@ fun JourneyContinueNode(
                 .padding(4.dp)
                 .fillMaxWidth(),
     ) {
+        // Display header if available
+        if (continueNode.header.isNotEmpty()) {
+            Text(
+                text = continueNode.header,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp)
+            )
+        }
+
+        // Display description if available
+        if (continueNode.description.isNotEmpty()) {
+            Text(
+                text = continueNode.description,
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+        }
+
         var showNext = true
 
         continueNode.callbacks.forEach {
@@ -141,12 +172,26 @@ fun JourneyContinueNode(
                 }
             }
         }
+
+        // Display footer if available
+        if (continueNode.pageFooter.isNotEmpty()) {
+            Text(
+                text = continueNode.pageFooter,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 16.dp, bottom = 8.dp)
+            )
+        }
+
         if (showNext) {
+            val buttonText = continueNode.submitButtonText.ifEmpty { "Next" }
             Button(
                 modifier = Modifier.align(Alignment.End),
                 onClick = onNext,
             ) {
-                Text("Next")
+                Text(buttonText)
             }
         }
     }


### PR DESCRIPTION


# JIRA Ticket

[SDKS-4763](https://pingidentity.atlassian.net/browse/SDKS-4763)

# Description

Introduced new extension properties to `ContinueNode` to simplify the retrieval of UI elements, including `header`, `description`, `stage`, `submitButtonText`, and `pageFooter`.

Key changes:
- Implemented `getLocalizedValueFromStage` to handle locale-specific strings from the stage JSON, supporting exact matches, language fallbacks, and multiple format variants (hyphens/underscores).
- Added logic to prioritize localized `submitButtonText` from the stage metadata with a fallback to legacy form descriptions.
- Updated sample applications to utilize these new properties for dynamic UI rendering.
- Added comprehensive unit tests in `ContinueNodeTest.kt` to verify localization priority and error handling.