### PR TITLE
Bug fix - Tamper Detector in SystemPropertyDetector not working as expected.

### DIFF
--- a/foundation/device/device-root/src/main/kotlin/com/pingidentity/device/root/DeviceTamperDetector.kt
+++ b/foundation/device/device-root/src/main/kotlin/com/pingidentity/device/root/DeviceTamperDetector.kt
@@ -10,7 +10,6 @@ import com.pingidentity.android.ContextProvider
 import com.pingidentity.device.root.detector.BuildTagsDetector
 import com.pingidentity.device.root.detector.BusyBoxProgramFileDetector
 import com.pingidentity.device.root.detector.DangerousPropertyDetector
-import com.pingidentity.device.root.detector.LoggerAware
 import com.pingidentity.device.root.detector.NativeDetector
 import com.pingidentity.device.root.detector.PermissionDetector
 import com.pingidentity.device.root.detector.RootApkDetector
@@ -164,6 +163,7 @@ suspend fun analyze(
     val detectors = config.tamperDetectors
     var max = 0.0
     for (detector in detectors) {
+        config.logger.i("Running detector: ${detector::class.simpleName}")
         max = max(max, detector.analyze(ContextProvider.context))
         if (max >= 1) {
             return max

--- a/foundation/device/device-root/src/main/kotlin/com/pingidentity/device/root/detector/SystemPropertyDetector.kt
+++ b/foundation/device/device-root/src/main/kotlin/com/pingidentity/device/root/detector/SystemPropertyDetector.kt
@@ -60,16 +60,22 @@ abstract class SystemPropertyDetector : TamperDetector {
      *
      * This method searches through all system properties to find matches for the
      * key-value pairs provided in the properties map. The format expected is
-     * `[key]: [value]` as returned by the `getprop` command.
+     * `[Map.keys]: [Map.values]` as returned by the `getprop` command.
      *
      * @param properties A map of property names to their suspicious values
      * @return `true` if any matching property-value pair is found, `false` otherwise
      */
     internal fun exists(properties: Map<String, String>): Boolean {
-        for (line in propsReader()) {
-            for (entry in properties.entries.toSet()) {
-                return (line.contains(entry.key) &&
-                        line.contains("[${entry.value}]"))
+        val systemPropertyList = propsReader()
+        systemPropertyList.forEach { property ->
+            for (entry in properties.entries) {
+                // Property format is "[key]: [value]"
+                val expectedProperty = "[${entry.key}]: [${entry.value}]"
+                logger.d("Checking property: $property against expected: $expectedProperty")
+                if (property == expectedProperty) {
+                    logger.w("Suspicious property found: $property")
+                    return true
+                }
             }
         }
         return false
@@ -80,7 +86,7 @@ abstract class SystemPropertyDetector : TamperDetector {
      *
      * This method executes the Android `getprop` command to retrieve all system
      * properties and returns them as a list of strings. Each string represents
-     * one property in the format `[key]: [value]`.
+     * one property in the format `[Map.keys]: [Map.values]`.
      *
      * @return A list of property strings, or an empty list if reading fails
      */

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/home/HomeApp.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/home/HomeApp.kt
@@ -112,9 +112,7 @@ fun HomeApp(
         }
         deviceStatus = try {
             val result = analyze {
-                detector {
-                    DefaultTamperDetector()
-                }
+                detector(DefaultTamperDetector())
             }
             if (result == 0.0) {
                 "✓ Secured"
@@ -333,7 +331,9 @@ fun HomeApp(
                     onClick = onConfigurationClick
                 )
 
-                Spacer(modifier = Modifier.padding(8.dp).fillMaxWidth())
+                Spacer(modifier = Modifier
+                    .padding(8.dp)
+                    .fillMaxWidth())
 
                 Card(
                     modifier = Modifier.fillMaxWidth(),
@@ -367,19 +367,25 @@ fun HomeApp(
                         )
                     }
                     HorizontalDivider(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 8.dp),
                         thickness = 1.dp,
                         color = colorResource(R.color.primary_dark)
                     )
                     TextButton(
                         onClick = onDeviceIdClick,
-                        modifier = Modifier.fillMaxWidth().padding(8.dp)
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
                     ) {
                         Text(text = deviceId)
                     }
                 }
 
-                Spacer(modifier = Modifier.padding(24.dp).fillMaxWidth())
+                Spacer(modifier = Modifier
+                    .padding(24.dp)
+                    .fillMaxWidth())
             }
 
         }


### PR DESCRIPTION

# JIRA Ticket

[SDKS-4792](https://pingidentity.atlassian.net/browse/SDKS-4792)

# Description

Default DangerousPropertyDetector was not working as expected because this condition mentioned below would always be false because a string cannot equal two different values at the same time. 
```kotlin
propertyExists = (it == "[${entry.key}]" && it == "[${entry.value}]")
``` 
The correct approach is to combine the key and the value and use:
```kotlin
val expectedProperty = "[${entry.key}]: [${entry.value}]"
if (property == expectedProperty) {
    logger.w("Suspicious property found: $property")
    return true
}
```