### PR TITLE
SDKS-4863 - Remove 'x-requested-with' header from DaVinci IdpRequestHandler

### DIFF
--- a/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/IdpRequestHandler.kt
+++ b/external-idp/src/main/kotlin/com/pingidentity/idp/davinci/IdpRequestHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -36,7 +36,6 @@ interface IdpRequestHandler {
 
         val response = httpClient.request {
             this.url = url
-            header("x-requested-with", "ping-sdk")
             header("Accept", "application/json")
         }
 


### PR DESCRIPTION
…andler

# JIRA Ticket

[SDKS-4863](https://pingidentity.atlassian.net/browse/SDKS-4863)

# Description

SDKS-4863 - Remove 'x-requested-with' header from DaVinci IdpRequestHandler