### PR TITLE
Update CustomTabActivity to finish activity and remove task on redirect

### DIFF
--- a/foundation/browser/src/main/kotlin/com/pingidentity/browser/CustomTabActivity.kt
+++ b/foundation/browser/src/main/kotlin/com/pingidentity/browser/CustomTabActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -97,6 +97,9 @@ internal class CustomTabActivity : ComponentActivity() {
                 val builder = CustomTabsIntent.Builder()
                 BrowserLauncher.customTabsCustomizer(builder)
                 val customTabsIntent = builder.build()
+                customTabsIntent.intent.apply {
+                    setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
                 BrowserLauncher.intentCustomizer(customTabsIntent.intent)
                 logger.d("Intent to launch the browser: ${customTabsIntent.intent}")
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4832](https://pingidentity.atlassian.net/browse/SDKS-4832)

# Description

Set the CustomTabIntent intent to be used with New Task flag and allow the redirect block to call `finishAndRemoveTask()` instead. This will clear the activity and will return it to the original calling activity.

```kotlin
customTabsIntent.intent.apply {
    setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
}
```