### PR TITLE
SDKS-4716: Add disaster recovery cleanup handling

### DIFF
--- a/mfa/auth-migration/src/main/kotlin/com/pingidentity/auth/migration/AuthMigration.kt
+++ b/mfa/auth-migration/src/main/kotlin/com/pingidentity/auth/migration/AuthMigration.kt
@@ -18,6 +18,13 @@ import com.pingidentity.migration.Migration
 object AuthMigration {
     val logger = Logger.STANDARD
 
+    /**
+     * Configuration for the migration process.
+     * Set this before starting migration if using custom storage with a different key alias.
+     */
+    @Volatile
+    var config: LegacyAuthenticationConfig = LegacyAuthenticationConfig()
+
     /** The migration configuration that defines the sequence of migration steps. */
     val migration = Migration {
         logger = this@AuthMigration.logger
@@ -26,6 +33,28 @@ object AuthMigration {
         step(step3)  // Migrate push notifications to Push storage
         step(step4)  // Migrate device token to Push storage
         step(step5)  // Cleanup legacy authenticator data
+    }
+
+    /**
+     * Configures the migration with custom settings.
+     *
+     * @param keyAlias The AndroidKeyStore alias used for encrypted storage.
+     *                 Default: "org.forgerock.android.authenticator.KEYS"
+     *
+     * ## Example - Custom Storage with Different Key Alias
+     *
+     * ```kotlin
+     * // Before starting migration, configure the key alias
+     * AuthMigration.configure(keyAlias = "com.myapp.custom.KEY_ALIAS")
+     *
+     * lifecycleScope.launch {
+     *     AuthMigration.start(applicationContext)
+     * }
+     * ```
+     */
+    fun configure(keyAlias: String = LegacyAuthenticationConfig.DEFAULT_KEY_ALIAS) {
+        config = LegacyAuthenticationConfig(keyAlias = keyAlias)
+        logger.i("Migration configured with key alias: $keyAlias")
     }
 
     /**

--- a/mfa/auth-migration/src/main/kotlin/com/pingidentity/auth/migration/AuthenticatorMigrationSteps.kt
+++ b/mfa/auth-migration/src/main/kotlin/com/pingidentity/auth/migration/AuthenticatorMigrationSteps.kt
@@ -6,6 +6,8 @@
 
 package com.pingidentity.auth.migration
 
+import android.content.Context
+import com.pingidentity.logger.Logger
 import com.pingidentity.mfa.oath.OathAlgorithm
 import com.pingidentity.mfa.oath.OathCredential
 import com.pingidentity.mfa.oath.OathType
@@ -36,17 +38,29 @@ private const val DEVICE_TOKEN = "deviceToken"
 private lateinit var pushStorage: SQLPushStorage
 /** OATH storage instance shared across migration steps. */
 private lateinit var oathStorage: SQLOathStorage
-private val json = Json { ignoreUnknownKeys = true }
+/** Build the json object with non-null fields  */
+private val json = Json {
+    encodeDefaults = false
+    ignoreUnknownKeys = true
+    explicitNulls = false
+}
 
 
 /**
  * Step 1: Export legacy authenticator data from Legacy SDK.
+ *
+ * Supports both:
+ * - Default storage (encrypted SharedPreferences)
+ * - Custom storage (unencrypted SharedPreferences)
+ *
+ * The repository automatically detects which format is in use.
+ * Uses AuthMigration.config for custom key alias configuration.
  */
 val step1 = MigrationStep(
     description = "Export legacy authenticator data"
 ) {
     logger.i("Checking for legacy authenticator data")
-    val repo = LegacyAuthenticationRepository(context)
+    val repo = LegacyAuthenticationRepository(context, AuthMigration.config)
 
     if (!repo.isExists()) {
         logger.i("No legacy repository found, skipping migration")
@@ -90,10 +104,27 @@ val step2 = MigrationStep(
 
     val accounts = getValue<Map<String, String>>(ACCOUNTS) ?: emptyMap()
 
-    // Create storage instances
-    oathStorage = SQLOathStorage { context = this@MigrationStep.context }
+    // Safely check and prepare database environment before migration
+    prepareDatabase(
+        context = this@MigrationStep.context,
+        logger = logger,
+    )
+
+    // Create storage instances with destructive recovery enabled for migration
+    // This allows recovery from corrupted databases that may occur if app is force-closed during migration
+    oathStorage = SQLOathStorage {
+        context = this@MigrationStep.context
+        allowDestructiveRecovery = true
+        backupOnError = true
+        autoRestoreFromBackup = true
+    }
     oathStorage.initializeDatabase()
-    pushStorage = SQLPushStorage { context = this@MigrationStep.context }
+    pushStorage = SQLPushStorage {
+        context = this@MigrationStep.context
+        allowDestructiveRecovery = true
+        backupOnError = true
+        autoRestoreFromBackup = true
+    }
     pushStorage.initializeDatabase()
 
 
@@ -106,29 +137,46 @@ val step2 = MigrationStep(
             when (val type = mechanismData["type"]?.jsonPrimitive?.content) {
                 OTP_AUTH, TOTP, HOTP -> {
                     // Migrate OATH/TOTP mechanism
-                    val accountId = mechanismData["mechanismUID"]?.jsonPrimitive?.content
+                    val mechanismIdValue = mechanismData["mechanismUID"]?.jsonPrimitive?.content
                         ?: mechanismData["id"]?.jsonPrimitive?.content
                         ?: mechanismId
 
-                    // Find associated account
+                    // First extract issuer and accountName from mechanism to construct Account ID
+                    // Account ID format: issuer + "-" + accountName (from legacy Account.java)
+                    val mechanismIssuer = mechanismData["issuer"]?.jsonPrimitive?.content ?: ""
+                    val mechanismAccountName = mechanismData["accountName"]?.jsonPrimitive?.content ?: ""
+                    val accountId = "$mechanismIssuer-$mechanismAccountName"
+
+                    // Find associated account using the constructed Account ID
                     val accountJson = accounts[accountId]
                     val accountData = accountJson?.let { json.parseToJsonElement(it).jsonObject }
 
-                    val issuer = accountData?.get("issuer")?.jsonPrimitive?.content
-                        ?: mechanismData["issuer"]?.jsonPrimitive?.content
-                        ?: "Unknown"
-                    val accountName = accountData?.get("accountName")?.jsonPrimitive?.content
-                        ?: mechanismData["accountName"]?.jsonPrimitive?.content
-                        ?: "Unknown"
+                    // Account-only fields (no fallback to mechanism)
+                    val issuer = accountData?.get("issuer")?.jsonPrimitive?.content ?: mechanismIssuer
+                    val accountName = accountData?.get("accountName")?.jsonPrimitive?.content ?: mechanismAccountName
+                    val displayIssuer = accountData?.get("displayIssuer")?.jsonPrimitive?.content ?: issuer
+                    val displayAccountName = accountData?.get("displayAccountName")?.jsonPrimitive?.content ?: accountName
+                    val imageURL = accountData?.get("imageURL")?.jsonPrimitive?.content
+                    val backgroundColor = accountData?.get("backgroundColor")?.jsonPrimitive?.content
+                    val policies = accountData?.get("policies")?.jsonPrimitive?.content
+                    val lockingPolicy = accountData?.get("lockingPolicy")?.jsonPrimitive?.content
+                    val isLocked = accountData?.get("lock")?.jsonPrimitive?.content?.toBoolean() ?: false
+                    val createdAt = accountData?.get("timeAdded")?.jsonPrimitive?.content?.toLongOrNull()
+                        ?: mechanismData["timeAdded"]?.jsonPrimitive?.content?.toLongOrNull()
+
+                    // Mechanism-only fields (no fallback to account)
+                    val userId = mechanismData["uid"]?.jsonPrimitive?.content
+                    val resourceId = mechanismData["resourceId"]?.jsonPrimitive?.content
 
                     val oathCredential = OathCredential(
-                        id = accountId,
+                        id = mechanismIdValue,  // Use mechanismUID as the credential ID
+                        userId = userId,
+                        resourceId = resourceId,
                         issuer = issuer,
+                        displayIssuer = displayIssuer,
                         accountName = accountName,
-                        oathType = when (mechanismData["oathType"]?.jsonPrimitive?.content?.uppercase()) {
-                            HOTP -> OathType.HOTP
-                            else -> OathType.TOTP
-                        },
+                        displayAccountName = displayAccountName,
+                        oathType = OathType.fromString(mechanismData["oathType"]?.jsonPrimitive?.content ?: TOTP),
                         secret = mechanismData["secret"]?.jsonPrimitive?.content ?: "",
                         oathAlgorithm = when (mechanismData["algorithm"]?.jsonPrimitive?.content) {
                             "sha256", "SHA256" -> OathAlgorithm.SHA256
@@ -138,8 +186,12 @@ val step2 = MigrationStep(
                         digits = mechanismData["digits"]?.jsonPrimitive?.content?.toIntOrNull() ?: 6,
                         period = mechanismData["period"]?.jsonPrimitive?.content?.toIntOrNull() ?: 30,
                         counter = mechanismData["counter"]?.jsonPrimitive?.content?.toLongOrNull() ?: 0L,
-                        imageURL = accountData?.get("imageURL")?.jsonPrimitive?.content,
-                        backgroundColor = accountData?.get("backgroundColor")?.jsonPrimitive?.content
+                        createdAt = createdAt?.let { Date(it) } ?: Date(),
+                        imageURL = imageURL,
+                        backgroundColor = backgroundColor,
+                        policies = policies,
+                        lockingPolicy = lockingPolicy,
+                        isLocked = isLocked
                     )
 
                     oathStorage.storeOathCredential(oathCredential)
@@ -149,31 +201,67 @@ val step2 = MigrationStep(
 
                 PUSH, PUSH_AUTH -> {
                     // Migrate Push mechanism
-                    val accountId = mechanismData["mechanismUID"]?.jsonPrimitive?.content
+                    val mechanismIdValue = mechanismData["mechanismUID"]?.jsonPrimitive?.content
                         ?: mechanismData["id"]?.jsonPrimitive?.content
                         ?: mechanismId
 
-                    // Find associated account
+                    // First extract issuer and accountName from mechanism to construct Account ID
+                    // Account ID format: issuer + "-" + accountName (from legacy Account.java)
+                    val mechanismIssuer = mechanismData["issuer"]?.jsonPrimitive?.content ?: ""
+                    val mechanismAccountName = mechanismData["accountName"]?.jsonPrimitive?.content ?: ""
+                    val accountId = "$mechanismIssuer-$mechanismAccountName"
+
+                    // Find associated account using the constructed Account ID
                     val accountJson = accounts[accountId]
                     val accountData = accountJson?.let { json.parseToJsonElement(it).jsonObject }
 
-                    val issuer = accountData?.get("issuer")?.jsonPrimitive?.content
-                        ?: mechanismData["issuer"]?.jsonPrimitive?.content
-                        ?: "Unknown"
-                    val accountName = accountData?.get("accountName")?.jsonPrimitive?.content
-                        ?: mechanismData["accountName"]?.jsonPrimitive?.content
-                        ?: "Unknown"
+                    // Account-only fields (no fallback to mechanism)
+                    val issuer = accountData?.get("issuer")?.jsonPrimitive?.content ?: mechanismIssuer
+                    val accountName = accountData?.get("accountName")?.jsonPrimitive?.content ?: mechanismAccountName
+                    val displayIssuer = accountData?.get("displayIssuer")?.jsonPrimitive?.content ?: issuer
+                    val displayAccountName = accountData?.get("displayAccountName")?.jsonPrimitive?.content ?: accountName
+                    val imageURL = accountData?.get("imageURL")?.jsonPrimitive?.content
+                    val backgroundColor = accountData?.get("backgroundColor")?.jsonPrimitive?.content
+                    val policies = accountData?.get("policies")?.jsonPrimitive?.content
+                    val lockingPolicy = accountData?.get("lockingPolicy")?.jsonPrimitive?.content
+                    val isLocked = accountData?.get("lock")?.jsonPrimitive?.content?.toBoolean() ?: false
+                    val createdAt = accountData?.get("timeAdded")?.jsonPrimitive?.content?.toLongOrNull()
+                        ?: mechanismData["timeAdded"]?.jsonPrimitive?.content?.toLongOrNull()
+
+                    // Mechanism-only fields (no fallback to account)
+                    val userId = mechanismData["uid"]?.jsonPrimitive?.content
+                    val resourceId = mechanismData["resourceId"]?.jsonPrimitive?.content
+                        ?: mechanismIdValue  // Fallback to mechanismUID if resourceId not present
+                    val platform = mechanismData["platform"]?.jsonPrimitive?.content ?: "PING_AM"
+
+                    // Extract base endpoint (remove query parameters like ?_action=authenticate)
+                    val rawEndpoint = mechanismData["authenticationEndpoint"]?.jsonPrimitive?.content
+                        ?: mechanismData["registrationEndpoint"]?.jsonPrimitive?.content
+                        ?: mechanismData["endpoint"]?.jsonPrimitive?.content
+                        ?: ""
+                    val serverEndpoint = if (rawEndpoint.contains("?")) {
+                        rawEndpoint.substringBefore("?")
+                    } else {
+                        rawEndpoint
+                    }
 
                     val pushCredential = PushCredential(
-                        id = accountId,
+                        id = mechanismIdValue,  // Use mechanismUID as the credential ID
+                        userId = userId,
+                        resourceId = resourceId,
                         issuer = issuer,
+                        displayIssuer = displayIssuer,
                         accountName = accountName,
-                        serverEndpoint = mechanismData["authenticationEndpoint"]?.jsonPrimitive?.content
-                            ?: mechanismData["endpoint"]?.jsonPrimitive?.content
-                            ?: "",
+                        displayAccountName = displayAccountName,
+                        serverEndpoint = serverEndpoint,
                         sharedSecret = mechanismData["secret"]?.jsonPrimitive?.content ?: "",
-                        imageURL = accountData?.get("imageURL")?.jsonPrimitive?.content,
-                        backgroundColor = accountData?.get("backgroundColor")?.jsonPrimitive?.content
+                        createdAt = createdAt?.let { Date(it) } ?: Date(),
+                        imageURL = imageURL,
+                        backgroundColor = backgroundColor,
+                        policies = policies,
+                        lockingPolicy = lockingPolicy,
+                        isLocked = isLocked,
+                        platform = platform
                     )
 
                     pushStorage.storePushCredential(pushCredential)
@@ -217,13 +305,37 @@ val step3 = MigrationStep(
             val pushNotification = PushNotification(
                 id = notificationId,
                 credentialId = notificationData["credentialId"]?.jsonPrimitive?.content ?: "",
-                messageId = notificationData["messageId"]?.jsonPrimitive?.content ?: notificationId,
-                challenge = notificationData["challenge"]?.jsonPrimitive?.content ?: "",
                 ttl = notificationData["ttl"]?.jsonPrimitive?.content?.toIntOrNull() ?: 120,
+                messageId = notificationData["messageId"]?.jsonPrimitive?.content ?: notificationId,
+                messageText = notificationData["messageText"]?.jsonPrimitive?.content
+                    ?: notificationData["message"]?.jsonPrimitive?.content,
+                customPayload = notificationData["customPayload"]?.jsonPrimitive?.content,
+                challenge = notificationData["challenge"]?.jsonPrimitive?.content ?: "",
+                numbersChallenge = notificationData["numbersChallenge"]?.jsonPrimitive?.content,
+                loadBalancer = notificationData["loadBalancer"]?.jsonPrimitive?.content
+                    ?: notificationData["amlbCookie"]?.jsonPrimitive?.content,
+                contextInfo = notificationData["contextInfo"]?.jsonPrimitive?.content,
+                pushType = notificationData["pushType"]?.jsonPrimitive?.content?.let { type ->
+                    try {
+                        PushType.fromString(type)
+                    } catch (e: Exception) {
+                        PushType.DEFAULT
+                    }
+                } ?: PushType.DEFAULT,
+                createdAt = Date(notificationData["timeAdded"]?.jsonPrimitive?.content?.toLongOrNull()
+                    ?: notificationData["createdAt"]?.jsonPrimitive?.content?.toLongOrNull()
+                    ?: System.currentTimeMillis()),
+                sentAt = notificationData["sentAt"]?.jsonPrimitive?.content?.toLongOrNull()?.let { Date(it) },
+                respondedAt = notificationData["respondedAt"]?.jsonPrimitive?.content?.toLongOrNull()?.let { Date(it) },
+                additionalData = notificationData["additionalData"]?.jsonPrimitive?.content?.let { dataStr ->
+                    try {
+                        json.decodeFromString<Map<String, Any>>(dataStr)
+                    } catch (e: Exception) {
+                        null
+                    }
+                },
                 approved = notificationData["approved"]?.jsonPrimitive?.content?.toBoolean() ?: false,
-                pending = notificationData["pending"]?.jsonPrimitive?.content?.toBoolean() ?: true,
-                createdAt = Date(notificationData["timeAdded"]?.jsonPrimitive?.content?.toLongOrNull() ?: System.currentTimeMillis()),
-                pushType = PushType.DEFAULT,
+                pending = notificationData["pending"]?.jsonPrimitive?.content?.toBoolean() ?: true
             )
 
             pushStorage.storePushNotification(pushNotification)
@@ -260,6 +372,7 @@ val step4 = MigrationStep(
                 id = tokenData["id"]?.jsonPrimitive?.content ?: "",
                 tokenId = tokenData["deviceToken"]?.jsonPrimitive?.content
                     ?: tokenData["token"]?.jsonPrimitive?.content
+                    ?: tokenData["tokenId"]?.jsonPrimitive?.content
                     ?: "",
                 createdAt = Date(tokenData["timeAdded"]?.jsonPrimitive?.content?.toLongOrNull() ?: System.currentTimeMillis()),
             )
@@ -283,7 +396,7 @@ val step5 = MigrationStep(
     logger.i("Cleaning up legacy authenticator data")
 
     try {
-        val repo = LegacyAuthenticationRepository(context)
+        val repo = LegacyAuthenticationRepository(context, AuthMigration.config)
         repo.deleteLegacyData()
         logger.i("Successfully deleted legacy authenticator data")
         oathStorage.closeDatabase()
@@ -296,4 +409,108 @@ val step5 = MigrationStep(
     }
 
     CONTINUE
+}
+
+/**
+ * Prepares the database environment for migration by safely handling any existing database files.
+ *
+ * @param context The Android context used to access database paths and storage APIs.
+ * @param logger The logger instance for tracking database operations and decisions.
+ *
+ * @see SQLOathStorage
+ * @see SQLPushStorage
+ */
+private suspend fun prepareDatabase(
+    context: Context,
+    logger: Logger,
+) {
+    logger.i("Checking existing databases before migration")
+
+    // Check OATH database
+    val oathDbPath = context.getDatabasePath("pingidentity_oath.db")
+    if (oathDbPath.exists()) {
+        logger.i("Found existing OATH database at: ${oathDbPath.absolutePath}")
+
+        val shouldDeleteOath = try {
+            // Try to open the database with current passphrase to check if it's valid
+            val testOathStorage = SQLOathStorage {
+                this.context = context
+                allowDestructiveRecovery = false // Don't allow auto-recovery during check
+            }
+
+            testOathStorage.initializeDatabase()
+            val existingCredentials = testOathStorage.getAllOathCredentials()
+            testOathStorage.closeDatabase()
+
+            if (existingCredentials.isNotEmpty()) {
+                logger.i("OATH database contains ${existingCredentials.size} existing credentials - preserving database")
+                false // Keep database with existing data
+            } else {
+                logger.i("OATH database is empty - deleting to avoid passphrase conflicts")
+                true // Delete empty database to avoid conflicts
+            }
+        } catch (e: Exception) {
+            // Database exists but cannot be opened with current passphrase
+            logger.w("OATH database exists but cannot be opened (likely encrypted with different passphrase): ${e.message}")
+            logger.i("Will delete incompatible OATH database to allow migration to proceed")
+            true // Delete incompatible database
+        }
+
+        if (shouldDeleteOath) {
+            try {
+                context.deleteDatabase("pingidentity_oath.db")
+                logger.i("Deleted incompatible OATH database")
+            } catch (e: Exception) {
+                logger.e("Failed to delete OATH database: ${e.message}", e)
+            }
+        }
+    } else {
+        logger.i("No existing OATH database found - will create fresh database")
+    }
+
+    // Check Push database
+    val pushDbPath = context.getDatabasePath("pingidentity_push.db")
+    if (pushDbPath.exists()) {
+        logger.i("Found existing Push database at: ${pushDbPath.absolutePath}")
+
+        val shouldDeletePush = try {
+            // Try to open the database with current passphrase to check if it's valid
+            val testPushStorage = SQLPushStorage {
+                this.context = context
+                allowDestructiveRecovery = false // Don't allow auto-recovery during check
+            }
+
+            testPushStorage.initializeDatabase()
+            val existingCredentials = testPushStorage.getAllPushCredentials()
+            val existingNotifications = testPushStorage.getAllPushNotifications()
+            val existingTokens = testPushStorage.getAllPushDeviceTokens()
+            testPushStorage.closeDatabase()
+
+            val totalItems = existingCredentials.size + existingNotifications.size + existingTokens.size
+
+            if (totalItems > 0) {
+                logger.i("Push database contains existing data (${existingCredentials.size} credentials, ${existingNotifications.size} notifications, ${existingTokens.size} tokens) - preserving database")
+                false // Keep database with existing data
+            } else {
+                logger.i("Push database is empty - deleting to avoid passphrase conflicts")
+                true // Delete empty database to avoid conflicts
+            }
+        } catch (e: Exception) {
+            // Database exists but cannot be opened with current passphrase
+            logger.w("Push database exists but cannot be opened (likely encrypted with different passphrase): ${e.message}")
+            logger.i("Will delete incompatible Push database to allow migration to proceed")
+            true // Delete incompatible database
+        }
+
+        if (shouldDeletePush) {
+            try {
+                context.deleteDatabase("pingidentity_push.db")
+                logger.i("Deleted incompatible Push database")
+            } catch (e: Exception) {
+                logger.e("Failed to delete Push database: ${e.message}", e)
+            }
+        }
+    } else {
+        logger.i("No existing Push database found - will create fresh database")
+    }
 }

--- a/mfa/auth-migration/src/main/kotlin/com/pingidentity/auth/migration/LegacyAuthenticatorRepository.kt
+++ b/mfa/auth-migration/src/main/kotlin/com/pingidentity/auth/migration/LegacyAuthenticatorRepository.kt
@@ -13,6 +13,22 @@ import kotlinx.serialization.Serializable
 import java.io.File
 
 /**
+ * Configuration for legacy authenticator data migration.
+ *
+ * @property keyAlias The AndroidKeyStore alias used for encrypting SharedPreferences.
+ *                    Default: "org.forgerock.android.authenticator.KEYS" (ForgeRock SDK default)
+ *                    Custom storage implementations may use different aliases.
+ */
+data class LegacyAuthenticationConfig(
+    val keyAlias: String = DEFAULT_KEY_ALIAS
+) {
+    companion object {
+        /** Default key alias used by ForgeRock Authenticator SDK */
+        const val DEFAULT_KEY_ALIAS = "org.forgerock.android.authenticator.KEYS"
+    }
+}
+
+/**
  * Exported authenticator data from Legacy SDK.
  */
 @Serializable
@@ -43,37 +59,55 @@ private const val AUTH_DATA_DEVICE_TOKEN = "org.forgerock.android.authenticator.
 
 /**
  * Repository for reading and exporting Legacy SDK authenticator data.
+ * Supports both encrypted (default storage) and unencrypted (custom storage) data.
+ *
+ * @param context Android application context
+ * @param config Configuration including custom key alias for encrypted storage
  */
-class LegacyAuthenticationRepository(private val context: Context) {
+class LegacyAuthenticationRepository(
+    private val context: Context,
+    private val config: LegacyAuthenticationConfig = LegacyAuthenticationConfig()
+) {
 
     private val decryptor = LegacyAuthenticationDecryptor(
         context,
-        "org.forgerock.android.authenticator.KEYS"
+        config.keyAlias
     )
 
     /**
-     * Checks if legacy encryption key exists in KeyStore.
+     * Checks if legacy data exists (either encrypted or unencrypted).
      */
     suspend fun isExists(): Boolean = withContext(Dispatchers.IO) {
-        decryptor.keyExists()
+        // Check for encrypted data (has encryption key)
+        if (decryptor.keyExists()) {
+            return@withContext true
+        }
+
+        // Check for unencrypted data (custom storage - plain SharedPreferences)
+        val prefsDir = File(context.applicationInfo.dataDir, "shared_prefs")
+        return@withContext listOf(
+            AUTH_DATA_ACCOUNT,
+            AUTH_DATA_MECHANISM,
+            AUTH_DATA_NOTIFICATIONS,
+            AUTH_DATA_DEVICE_TOKEN
+        ).any { prefName ->
+            File(prefsDir, "$prefName.xml").exists()
+        }
     }
 
     /**
      * Export all FR Authenticator data from Legacy SDK.
-     * Uses standalone decryptor - NO Legacy SDK dependency required!
+     * Supports both encrypted (default) and unencrypted (custom storage) data.
      */
     suspend fun exportAllData(): ExportedData = withContext(Dispatchers.IO) {
-        // Check if legacy data exists
-        if (!decryptor.keyExists()) {
-            return@withContext emptyExport()
-        }
-
         try {
-            // Decrypt all 4 files
-            val accounts = decryptIfExists(AUTH_DATA_ACCOUNT)
-            val mechanisms = decryptIfExists(AUTH_DATA_MECHANISM)
-            val notifications = decryptIfExists(AUTH_DATA_NOTIFICATIONS)
-            val deviceToken = decryptIfExists(AUTH_DATA_DEVICE_TOKEN)
+            // Try encrypted data first (default storage)
+            val isEncrypted = decryptor.keyExists()
+
+            val accounts = readPreferences(AUTH_DATA_ACCOUNT, isEncrypted)
+            val mechanisms = readPreferences(AUTH_DATA_MECHANISM, isEncrypted)
+            val notifications = readPreferences(AUTH_DATA_NOTIFICATIONS, isEncrypted)
+            val deviceToken = readPreferences(AUTH_DATA_DEVICE_TOKEN, isEncrypted)
 
             ExportedData(
                 accounts = accounts,
@@ -94,9 +128,9 @@ class LegacyAuthenticationRepository(private val context: Context) {
     }
 
     /**
-     * Decrypts SharedPreferences file if it exists on disk.
+     * Reads SharedPreferences data, handling both encrypted and unencrypted formats.
      */
-    private fun decryptIfExists(preferenceName: String): Map<String, String> {
+    private fun readPreferences(preferenceName: String, isEncrypted: Boolean): Map<String, String> {
         // Check if file exists
         val prefsDir = File(context.applicationInfo.dataDir, "shared_prefs")
         val prefsFile = File(prefsDir, "$preferenceName.xml")
@@ -106,36 +140,59 @@ class LegacyAuthenticationRepository(private val context: Context) {
         }
 
         return try {
-            decryptor.decryptAll(preferenceName)
+            if (isEncrypted) {
+                // Decrypt encrypted SharedPreferences (default storage)
+                AuthMigration.logger.d("Reading encrypted data from $preferenceName")
+                decryptor.decryptAll(preferenceName)
+            } else {
+                // Read plain SharedPreferences (custom storage)
+                AuthMigration.logger.d("Reading unencrypted data from $preferenceName")
+                readPlainSharedPreferences(preferenceName)
+            }
         } catch (e: Exception) {
-            AuthMigration.logger.e("Failed to decrypt $preferenceName: ${e.message}", e)
+            AuthMigration.logger.e("Failed to read $preferenceName: ${e.message}", e)
             emptyMap()
         }
     }
 
     /**
+     * Reads plain (unencrypted) SharedPreferences used by custom storage.
+     */
+    private fun readPlainSharedPreferences(preferenceName: String): Map<String, String> {
+        val prefs = context.getSharedPreferences(preferenceName, Context.MODE_PRIVATE)
+        val result = mutableMapOf<String, String>()
+
+        prefs.all.forEach { (key, value) ->
+            if (value is String) {
+                result[key] = value
+            }
+        }
+
+        AuthMigration.logger.d("Read ${result.size} entries from plain SharedPreferences: $preferenceName")
+        return result
+    }
+
+    /**
      * Delete legacy data after successful migration.
+     * Handles both encrypted (default storage) and unencrypted (custom storage) data.
      */
     suspend fun deleteLegacyData() = withContext(Dispatchers.IO) {
+        // Delete SharedPreferences files (works for both encrypted and unencrypted)
         context.deleteSharedPreferences(AUTH_DATA_ACCOUNT)
         context.deleteSharedPreferences(AUTH_DATA_MECHANISM)
         context.deleteSharedPreferences(AUTH_DATA_NOTIFICATIONS)
         context.deleteSharedPreferences(AUTH_DATA_DEVICE_TOKEN)
 
-        // Delete encryption key
-        val keyStore = java.security.KeyStore.getInstance("AndroidKeyStore")
-        keyStore.load(null)
-        keyStore.deleteEntry("org.forgerock.android.authenticator.KEYS")
+        // Delete encryption key if it exists (only for default storage)
+        try {
+            if (decryptor.keyExists()) {
+                val keyStore = java.security.KeyStore.getInstance("AndroidKeyStore")
+                keyStore.load(null)
+                keyStore.deleteEntry(config.keyAlias)
+                AuthMigration.logger.d("Deleted legacy encryption key: ${config.keyAlias}")
+            }
+        } catch (e: Exception) {
+            AuthMigration.logger.w("Failed to delete encryption key (may not exist): ${e.message}")
+        }
     }
-
-    /**
-     * Creates an empty export data object.
-     */
-    private fun emptyExport() = ExportedData(
-        accounts = emptyMap(),
-        mechanisms = emptyMap(),
-        notifications = emptyMap(),
-        deviceToken = emptyMap(),
-        metadata = ExportMetadata(0, 0, 0, false)
-    )
 }

--- a/mfa/auth-migration/src/test/kotlin/com/pingidentity/auth/migration/AuthMigrationTest.kt
+++ b/mfa/auth-migration/src/test/kotlin/com/pingidentity/auth/migration/AuthMigrationTest.kt
@@ -17,6 +17,7 @@ import com.pingidentity.mfa.oath.storage.SQLOathStorage
 import com.pingidentity.mfa.push.PushCredential
 import com.pingidentity.mfa.push.PushDeviceToken
 import com.pingidentity.mfa.push.PushNotification
+import com.pingidentity.mfa.push.PushType
 import com.pingidentity.mfa.push.storage.SQLPushStorage
 import com.pingidentity.migration.MigrationProgress
 import io.mockk.coEvery
@@ -31,6 +32,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
+import kotlin.test.DefaultAsserter.assertTrue
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -185,7 +187,8 @@ class AuthMigrationTest {
 
     @Test
     fun `migration migrates OATH credentials correctly`() = runTest {
-        // Given - Legacy repository with TOTP mechanism
+        // Given - Legacy repository with TOTP mechanism with ALL fields
+        val testTime = System.currentTimeMillis()
         val mechanisms = mapOf(
             "totp-mechanism-1" to """
                 {
@@ -197,18 +200,26 @@ class AuthMigrationTest {
                     "algorithm": "sha1",
                     "digits": 6,
                     "period": 30,
-                    "oathType": "TOTP"
+                    "counter": 0,
+                    "oathType": "TOTP",
+                    "uid": "user-12345",
+                    "resourceId": "resource-67890",
+                    "timeAdded": $testTime
                 }
             """.trimIndent()
         )
         val accounts = mapOf(
-            "totp-mechanism-1" to """
+            "Google-user@example.com" to """
                 {
-                    "id": "totp-mechanism-1",
+                    "id": "Google-user@example.com",
                     "issuer": "Google",
+                    "displayIssuer": "Google Authenticator",
                     "accountName": "user@example.com",
+                    "displayAccountName": "Demo User",
                     "imageURL": "https://example.com/logo.png",
-                    "backgroundColor": "#4285F4"
+                    "backgroundColor": "#4285F4",
+                    "policies": "{\"deviceTampering\":true}",
+                    "lock": false
                 }
             """.trimIndent()
         )
@@ -236,26 +247,114 @@ class AuthMigrationTest {
 
         // Capture the stored credential
         val oathSlot = slot<OathCredential>()
-        // Verify the storage function was called with the expected credential
         coVerify(exactly = 1) { anyConstructed<SQLOathStorage>().storeOathCredential(capture(oathSlot)) }
 
-        // Verify the captured credential has the expected values
+        // Verify ALL 19 fields are correctly migrated
         val storedCredential = oathSlot.captured
         assertEquals("totp-mechanism-1", storedCredential.id)
+        assertEquals("user-12345", storedCredential.userId)
+        assertEquals("resource-67890", storedCredential.resourceId)
         assertEquals("Google", storedCredential.issuer)
+        assertEquals("Google Authenticator", storedCredential.displayIssuer)
         assertEquals("user@example.com", storedCredential.accountName)
-        assertEquals("JBSWY3DPEHPK3PXP", storedCredential.secret)
+        assertEquals("Demo User", storedCredential.displayAccountName)
         assertEquals(OathType.TOTP, storedCredential.oathType)
+        assertEquals("JBSWY3DPEHPK3PXP", storedCredential.secret)
         assertEquals(OathAlgorithm.SHA1, storedCredential.oathAlgorithm)
         assertEquals(6, storedCredential.digits)
         assertEquals(30, storedCredential.period)
+        assertEquals(0L, storedCredential.counter)
+        assertEquals(testTime, storedCredential.createdAt.time)
         assertEquals("https://example.com/logo.png", storedCredential.imageURL)
         assertEquals("#4285F4", storedCredential.backgroundColor)
+        assertEquals("{\"deviceTampering\":true}", storedCredential.policies)
+        assertEquals(null, storedCredential.lockingPolicy)
+        assertEquals(false, storedCredential.isLocked)
+    }
+
+    @Test
+    fun `migration migrates HOTP credentials correctly with counter`() = runTest {
+        // Given - Legacy repository with HOTP mechanism
+        val testTime = System.currentTimeMillis()
+        val mechanisms = mapOf(
+            "hotp-mechanism-1" to """
+                {
+                    "type": "hotp",
+                    "mechanismUID": "hotp-mechanism-1",
+                    "issuer": "GitHub",
+                    "accountName": "developer@example.com",
+                    "secret": "HOTPSECRETKEY123",
+                    "algorithm": "sha256",
+                    "digits": 8,
+                    "counter": 42,
+                    "oathType": "HOTP",
+                    "uid": "hotp-user-789",
+                    "resourceId": "hotp-resource-456",
+                    "timeAdded": $testTime
+                }
+            """.trimIndent()
+        )
+        val accounts = mapOf(
+            "GitHub-developer@example.com" to """
+                {
+                    "id": "GitHub-developer@example.com",
+                    "issuer": "GitHub",
+                    "displayIssuer": "GitHub Inc",
+                    "accountName": "developer@example.com",
+                    "displayAccountName": "Developer Account",
+                    "imageURL": "https://github.com/logo.png",
+                    "backgroundColor": "#24292e",
+                    "lock": false
+                }
+            """.trimIndent()
+        )
+
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().isExists() } returns true
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().exportAllData() } returns ExportedData(
+            accounts = accounts,
+            mechanisms = mechanisms,
+            notifications = emptyMap(),
+            deviceToken = emptyMap(),
+            metadata = ExportMetadata(1, 1, 0, false)
+        )
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().deleteLegacyData() } returns Unit
+
+        // When
+        val progressList = AuthMigration.migration.migrate(context).toList()
+
+        // Then
+        assertTrue(progressList.any { it is MigrationProgress.Success })
+
+        val oathSlot = slot<OathCredential>()
+        coVerify(exactly = 1) { anyConstructed<SQLOathStorage>().storeOathCredential(capture(oathSlot)) }
+
+        // Verify HOTP-specific fields and all others
+        val storedCredential = oathSlot.captured
+        assertEquals("hotp-mechanism-1", storedCredential.id)
+        assertEquals("hotp-user-789", storedCredential.userId)
+        assertEquals("hotp-resource-456", storedCredential.resourceId)
+        assertEquals("GitHub", storedCredential.issuer)
+        assertEquals("GitHub Inc", storedCredential.displayIssuer)
+        assertEquals("developer@example.com", storedCredential.accountName)
+        assertEquals("Developer Account", storedCredential.displayAccountName)
+        assertEquals(OathType.HOTP, storedCredential.oathType)  // HOTP type
+        assertEquals("HOTPSECRETKEY123", storedCredential.secret)
+        assertEquals(OathAlgorithm.SHA256, storedCredential.oathAlgorithm)  // SHA256
+        assertEquals(8, storedCredential.digits)  // 8 digits
+        assertEquals(30, storedCredential.period)  // Default period (not used for HOTP)
+        assertEquals(42L, storedCredential.counter)  // Counter value
+        assertEquals(testTime, storedCredential.createdAt.time)
+        assertEquals("https://github.com/logo.png", storedCredential.imageURL)
+        assertEquals("#24292e", storedCredential.backgroundColor)
+        assertEquals(null, storedCredential.policies)
+        assertEquals(null, storedCredential.lockingPolicy)
+        assertEquals(false, storedCredential.isLocked)
     }
 
     @Test
     fun `migration migrates Push credentials correctly`() = runTest {
-        // Given - Legacy repository with Push mechanism
+        // Given - Legacy repository with Push mechanism with ALL fields
+        val testTime = System.currentTimeMillis()
         val mechanisms = mapOf(
             "push-mechanism-1" to """
                 {
@@ -264,16 +363,28 @@ class AuthMigrationTest {
                     "issuer": "ForgeRock",
                     "accountName": "admin@company.com",
                     "secret": "sharedSecret123",
-                    "authenticationEndpoint": "https://am.example.com/push"
+                    "uid": "user-99999",
+                    "resourceId": "push-resource-11111",
+                    "authenticationEndpoint": "https://am.example.com/push?_action=authenticate",
+                    "registrationEndpoint": "https://am.example.com/push?_action=register",
+                    "platform": "PING_AM",
+                    "timeAdded": $testTime
                 }
             """.trimIndent()
         )
         val accounts = mapOf(
-            "push-mechanism-1" to """
+            "ForgeRock-admin@company.com" to """
                 {
-                    "id": "push-mechanism-1",
+                    "id": "ForgeRock-admin@company.com",
                     "issuer": "ForgeRock",
-                    "accountName": "admin@company.com"
+                    "displayIssuer": "ForgeRock Identity",
+                    "accountName": "admin@company.com",
+                    "displayAccountName": "Admin User",
+                    "imageURL": "https://forgerock.com/logo.png",
+                    "backgroundColor": "#00A1DE",
+                    "policies": "{\"biometric\":true}",
+                    "lockingPolicy": "BiometricNotAvailable",
+                    "lock": true
                 }
             """.trimIndent()
         )
@@ -301,33 +412,53 @@ class AuthMigrationTest {
 
         // Capture the stored credential
         val pushSlot = slot<PushCredential>()
-        // Verify the storage function was called with the expected credential
         coVerify(exactly = 1) { anyConstructed<SQLPushStorage>().storePushCredential(capture(pushSlot)) }
 
-        // Verify the captured credential has the expected values
+        // Verify ALL 16 fields are correctly migrated
         val storedCredential = pushSlot.captured
         assertEquals("push-mechanism-1", storedCredential.id)
+        assertEquals("user-99999", storedCredential.userId)
+        assertEquals("push-resource-11111", storedCredential.resourceId)
         assertEquals("ForgeRock", storedCredential.issuer)
+        assertEquals("ForgeRock Identity", storedCredential.displayIssuer)
         assertEquals("admin@company.com", storedCredential.accountName)
+        assertEquals("Admin User", storedCredential.displayAccountName)
+        assertEquals("https://am.example.com/push", storedCredential.serverEndpoint) // Base URL without query params
         assertEquals("sharedSecret123", storedCredential.sharedSecret)
-        assertEquals("https://am.example.com/push", storedCredential.serverEndpoint)
+        assertEquals(testTime, storedCredential.createdAt.time)
+        assertEquals("https://forgerock.com/logo.png", storedCredential.imageURL)
+        assertEquals("#00A1DE", storedCredential.backgroundColor)
+        assertEquals("{\"biometric\":true}", storedCredential.policies)
+        assertEquals("BiometricNotAvailable", storedCredential.lockingPolicy)
+        assertEquals(true, storedCredential.isLocked)
+        assertEquals("PING_AM", storedCredential.platform)
     }
 
     @Test
     fun `migration migrates push notifications correctly`() = runTest {
-        // Given - Legacy repository with notification
+        // Given - Legacy repository with notification with ALL fields
         val notificationTime = System.currentTimeMillis()
+        val sentTime = notificationTime - 5000
+        val respondedTime = notificationTime + 1000
         val notifications = mapOf(
             "notification-1" to """
                 {
                     "id": "notification-1",
                     "credentialId": "push-credential-1",
-                    "messageId": "msg-123",
-                    "challenge": "challenge-data",
                     "ttl": 120,
+                    "messageId": "msg-123",
+                    "messageText": "Login attempt from Chrome",
+                    "customPayload": "custom-data-123",
+                    "challenge": "challenge-data",
+                    "numbersChallenge": "42",
+                    "loadBalancer": "amlb-cookie-value",
+                    "contextInfo": "Location: San Francisco",
+                    "pushType": "challenge",
+                    "timeAdded": $notificationTime,
+                    "sentAt": $sentTime,
+                    "respondedAt": $respondedTime,
                     "approved": false,
-                    "pending": true,
-                    "timeAdded": $notificationTime
+                    "pending": true
                 }
             """.trimIndent()
         )
@@ -355,19 +486,27 @@ class AuthMigrationTest {
 
         // Capture the stored notification
         val notificationSlot = slot<PushNotification>()
-        // Verify the storage function was called with the expected notification
         coVerify(exactly = 1) { anyConstructed<SQLPushStorage>().storePushNotification(capture(notificationSlot)) }
 
-        // Verify the captured notification has the expected values
+        // Verify ALL 17 fields are correctly migrated
         val storedNotification = notificationSlot.captured
         assertEquals("notification-1", storedNotification.id)
         assertEquals("push-credential-1", storedNotification.credentialId)
-        assertEquals("msg-123", storedNotification.messageId)
-        assertEquals("challenge-data", storedNotification.challenge)
         assertEquals(120, storedNotification.ttl)
+        assertEquals("msg-123", storedNotification.messageId)
+        assertEquals("Login attempt from Chrome", storedNotification.messageText)
+        assertEquals("custom-data-123", storedNotification.customPayload)
+        assertEquals("challenge-data", storedNotification.challenge)
+        assertEquals("42", storedNotification.numbersChallenge)
+        assertEquals("amlb-cookie-value", storedNotification.loadBalancer)
+        assertEquals("Location: San Francisco", storedNotification.contextInfo)
+        assertEquals(PushType.CHALLENGE, storedNotification.pushType)
+        assertEquals(notificationTime, storedNotification.createdAt.time)
+        assertEquals(sentTime, storedNotification.sentAt?.time)
+        assertEquals(respondedTime, storedNotification.respondedAt?.time)
+        assertEquals(null, storedNotification.additionalData) // No JSON string in test data
         assertEquals(false, storedNotification.approved)
         assertEquals(true, storedNotification.pending)
-        assertEquals(notificationTime, storedNotification.createdAt.time)
     }
 
     @Test
@@ -587,6 +726,51 @@ class AuthMigrationTest {
     }
 
     @Test
+    fun `migration handles database initialization failure with destructive recovery enabled`() = runTest {
+        // Given - Legacy repository with valid data
+        val mechanisms = mapOf(
+            "totp-mechanism-1" to """
+                {
+                    "type": "totp",
+                    "mechanismUID": "totp-mechanism-1",
+                    "issuer": "Google",
+                    "accountName": "user@example.com",
+                    "secret": "JBSWY3DPEHPK3PXP",
+                    "algorithm": "sha1",
+                    "digits": 6,
+                    "period": 30,
+                    "oathType": "TOTP"
+                }
+            """.trimIndent()
+        )
+
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().isExists() } returns true
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().exportAllData() } returns ExportedData(
+            accounts = emptyMap(),
+            mechanisms = mechanisms,
+            notifications = emptyMap(),
+            deviceToken = emptyMap(),
+            metadata = ExportMetadata(0, 1, 0, false)
+        )
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().deleteLegacyData() } returns Unit
+
+        // With destructive recovery enabled in the migration step configuration,
+        // the storage should be able to recover from database corruption.
+        // This test verifies that the migration configures storage correctly.
+
+        // When
+        val progressList = AuthMigration.migration.migrate(context).toList()
+
+        // Then - Migration should complete successfully with destructive recovery enabled
+        assertTrue(progressList.any { it is MigrationProgress.Started })
+        assertTrue(progressList.any { it is MigrationProgress.Success })
+
+        // Verify storage was initialized with proper configuration
+        coVerify(atLeast = 1) { anyConstructed<SQLOathStorage>().initializeDatabase() }
+        coVerify(atLeast = 1) { anyConstructed<SQLPushStorage>().initializeDatabase() }
+    }
+
+    @Test
     fun `migration cleanup step continues even if cleanup fails`() = runTest {
         // Given - Legacy repository with data but cleanup will fail
         val mechanisms = mapOf(
@@ -626,6 +810,55 @@ class AuthMigrationTest {
         // All steps should complete
         val stepCompletedEvents = progressList.filterIsInstance<MigrationProgress.StepCompleted>()
         assertEquals(5, stepCompletedEvents.size)
+    }
+
+    @Test
+    fun `migration preserves existing valid databases and only removes incompatible ones`() = runTest {
+        // Given - Legacy repository with data to migrate
+        val mechanisms = mapOf(
+            "totp-mechanism-1" to """
+                {
+                    "type": "totp",
+                    "mechanismUID": "totp-mechanism-1",
+                    "issuer": "Google",
+                    "accountName": "user@example.com",
+                    "secret": "JBSWY3DPEHPK3PXP",
+                    "algorithm": "sha1",
+                    "digits": 6,
+                    "period": 30,
+                    "oathType": "TOTP"
+                }
+            """.trimIndent()
+        )
+
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().isExists() } returns true
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().exportAllData() } returns ExportedData(
+            accounts = emptyMap(),
+            mechanisms = mechanisms,
+            notifications = emptyMap(),
+            deviceToken = emptyMap(),
+            metadata = ExportMetadata(0, 1, 0, false)
+        )
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().deleteLegacyData() } returns Unit
+
+        // Mock getAllOathCredentials to return empty list (simulating empty but valid database)
+        coEvery { anyConstructed<SQLOathStorage>().getAllOathCredentials() } returns emptyList()
+        coEvery { anyConstructed<SQLPushStorage>().getAllPushCredentials() } returns emptyList()
+        coEvery { anyConstructed<SQLPushStorage>().getAllPushNotifications() } returns emptyList()
+        coEvery { anyConstructed<SQLPushStorage>().getAllPushDeviceTokens() } returns emptyList()
+
+        // When - The prepareDatabase function will:
+        // 1. Try to open existing databases with current passphrase
+        // 2. Check if they contain data
+        // 3. Keep them if they can be opened (even if empty)
+        // 4. Only delete if they cannot be opened (passphrase mismatch)
+        val progressList = AuthMigration.migration.migrate(context).toList()
+
+        // Then - Migration should complete successfully
+        assertTrue(progressList.any { it is MigrationProgress.Success })
+
+        // Verify migration completed and stored the credential
+        coVerify(atLeast = 1) { anyConstructed<SQLOathStorage>().storeOathCredential(any()) }
     }
 
     // Helper methods
@@ -709,6 +942,133 @@ class AuthMigrationTest {
         val notifications: Map<String, String>,
         val deviceTokens: Map<String, String>
     )
+
+    @Test
+    fun `migration supports custom storage with unencrypted SharedPreferences`() = runTest {
+        // Given - Custom storage data (plain SharedPreferences, no encryption)
+        // This simulates FRAClient built with CustomStorageClient
+        val testTime = System.currentTimeMillis()
+        val mechanisms = mapOf(
+            "custom-totp-1" to """
+                {
+                    "type": "totp",
+                    "mechanismUID": "custom-totp-1",
+                    "issuer": "CustomApp",
+                    "accountName": "custom@example.com",
+                    "secret": "CUSTOMSECRET123",
+                    "algorithm": "sha1",
+                    "digits": 6,
+                    "period": 30,
+                    "oathType": "TOTP",
+                    "uid": "custom-user-123",
+                    "resourceId": "custom-resource-456",
+                    "timeAdded": $testTime
+                }
+            """.trimIndent()
+        )
+        val accounts = mapOf(
+            "CustomApp-custom@example.com" to """
+                {
+                    "id": "CustomApp-custom@example.com",
+                    "issuer": "CustomApp",
+                    "displayIssuer": "Custom Application",
+                    "accountName": "custom@example.com",
+                    "displayAccountName": "Custom User",
+                    "imageURL": "https://custom.com/logo.png",
+                    "backgroundColor": "#FF5733",
+                    "lock": false
+                }
+            """.trimIndent()
+        )
+
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().isExists() } returns true
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().exportAllData() } returns ExportedData(
+            accounts = accounts,
+            mechanisms = mechanisms,
+            notifications = emptyMap(),
+            deviceToken = emptyMap(),
+            metadata = ExportMetadata(1, 1, 0, false)
+        )
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().deleteLegacyData() } returns Unit
+
+        // When
+        val progress = AuthMigration.migration.migrate(context).toList()
+
+        // Then
+        assertTrue("Migration must succeed", progress.any { it is MigrationProgress.Success })
+
+        // Verify the credential was migrated
+        val oathSlot = slot<OathCredential>()
+        coVerify(exactly = 1) { anyConstructed<SQLOathStorage>().storeOathCredential(capture(oathSlot)) }
+
+        val storedCredential = oathSlot.captured
+        assertEquals("custom-totp-1", storedCredential.id)
+        assertEquals("CustomApp", storedCredential.issuer)
+        assertEquals("Custom Application", storedCredential.displayIssuer)
+        assertEquals("custom@example.com", storedCredential.accountName)
+        assertEquals("Custom User", storedCredential.displayAccountName)
+        assertEquals("custom-user-123", storedCredential.userId)
+        assertEquals("custom-resource-456", storedCredential.resourceId)
+    }
+
+    @Test
+    fun `migration supports custom key alias configuration`() = runTest {
+        // Given - Configure migration with custom key alias
+        val customKeyAlias = "com.myapp.custom.STORAGE_KEY"
+        AuthMigration.configure(keyAlias = customKeyAlias)
+
+        val mechanisms = mapOf(
+            "custom-key-totp" to """
+                {
+                    "type": "totp",
+                    "mechanismUID": "custom-key-totp",
+                    "issuer": "CustomKeyApp",
+                    "accountName": "user@customkey.com",
+                    "secret": "CUSTOMKEYSECRET",
+                    "algorithm": "sha1",
+                    "digits": 6,
+                    "period": 30,
+                    "oathType": "TOTP"
+                }
+            """.trimIndent()
+        )
+        val accounts = mapOf(
+            "CustomKeyApp-user@customkey.com" to """
+                {
+                    "id": "CustomKeyApp-user@customkey.com",
+                    "issuer": "CustomKeyApp",
+                    "accountName": "user@customkey.com"
+                }
+            """.trimIndent()
+        )
+
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().isExists() } returns true
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().exportAllData() } returns ExportedData(
+            accounts = accounts,
+            mechanisms = mechanisms,
+            notifications = emptyMap(),
+            deviceToken = emptyMap(),
+            metadata = ExportMetadata(1, 1, 0, false)
+        )
+        coEvery { anyConstructed<LegacyAuthenticationRepository>().deleteLegacyData() } returns Unit
+
+        // When
+        val progress = AuthMigration.migration.migrate(context).toList()
+
+        // Then
+        assertTrue("Migration with custom key alias must succeed", progress.any { it is MigrationProgress.Success })
+
+        // Verify the credential was migrated
+        val oathSlot = slot<OathCredential>()
+        coVerify(exactly = 1) { anyConstructed<SQLOathStorage>().storeOathCredential(capture(oathSlot)) }
+
+        val storedCredential = oathSlot.captured
+        assertEquals("custom-key-totp", storedCredential.id)
+        assertEquals("CustomKeyApp", storedCredential.issuer)
+
+        // Reset configuration to default for other tests
+        AuthMigration.configure()
+    }
 }
 
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4716](https://pingidentity.atlassian.net/browse/SDKS-4716)

# Description

Add disaster recovery when opening the database when migrating Legacy auth data. This prevents the migration to fail when in disaster recovery.

## Problem Scenario
When an app is uninstalled, database files may remain on the device. When the app is reinstalled with the same package name, the Android KeyStore generates a new encryption passphrase, making the old database files unreadable. This causes SQLCipher to throw `SQLiteNotADatabaseException: file is not a database (code 26)`.

## Solution
This function proactively checks if there is an existing database available and backup data or deletes any existing OATH and Push database files if they are unrecoverable before initializing new storage instances, ensuring a clean migration environment.

## Database Files Cleaned
- `pingidentity_oath.db` - OATH/TOTP credentials database
- `pingidentity_push.db` - Push credentials, notifications, and device tokens database
 