### PR TITLE
SDKS-4766: Rename OidcWeb to OidcWebClient

### DIFF
--- a/foundation/oidc/README.md
+++ b/foundation/oidc/README.md
@@ -102,7 +102,7 @@ Basic Configuration, use `discoveryEndpoint` to lookup OIDC endpoints
 ```kotlin
 
 // Create an OIDC client with the discovery endpoint, and other configurations
-val web = OidcWeb {
+val web = OidcWebClient {
     logger = Logger.STANDARD
     module(com.pingidentity.oidc.module.Oidc) {
         discoveryEndpoint =
@@ -152,7 +152,7 @@ however developers can override the storage and logger settings.
 Basic Configuration with custom `storage` and `logger`
 
 ```kotlin
-val web = OidcWeb {
+val web = OidcWebClient {
     logger = Logger.STANDARD
     module(com.pingidentity.oidc.module.Oidc) {
         discoveryEndpoint =
@@ -169,7 +169,7 @@ More OidcClient configuration, configurable attribute can be found under
 [OIDC Spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
 
 ```kotlin
-val web = OidcWeb {
+val web = OidcWebClient {
     module(com.pingidentity.oidc.module.Oidc) {
         discoveryEndpoint =
             "https://example.com/envId/as/.well-known/openid-configuration"

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWebClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWebClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,7 +22,7 @@ import com.pingidentity.orchestrate.WorkflowConfig
  * OIDC Web configuration class.
  * Provide configuration for the OIDC web module.
  */
-class OidcWebConfig : WorkflowConfig() {
+class OidcWebClientConfig : WorkflowConfig() {
     // additional configuration for example browser settings
 }
 
@@ -32,7 +32,7 @@ class OidcWebConfig : WorkflowConfig() {
  *
  * @param config The OIDC web configuration.
  */
-class OidcWeb(val config: OidcWebConfig) {
+class OidcWebClient(val config: OidcWebClientConfig) {
 
     private var oidcFlow = OidcFlow(config)
 
@@ -66,18 +66,18 @@ class OidcWeb(val config: OidcWebConfig) {
 
     companion object {
         /**
-         * Creates an instance of [OidcWeb] with the provided configuration block.
+         * Creates an instance of [OidcWebClient] with the provided configuration block.
          *
          * @param block The configuration block to apply to the OIDC web configuration.
-         * @return An instance of [OidcWeb].
+         * @return An instance of [OidcWebClient].
          */
-        operator fun invoke(block: OidcWebConfig.() -> Unit = {}): OidcWeb {
-            val config = OidcWebConfig()
+        operator fun invoke(block: OidcWebClientConfig.() -> Unit = {}): OidcWebClient {
+            val config = OidcWebClientConfig()
             config.apply {
                 config.module(Web) // register the web module
             }
             config.apply(block) // apply the configuration block
-            return OidcWeb(config)
+            return OidcWebClient(config)
         }
     }
 }

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -38,7 +38,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
-class OidcWebTest {
+class OidcWebClientTest {
 
     private lateinit var mockEngine: MockEngine
 
@@ -94,7 +94,7 @@ class OidcWebTest {
 
         every { mockUri.getQueryParameter(Constants.CODE) } returns "test-code"
 
-        val web = OidcWeb {
+        val web = OidcWebClient {
             httpClient = KtorHttpClient(HttpClient(mockEngine))
             logger = Logger.CONSOLE
             module(Oidc) {
@@ -136,7 +136,7 @@ class OidcWebTest {
             BrowserCanceledException()
         )
 
-        val web = OidcWeb {
+        val web = OidcWebClient {
             httpClient = KtorHttpClient(HttpClient(mockEngine))
             logger = Logger.CONSOLE
             module(Oidc) {
@@ -160,7 +160,7 @@ class OidcWebTest {
 
         every { mockUri.getQueryParameter(Constants.CODE) } returns null
 
-        val web = OidcWeb {
+        val web = OidcWebClient {
             httpClient = KtorHttpClient(HttpClient(mockEngine))
             logger = Logger.CONSOLE
             module(Oidc) {
@@ -184,7 +184,7 @@ class OidcWebTest {
         coEvery { BrowserLauncher.launch(capture(urlSlot)) } returns Result.success(mockUri)
         every { mockUri.getQueryParameter(Constants.CODE) } returns "test-code"
 
-        val web = OidcWeb {
+        val web = OidcWebClient {
             httpClient = KtorHttpClient(HttpClient(mockEngine))
             logger = Logger.CONSOLE
             module(Oidc) {

--- a/samples/app/src/main/java/com/pingidentity/samples/app/env/EnvViewModel.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/env/EnvViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -23,7 +23,7 @@ import com.pingidentity.davinci.plugin.DaVinci
 import com.pingidentity.logger.Logger
 import com.pingidentity.logger.STANDARD
 import com.pingidentity.oidc.OidcClientConfig
-import com.pingidentity.oidc.OidcWeb
+import com.pingidentity.oidc.OidcWebClient
 import com.pingidentity.oidc.module.Web
 import com.pingidentity.samples.app.User
 import com.pingidentity.samples.app.settingDataStore
@@ -74,7 +74,7 @@ val social by lazy {
 }
 
 lateinit var daVinci: DaVinci
-lateinit var web: OidcWeb
+lateinit var web: OidcWebClient
 lateinit var redirectUri: Uri //For Social Login redirect parameter using Auth Tab
 
 class EnvViewModel : ViewModel() {
@@ -100,7 +100,7 @@ class EnvViewModel : ViewModel() {
         val oidcConfig = server.oidcConfig()
         redirectUri = oidcConfig.redirectUri.toUri()
 
-        web = OidcWeb {
+        web = OidcWebClient {
             logger = Logger.STANDARD
             module(com.pingidentity.oidc.module.Oidc) {
                 clientId = oidcConfig.clientId

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2026 - 2026 Ping Identity Corporation. All rights reserved.
+ *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
@@ -18,16 +19,12 @@ import androidx.lifecycle.ViewModel
 import com.pingidentity.android.ContextProvider
 import com.pingidentity.davinci.DaVinci
 import com.pingidentity.davinci.plugin.DaVinci
-import com.pingidentity.davinci.user as daVinciUser
 import com.pingidentity.journey.Journey
-import com.pingidentity.journey.module.Oidc as JourneyOidc
-import com.pingidentity.davinci.module.Oidc as DaVinciOidc
-import com.pingidentity.journey.user as journeyUser
 import com.pingidentity.logger.Logger
 import com.pingidentity.logger.STANDARD
 import com.pingidentity.oidc.OidcClient
 import com.pingidentity.oidc.OidcClientConfig
-import com.pingidentity.oidc.OidcWeb
+import com.pingidentity.oidc.OidcWebClient
 import com.pingidentity.oidc.module.Web
 import com.pingidentity.orchestrate.Workflow
 import com.pingidentity.samples.pingsampleapp.settingDataStore
@@ -36,6 +33,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.time.Duration.Companion.seconds
+import com.pingidentity.davinci.module.Oidc as DaVinciOidc
+import com.pingidentity.davinci.user as daVinciUser
+import com.pingidentity.journey.module.Oidc as JourneyOidc
+import com.pingidentity.journey.user as journeyUser
 
 val testDaVinci by lazy {
     DaVinci {
@@ -134,7 +135,7 @@ val social by lazy {
 
 // Standalone OIDC configurations (not tied to Journey or DaVinci)
 val oidcForgeBlock by lazy {
-    OidcWeb {
+    OidcWebClient {
         logger = Logger.STANDARD
         module(com.pingidentity.oidc.module.Oidc) {
             clientId = "AndroidTest"
@@ -155,7 +156,7 @@ val oidcForgeBlock by lazy {
 }
 
 val oidcPingOne by lazy {
-    OidcWeb {
+    OidcWebClient {
         logger = Logger.STANDARD
         module(com.pingidentity.oidc.module.Oidc) {
             clientId = "dummy"
@@ -179,7 +180,7 @@ val oidcPingOne by lazy {
 var journey = journeyTest
 var oidcClient: OidcClient? = null
 var daVinci: DaVinci? = null
-var web: OidcWeb? = null
+var web: OidcWebClient? = null
 lateinit var redirectUri: Uri //For Social Login redirect parameter using Auth Tab
 
 
@@ -210,11 +211,11 @@ class EnvViewModel : ViewModel() {
 
 
     /**
-     * Creates an OidcWeb instance with the provided OIDC configuration.
+     * Creates an OidcWebClient instance with the provided OIDC configuration.
      * This is used to initialize centralized OIDC login for all authentication types.
      */
-    private fun createOidcWeb(oidcConfig: OidcClientConfig): OidcWeb {
-        return OidcWeb {
+    private fun createOidcWeb(oidcConfig: OidcClientConfig): OidcWebClient {
+        return OidcWebClient {
             logger = Logger.STANDARD
             module(com.pingidentity.oidc.module.Oidc) {
                 clientId = oidcConfig.clientId
@@ -355,9 +356,9 @@ private fun Workflow.oidcConfig(): OidcClientConfig {
 }
 
 /**
- * Get the current [OidcClientConfig] from an OidcWeb instance.
+ * Get the current [OidcClientConfig] from an OidcWebClient instance.
  */
-private fun OidcWeb.oidcConfig(): OidcClientConfig {
+private fun OidcWebClient.oidcConfig(): OidcClientConfig {
     return config.modules.first { it.config is OidcClientConfig }.config as OidcClientConfig
 }
 


### PR DESCRIPTION


# JIRA Ticket

[SDKS-4766](https://pingidentity.atlassian.net/browse/SDKS-4766)

# Description

To improve clarity and consistency with client-server terminology, the `OidcWeb` class has been renamed to `OidcWebClient`.

This change is applied across the library, including the main class, configuration, tests, and all usages in the sample applications. The corresponding test file `OidcWebTest.kt` was also renamed to `OidcWebClientTest.kt`, and documentation has been updated to reflect the new class name.