### PR TITLE
SDKS-4231 Implement Pushed Authorization Request (PAR) support for OIDC

### DIFF
--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -16,14 +16,18 @@ val headers = headersOf(HttpHeaders.ContentType, "application/json")
 
 fun openIdConfigurationResponse() =
     ByteReadChannel(
-        "{\n" +
-                "  \"authorization_endpoint\" : \"http://auth.test-one-pingone.com/authorize\",\n" +
-                "  \"token_endpoint\" : \"https://auth.test-one-pingone.com/token\",\n" +
-                "  \"userinfo_endpoint\" : \"https://auth.test-one-pingone.com/userinfo\",\n" +
-                "  \"end_session_endpoint\" : \"https://auth.test-one-pingone.com/signoff\",\n" +
-                "  \"revocation_endpoint\" : \"https://auth.test-one-pingone.com/revoke\"\n" +
-                "}",
+        """
+        {
+          "authorization_endpoint" : "http://auth.test-one-pingone.com/authorize",
+          "token_endpoint" : "https://auth.test-one-pingone.com/token",
+          "userinfo_endpoint" : "https://auth.test-one-pingone.com/userinfo",
+          "end_session_endpoint" : "https://auth.test-one-pingone.com/signoff",
+          "revocation_endpoint" : "https://auth.test-one-pingone.com/revoke",
+          "pushed_authorization_request_endpoint" : "https://auth.test-one-pingone.com/par"
+        }
+        """,
     )
+
 
 fun tokeResponse() =
     ByteReadChannel(

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -105,10 +105,14 @@ class DaVinciTest {
                         respond(authorizeResponse(), HttpStatusCode.OK, authorizeResponseHeaders)
                     }
 
+                    "/par" -> {
+                        respond(parResponse(), HttpStatusCode.Created, headers)
+                    }
+
                     else -> {
                         return@MockEngine respond(
                             content =
-                            ByteReadChannel(""),
+                                ByteReadChannel(""),
                             status = HttpStatusCode.InternalServerError,
                         )
                     }
@@ -179,9 +183,9 @@ class DaVinciTest {
             assertTrue(node is ContinueNode)
             assertTrue { (node as ContinueNode).collectors.size == 5 }
             assertEquals("cq77vwelou", node.id)
-            assertEquals("Username/Password Form",  node.name)
-            assertEquals("Test Description",  node.description)
-            assertEquals("CUSTOM_HTML",  node.category)
+            assertEquals("Username/Password Form", node.name)
+            assertEquals("Test Description", node.description)
+            assertEquals("CUSTOM_HTML", node.category)
 
             (node.collectors[0] as? TextCollector)?.value = "My First Name"
             (node.collectors[1] as? PasswordCollector)?.value = "My Password"
@@ -234,7 +238,10 @@ class DaVinciTest {
 
                 //Make sure the request to signoff is made
                 val signOff = mockEngine.requestHistory[5]
-                assertEquals("https://auth.test-one-pingone.com/signoff?id_token_hint=Dummy+IdToken&client_id=test", signOff.url.toString())
+                assertEquals(
+                    "https://auth.test-one-pingone.com/signoff?id_token_hint=Dummy+IdToken&client_id=test",
+                    signOff.url.toString()
+                )
                 assertContains(signOff.headers["Cookie"].toString(), "ST=session_token")
                 //Ensure storage are removed
                 assertNull(tokenStorage.get())
@@ -355,13 +362,17 @@ class DaVinciTest {
                     }
 
                     "/authorize" -> {
-                        respond(ByteReadChannel(readFile("ResponseWithBasicType.json")), HttpStatusCode.OK, authorizeResponseHeaders)
+                        respond(
+                            ByteReadChannel(readFile("ResponseWithBasicType.json")),
+                            HttpStatusCode.OK,
+                            authorizeResponseHeaders
+                        )
                     }
 
                     else -> {
                         return@MockEngine respond(
                             content =
-                            ByteReadChannel(""),
+                                ByteReadChannel(""),
                             status = HttpStatusCode.InternalServerError,
                         )
                     }
@@ -389,7 +400,12 @@ class DaVinciTest {
         assertEquals(11, node.collectors.size)
 
         (node.collectors[0] as? LabelCollector)?.content?.let { assertEquals("Sign On", it) }
-        (node.collectors[1] as? LabelCollector)?.content?.let { assertEquals("Welcome to Ping Identity", it) }
+        (node.collectors[1] as? LabelCollector)?.content?.let {
+            assertEquals(
+                "Welcome to Ping Identity",
+                it
+            )
+        }
 
         (node.collectors[2] as? TextCollector)?.let {
             assertEquals("TEXT", it.type)
@@ -464,4 +480,75 @@ class DaVinciTest {
             assertEquals("default-checkbox", it.value)
         }
     }
+
+    @Test
+    fun `DaVinci with PAR enabled`() = runTest {
+        val tokenStorage = MemoryStorage<Token>()
+        val cookieStorage = MemoryStorage<Cookies>()
+        val daVinci =
+            DaVinci {
+                httpClient = KtorHttpClient(HttpClient(mockEngine))
+                // Oidc as module with PAR enabled
+                module(Oidc) {
+                    clientId = "test"
+                    discoveryEndpoint =
+                        "http://localhost/.well-known/openid-configuration"
+                    scopes = mutableSetOf("openid", "email", "address")
+                    redirectUri = "http://localhost:8080"
+                    storage = { tokenStorage }
+                    par = true // Enable PAR
+                    logger = Logger.STANDARD
+                }
+                module(Cookie) {
+                    storage = { cookieStorage }
+                    persist = mutableListOf("ST")
+                }
+            }
+
+        var node = daVinci.start() // Return first Node
+        assertTrue(node is ContinueNode)
+        assertTrue { (node as ContinueNode).collectors.size == 5 }
+
+        (node.collectors[0] as? TextCollector)?.value = "My First Name"
+        (node.collectors[1] as? PasswordCollector)?.value = "My Password"
+        (node.collectors[2] as? SubmitCollector)?.value = "click me"
+
+        node = node.next()
+        assertTrue(node is SuccessNode)
+
+        mockEngine.requestHistory[0] // well-known
+        val parRequest = mockEngine.requestHistory[1] // par
+        assertEquals("https://auth.test-one-pingone.com/par", parRequest.url.toString())
+        // Verify client_id and response_mode are in the POST body, not URL
+        assertTrue(parRequest.body is FormDataContent)
+        val parBody = parRequest.body as FormDataContent
+        assertEquals("test", parBody.formData["client_id"])
+        assertEquals("code", parBody.formData["response_type"])
+        assertEquals("pi.flow", parBody.formData["response_mode"])
+        assertEquals("openid email address", parBody.formData["scope"])
+        assertEquals("http://localhost:8080", parBody.formData["redirect_uri"])
+        assertNotNull(parBody.formData["code_challenge"])
+        assertEquals("S256", parBody.formData["code_challenge_method"])
+
+
+        // Verify PAR request was made
+        val authorizeRequest =
+            mockEngine.requestHistory[2] // authorize request (after well-known, authorize, customHTMLTemplate)
+        assertEquals(
+            "http://auth.test-one-pingone.com/authorize?response_mode=pi.flow&request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Atest-request-uri&client_id=test",
+            authorizeRequest.url.toString()
+        )
+
+        // The token request should use the PAR flow
+        val tokenRequest = mockEngine.requestHistory[4] // token request
+        assertEquals("https://auth.test-one-pingone.com/token", tokenRequest.url.toString())
+    }
+
+    private fun parResponse(): String =
+        """
+        {
+            "request_uri": "urn:ietf:params:oauth:request_uri:test-request-uri",
+            "expires_in": 60
+        }
+        """.trimIndent()
 }

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Constants.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/Constants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -33,4 +33,6 @@ object Constants {
     const val STATE = "state"
     const val UI_LOCATES = "ui_locales"
     const val ACR_VALUES = "acr_values"
+    const val REQUEST_URI = "request_uri"
+    const val RESPONSE_MODE = "response_mode"
 }

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -110,7 +110,19 @@ class OidcClientConfig {
     lateinit var clientId: String
 
     /**
-     * Set of scopes for OIDC.
+     * Enable PAR (Pushed Authorization Request) RFC 9126.
+     *
+     * When enabled:
+     * - Authorization parameters are pushed to the server before authorization
+     * - Improves security by preventing parameter tampering
+     * - Reduces authorization URL length
+     * - Requires PAR endpoint support from the OIDC provider
+     */
+    var par = false
+
+    /**
+     * Set of OAuth2 scopes to request during authorization.
+     * Common scopes include: "openid", "profile", "email", "offline_access"
      */
     var scopes = mutableSetOf<String>()
 
@@ -257,5 +269,6 @@ class OidcClientConfig {
         this.acrValues = other.acrValues
         this.additionalParameters = other.additionalParameters
         this.httpClient = other.httpClient
+        this.par = other.par
     }
 }

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OpenIdConfiguration.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OpenIdConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -24,6 +24,8 @@ import kotlinx.serialization.Serializable
 data class OpenIdConfiguration(
     @SerialName("authorization_endpoint")
     val authorizationEndpoint: String = "",
+    @SerialName("pushed_authorization_request_endpoint")
+    val pushAuthorizationRequestEndpoint: String = "",
     @SerialName("token_endpoint")
     val tokenEndpoint: String = "",
     @SerialName("userinfo_endpoint")

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/module/OidcRequest.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/module/OidcRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,6 +7,8 @@
 
 package com.pingidentity.oidc.module
 
+import androidx.core.net.toUri
+import com.pingidentity.network.isSuccess
 import com.pingidentity.oidc.Constants.ACR_VALUES
 import com.pingidentity.oidc.Constants.CLIENT_ID
 import com.pingidentity.oidc.Constants.CODE
@@ -17,52 +19,118 @@ import com.pingidentity.oidc.Constants.LOGIN_HINT
 import com.pingidentity.oidc.Constants.NONCE
 import com.pingidentity.oidc.Constants.PROMPT
 import com.pingidentity.oidc.Constants.REDIRECT_URI
+import com.pingidentity.oidc.Constants.REQUEST_URI
+import com.pingidentity.oidc.Constants.RESPONSE_MODE
 import com.pingidentity.oidc.Constants.RESPONSE_TYPE
 import com.pingidentity.oidc.Constants.SCOPE
 import com.pingidentity.oidc.Constants.STATE
 import com.pingidentity.oidc.Constants.UI_LOCATES
 import com.pingidentity.oidc.OidcClientConfig
 import com.pingidentity.oidc.Pkce
+import com.pingidentity.oidc.exception.AuthorizeException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import com.pingidentity.network.HttpRequest as Request
 
 /**
- * Function to populate an OIDC request with the necessary parameters.
+ * Builds OIDC authorization request parameters using the provided configuration.
+ *
+ * This function populates all required and optional OAuth2/OIDC parameters for an authorization request:
+ * - Required parameters: client_id, response_type, scope, redirect_uri, PKCE parameters
+ * - Optional parameters: state, nonce, login_hint, prompt, display, UI locales, ACR values
+ * - Additional custom parameters from configuration
+ * - Extra parameters passed to this specific request
+ *
+ * @param pkce PKCE (Proof Key for Code Exchange) parameters for enhanced security
+ * @param extraParameters Additional parameters specific to this authorization request
+ * @param onParam Callback function to handle each parameter (name, value) pair
  */
-internal val populateRequest: OidcClientConfig.(Request, Map<String, String>, Pkce) -> Request = { request, parameters, pkce ->
-
-    request.url = openId.authorizationEndpoint
-    request.parameter(CLIENT_ID, clientId)
-    request.parameter(RESPONSE_TYPE, CODE)
-    request.parameter(SCOPE, scopes.joinToString(" "))
-    request.parameter(REDIRECT_URI, redirectUri)
-    request.parameter(CODE_CHALLENGE, pkce.codeChallenge)
-    request.parameter(CODE_CHALLENGE_METHOD, pkce.codeChallengeMethod)
+internal fun OidcClientConfig.buildAuthorizeParams(
+    pkce: Pkce,
+    extraParameters: Map<String, String> = emptyMap(),
+    onParam: (String, String) -> Unit,
+) {
+    onParam(CLIENT_ID, clientId)
+    onParam(RESPONSE_TYPE, CODE)
+    onParam(SCOPE, scopes.joinToString(" "))
+    onParam(REDIRECT_URI, redirectUri)
+    onParam(CODE_CHALLENGE, pkce.codeChallenge)
+    onParam(CODE_CHALLENGE_METHOD, pkce.codeChallengeMethod)
     acrValues?.let {
-        request.parameter(ACR_VALUES, it)
+        onParam(ACR_VALUES, it)
     }
     display?.let {
-        request.parameter(DISPLAY, it)
+        onParam(DISPLAY, it)
     }
     additionalParameters.forEach { (key, value) ->
-        request.parameter(key, value)
+        onParam(key, value)
     }
     loginHint?.let {
-        request.parameter(LOGIN_HINT, it)
+        onParam(LOGIN_HINT, it)
     }
     state?.let {
-        request.parameter(STATE, it)
+        onParam(STATE, it)
     }
     nonce?.let {
-        request.parameter(NONCE, it)
+        onParam(NONCE, it)
     }
     prompt?.let {
-        request.parameter(PROMPT, it)
+        onParam(PROMPT, it)
     }
     uiLocales?.let {
-        request.parameter(UI_LOCATES, it)
+        onParam(UI_LOCATES, it)
     }
-    parameters.forEach { (key, value) ->
-        request.parameter(key, value)
+    extraParameters.forEach { (key, value) ->
+        onParam(key, value)
     }
-    request
 }
+
+
+/**
+ * Internal function to populate an OIDC authorization request with the necessary parameters.
+ *
+ * This function handles both standard OAuth2 authorization requests and PAR (Pushed Authorization Request):
+ *
+ * **Standard Flow:**
+ * - Builds authorization URL with all parameters in the query string
+ * - Suitable for most OAuth2/OIDC implementations
+ *
+ * **PAR Flow (RFC 9126):**
+ * - First pushes authorization parameters to the PAR endpoint via POST
+ * - Receives a request_uri that references the pushed parameters
+ * - Uses the request_uri in the actual authorization request
+ * - Provides better security and reduces URL length
+ *
+ * @return The populated request ready for execution
+ * @throws AuthorizeException If PAR request fails when PAR is enabled
+ */
+val populateRequest: suspend OidcClientConfig.(Request, Map<String, String>, Pkce) -> Request =
+    { request, parameters, pkce ->
+        if (par) {
+            val response = httpClient.request {
+                url = openId.pushAuthorizationRequestEndpoint
+                form {
+                    request.url.toUri().getQueryParameter(RESPONSE_MODE)
+                        ?.let { put(RESPONSE_MODE, it) }
+                    buildAuthorizeParams(pkce, parameters) { k, v -> put(k, v) }
+                }
+            }
+            if (response.status.isSuccess()) {
+                val res: String = response.body()
+                val json = Json.parseToJsonElement(res).jsonObject
+                val requestUri = json[REQUEST_URI]?.jsonPrimitive?.content
+                    ?: throw AuthorizeException("PAR response missing required 'request_uri' field")
+                request.url = openId.authorizationEndpoint
+                request.parameter(REQUEST_URI, requestUri)
+                request.parameter(CLIENT_ID, clientId)
+            } else {
+                val errorBody: String = response.body()
+                throw AuthorizeException("Failed to create par request: ${response.status} - $errorBody")
+            }
+        } else {
+            request.url = openId.authorizationEndpoint
+            buildAuthorizeParams(pkce, parameters) { k, v -> request.parameter(k, v) }
+        }
+        request
+    }

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientConfigTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientConfigTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -146,6 +146,7 @@ class OidcClientConfigTest {
                 storage { fileName = "test" }
                 discoveryEndpoint = "http://localhost"
                 clientId = "clientId"
+                par = true
                 scope("openid")
                 redirectUri = "http://localhost/callback"
                 loginHint = "loginHint"
@@ -168,6 +169,7 @@ class OidcClientConfigTest {
         assertEquals(otherConfig.storage, oidcClientConfig.storage)
         assertEquals(otherConfig.discoveryEndpoint, oidcClientConfig.discoveryEndpoint)
         assertEquals(otherConfig.clientId, oidcClientConfig.clientId)
+        assertEquals(otherConfig.par, oidcClientConfig.par)
         assertEquals(otherConfig.scopes, oidcClientConfig.scopes)
         assertEquals(otherConfig.redirectUri, oidcClientConfig.redirectUri)
         assertEquals(otherConfig.loginHint, oidcClientConfig.loginHint)
@@ -192,6 +194,7 @@ class OidcClientConfigTest {
                 storage = { mockk<StorageDelegate<Token>>() }
                 discoveryEndpoint = "http://localhost"
                 clientId = "clientId"
+                par = true
                 scope("openid")
                 redirectUri = "http://localhost/callback"
                 signOutRedirectUri = "http://localhost/signout"
@@ -206,9 +209,9 @@ class OidcClientConfigTest {
                 httpClient = mockk()
             }
 
-        //Ensure there are 21 properties in the class for now.
+        //Ensure there are 22 properties in the class for now.
         val clazz: KClass<OidcClientConfig> = OidcClientConfig::class
-        assertEquals(clazz.memberProperties.size, 21)
+        assertEquals(clazz.memberProperties.size, 22)
 
         val clonedConfig = oidcClientConfig.clone()
 
@@ -220,6 +223,7 @@ class OidcClientConfigTest {
         assertFalse(oidcClientConfig.isTokenStorageInitialized())
         assertEquals(oidcClientConfig.discoveryEndpoint, clonedConfig.discoveryEndpoint)
         assertEquals(oidcClientConfig.clientId, clonedConfig.clientId)
+        assertEquals(oidcClientConfig.par, clonedConfig.par)
         assertEquals(oidcClientConfig.scopes, clonedConfig.scopes)
         assertEquals(oidcClientConfig.redirectUri, clonedConfig.redirectUri)
         assertEquals(oidcClientConfig.signOutRedirectUri, clonedConfig.signOutRedirectUri)
@@ -245,6 +249,7 @@ class OidcClientConfigTest {
                 storage = { mockk<StorageDelegate<Token>>() }
                 discoveryEndpoint = "http://localhost"
                 clientId = "clientId"
+                par = true
                 scope("openid")
                 redirectUri = "http://localhost/callback"
                 signOutRedirectUri = "http://localhost/signout"
@@ -269,6 +274,7 @@ class OidcClientConfigTest {
         assertEquals(oidcClientConfig.tokenStorage, clonedConfig.tokenStorage)
         assertEquals(oidcClientConfig.discoveryEndpoint, clonedConfig.discoveryEndpoint)
         assertEquals(oidcClientConfig.clientId, clonedConfig.clientId)
+        assertEquals(oidcClientConfig.par, clonedConfig.par)
         assertEquals(oidcClientConfig.scopes, clonedConfig.scopes)
         assertEquals(oidcClientConfig.redirectUri, clonedConfig.redirectUri)
         assertEquals(oidcClientConfig.signOutRedirectUri, clonedConfig.signOutRedirectUri)

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,8 +8,10 @@
 package com.pingidentity.oidc
 
 import com.pingidentity.network.ktor.KtorHttpClient
+import com.pingidentity.network.ktor.KtorHttpRequest
 import com.pingidentity.oidc.agent.BrowserConfig
 import com.pingidentity.oidc.agent.browser
+import com.pingidentity.oidc.module.populateRequest
 import com.pingidentity.storage.MemoryStorage
 import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
@@ -30,6 +32,8 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Rule
 import org.junit.rules.TestWatcher
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -47,6 +51,20 @@ class TestAgent(agent: Agent<BrowserConfig>) : Agent<BrowserConfig> by agent {
     }
 }
 
+/**
+ * A test agent that exercises the PAR (Pushed Authorization Request) flow by calling
+ * [populateRequest] on the OIDC config before returning an [AuthCode].
+ */
+class PARTestAgent(agent: Agent<BrowserConfig>) : Agent<BrowserConfig> by agent {
+    override suspend fun authorize(oidcConfig: OidcConfig<BrowserConfig>): AuthCode {
+        val pkce = Pkce.generate()
+        val request = KtorHttpRequest()
+        oidcConfig.oidcClientConfig.populateRequest(request, emptyMap(), pkce)
+        return AuthCode("test-code", pkce.codeVerifier)
+    }
+}
+
+@RunWith(RobolectricTestRunner::class)
 class OidcClientTest {
     private lateinit var mockEngine: MockEngine
     private lateinit var testAgent: Agent<BrowserConfig>
@@ -614,6 +632,103 @@ class OidcClientTest {
                 HttpStatusCode.Unauthorized.value,
                 (result.value as OidcError.ApiError).code,
             )
+        }
+
+    @Test
+    fun `token with PAR enabled pushes auth params to PAR endpoint`() =
+        runTest {
+            mockEngine =
+                MockEngine { request ->
+                    when (request.url.encodedPath) {
+                        "/openid-configuration" -> {
+                            respond(openIdConfigurationWithParResponse(), HttpStatusCode.OK, headers)
+                        }
+
+                        "/par" -> {
+                            respond(parResponse(), HttpStatusCode.OK, headers)
+                        }
+
+                        "/token" -> {
+                            respond(tokeResponse(), HttpStatusCode.OK, headers)
+                        }
+
+                        else -> {
+                            return@MockEngine respond(
+                                content = ByteReadChannel(""),
+                                status = HttpStatusCode.InternalServerError,
+                            )
+                        }
+                    }
+                }
+
+            val oidcClient =
+                OidcClient {
+                    httpClient = KtorHttpClient(HttpClient(mockEngine))
+                    discoveryEndpoint = "http://localhost/openid-configuration"
+                    redirectUri = "http://localhost/redirect"
+                    clientId = "test-client-id"
+                    scopes = mutableSetOf("openid", "profile")
+                    storage = { MemoryStorage() }
+                    par = true
+                    updateAgent(PARTestAgent(browser))
+                }
+
+            val result = oidcClient.token()
+            assertTrue(result is Success<Token>)
+
+            // Verify PAR request was made (index 0=discovery, 1=PAR, 2=token)
+            val parRequest = mockEngine.requestHistory[1]
+            assertEquals("/par", parRequest.url.encodedPath)
+            assertTrue(parRequest.body is FormDataContent)
+            val parBody = parRequest.body as FormDataContent
+            assertEquals("test-client-id", parBody.formData["client_id"])
+            assertEquals("code", parBody.formData["response_type"])
+            assertEquals("openid profile", parBody.formData["scope"])
+            assertEquals("http://localhost/redirect", parBody.formData["redirect_uri"])
+            assertNotNull(parBody.formData["code_challenge"])
+            assertEquals("S256", parBody.formData["code_challenge_method"])
+
+            // Verify token was obtained successfully
+            assertEquals("Dummy AccessToken", result.value.accessToken)
+        }
+
+    @Test
+    fun `token with PAR enabled fails when PAR endpoint returns an error`() =
+        runTest {
+            mockEngine =
+                MockEngine { request ->
+                    when (request.url.encodedPath) {
+                        "/openid-configuration" -> {
+                            respond(openIdConfigurationWithParResponse(), HttpStatusCode.OK, headers)
+                        }
+
+                        "/par" -> {
+                            respond("", HttpStatusCode.BadRequest, headers)
+                        }
+
+                        else -> {
+                            return@MockEngine respond(
+                                content = ByteReadChannel(""),
+                                status = HttpStatusCode.InternalServerError,
+                            )
+                        }
+                    }
+                }
+
+            val oidcClient =
+                OidcClient {
+                    httpClient = KtorHttpClient(HttpClient(mockEngine))
+                    discoveryEndpoint = "http://localhost/openid-configuration"
+                    redirectUri = "http://localhost/redirect"
+                    clientId = "test-client-id"
+                    scopes = mutableSetOf("openid", "profile")
+                    storage = { MemoryStorage() }
+                    par = true
+                    updateAgent(PARTestAgent(browser))
+                }
+
+            val result = oidcClient.token()
+            assertTrue(result is Failure<OidcError>)
         }
 
     @TestRailCase(22094)

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
@@ -7,7 +7,11 @@
 
 package com.pingidentity.oidc
 
+import android.app.Application
+import android.content.Context
 import android.net.Uri
+import androidx.test.core.app.ApplicationProvider
+import com.pingidentity.android.ContextProvider
 import com.pingidentity.browser.BrowserCanceledException
 import com.pingidentity.browser.BrowserLauncher
 import com.pingidentity.logger.CONSOLE
@@ -19,6 +23,7 @@ import com.pingidentity.utils.Result.Success
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.request.forms.FormDataContent
 import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import io.mockk.coEvery
@@ -29,6 +34,8 @@ import io.mockk.slot
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import java.net.URL
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -38,13 +45,16 @@ import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+@RunWith(RobolectricTestRunner::class)
 class OidcWebClientTest {
 
     private lateinit var mockEngine: MockEngine
+    private val context: Context by lazy { ApplicationProvider.getApplicationContext<Application>() }
 
     @BeforeTest
     fun setUp() {
 
+        ContextProvider.init(context)
         mockkObject(BrowserLauncher)
 
         mockEngine =
@@ -90,7 +100,7 @@ class OidcWebClientTest {
     fun `authorize returns success when OidcFlow succeeds`() = runTest {
 
         val mockUri = mockk<Uri>()
-        coEvery { BrowserLauncher.launch(any<URL>()) } returns Result.success(mockUri)
+        coEvery { BrowserLauncher.launch(any<URL>(), any()) } returns Result.success(mockUri)
 
         every { mockUri.getQueryParameter(Constants.CODE) } returns "test-code"
 
@@ -132,7 +142,7 @@ class OidcWebClientTest {
 
     @Test
     fun `authorize returns failure when BrowserLauncher fails`() = runTest {
-        coEvery { BrowserLauncher.launch(any<URL>()) } returns Result.failure(
+        coEvery { BrowserLauncher.launch(any<URL>(), any()) } returns Result.failure(
             BrowserCanceledException()
         )
 
@@ -156,7 +166,7 @@ class OidcWebClientTest {
     @Test
     fun `authorize returns failure when BrowserLauncher returns Uri without code`() = runTest {
         val mockUri = mockk<Uri>()
-        coEvery { BrowserLauncher.launch(any<URL>()) } returns Result.success(mockUri)
+        coEvery { BrowserLauncher.launch(any<URL>(), any()) } returns Result.success(mockUri)
 
         every { mockUri.getQueryParameter(Constants.CODE) } returns null
 
@@ -181,7 +191,7 @@ class OidcWebClientTest {
     fun `authorize correctly passes custom parameters to flow`() = runTest {
         val mockUri = mockk<Uri>()
         val urlSlot = slot<URL>()
-        coEvery { BrowserLauncher.launch(capture(urlSlot)) } returns Result.success(mockUri)
+        coEvery { BrowserLauncher.launch(capture(urlSlot), any()) } returns Result.success(mockUri)
         every { mockUri.getQueryParameter(Constants.CODE) } returns "test-code"
 
         val web = OidcWebClient {
@@ -230,6 +240,78 @@ class OidcWebClientTest {
         assertTrue(url.query.contains("login_hint=test-login"))
         assertTrue(url.query.contains("acr_values=urn%3Amace%3Aincommon%3Aiap%3Asilver"))
         assertTrue(url.query.contains("additional=additionalvalue"))
+        assertTrue(url.query.contains("custom=value"))
+    }
+
+    @Test
+    fun `authorize with PAR pushes params to PAR endpoint and uses request_uri in authorization URL`() = runTest {
+        val parMockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/.well-known/openid-configuration" -> {
+                    respond(openIdConfigurationWithParResponse(), HttpStatusCode.OK, headers)
+                }
+
+                "/par" -> {
+                    respond(parResponse(), HttpStatusCode.OK, headers)
+                }
+
+                "/token" -> {
+                    respond(tokeResponse(), HttpStatusCode.OK, headers)
+                }
+
+                else -> {
+                    respond(
+                        content = ByteReadChannel(""),
+                        status = HttpStatusCode.InternalServerError,
+                    )
+                }
+            }
+        }
+
+        val mockUri = mockk<Uri>()
+        val urlSlot = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(urlSlot), any()) } returns Result.success(mockUri)
+        every { mockUri.getQueryParameter(Constants.CODE) } returns "test-code"
+
+        val web = OidcWebClient {
+            httpClient = KtorHttpClient(HttpClient(parMockEngine))
+            logger = Logger.CONSOLE
+            module(Oidc) {
+                clientId = "test-client"
+                discoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+                scopes = mutableSetOf("openid", "profile")
+                redirectUri = "https://example.com/callback"
+                storage = { MemoryStorage() }
+                par = true
+            }
+        }
+
+        val result = web.authorize()
+        assertTrue(result.isSuccess)
+
+        // Verify PAR request (index 0=well-known, 1=par)
+        val parRequest = parMockEngine.requestHistory[1]
+        assertEquals("https://auth.test-one-pingone.com/par", parRequest.url.toString())
+        assertTrue(parRequest.body is FormDataContent)
+        val parBody = parRequest.body as FormDataContent
+        assertEquals("test-client", parBody.formData["client_id"])
+        assertEquals("code", parBody.formData["response_type"])
+        assertEquals("openid profile", parBody.formData["scope"])
+        assertEquals("https://example.com/callback", parBody.formData["redirect_uri"])
+        assertNotNull(parBody.formData["code_challenge"])
+        assertEquals("S256", parBody.formData["code_challenge_method"])
+
+        // Verify the browser was launched with request_uri and client_id only (PAR flow)
+        val launchedUrl = urlSlot.captured
+        val urlQuery = launchedUrl.query ?: ""
+        assertContains(urlQuery, "request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Atest-request-uri")
+        assertContains(urlQuery, "client_id=test-client")
+        // Regular auth params must NOT be in the browser URL when PAR is used
+        assertTrue(!urlQuery.contains("scope="))
+        assertTrue(!urlQuery.contains("redirect_uri="))
+        assertTrue(!urlQuery.contains("code_challenge="))
+
+        parMockEngine.close()
     }
 
 }

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OpenIdConfigurationTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OpenIdConfigurationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -9,7 +9,6 @@ package com.pingidentity.oidc
 
 import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.Rule
 import org.junit.rules.TestWatcher
@@ -27,6 +26,7 @@ class OpenIdConfigurationTest {
     fun `OpenIdConfiguration default constructor should set all fields to empty strings`() {
         val config = OpenIdConfiguration()
         assertEquals("", config.authorizationEndpoint)
+        assertEquals("", config.pushAuthorizationRequestEndpoint)
         assertEquals("", config.tokenEndpoint)
         assertEquals("", config.userinfoEndpoint)
         assertEquals("", config.endSessionEndpoint)
@@ -39,6 +39,7 @@ class OpenIdConfigurationTest {
     fun `OpenIdConfiguration should serialize to JSON correctly`() {
         val config = OpenIdConfiguration(
             authorizationEndpoint = "https://auth.example.com",
+            pushAuthorizationRequestEndpoint = "https://par.example.com",
             tokenEndpoint = "https://token.example.com",
             userinfoEndpoint = "https://userinfo.example.com",
             endSessionEndpoint = "https://endsession.example.com",
@@ -47,7 +48,7 @@ class OpenIdConfigurationTest {
         )
         val json = Json.encodeToString(config)
         assertEquals(
-            """{"authorization_endpoint":"https://auth.example.com","token_endpoint":"https://token.example.com","userinfo_endpoint":"https://userinfo.example.com","end_session_endpoint":"https://endsession.example.com","ping_end_idp_session_endpoint":"https://pingend.example.com","revocation_endpoint":"https://revoke.example.com"}""",
+            """{"authorization_endpoint":"https://auth.example.com","pushed_authorization_request_endpoint":"https://par.example.com","token_endpoint":"https://token.example.com","userinfo_endpoint":"https://userinfo.example.com","end_session_endpoint":"https://endsession.example.com","ping_end_idp_session_endpoint":"https://pingend.example.com","revocation_endpoint":"https://revoke.example.com"}""",
             json
         )
     }
@@ -55,9 +56,10 @@ class OpenIdConfigurationTest {
     @TestRailCase(22108)
     @Test
     fun `OpenIdConfiguration should deserialize from JSON correctly`() {
-        val json = """{"authorization_endpoint":"https://auth.example.com","token_endpoint":"https://token.example.com","userinfo_endpoint":"https://userinfo.example.com","end_session_endpoint":"https://endsession.example.com","ping_end_idp_session_endpoint":"https://pingend.example.com","revocation_endpoint":"https://revoke.example.com"}"""
+        val json = """{"authorization_endpoint":"https://auth.example.com","pushed_authorization_request_endpoint":"https://par.example.com","token_endpoint":"https://token.example.com","userinfo_endpoint":"https://userinfo.example.com","end_session_endpoint":"https://endsession.example.com","ping_end_idp_session_endpoint":"https://pingend.example.com","revocation_endpoint":"https://revoke.example.com"}"""
         val config = Json.decodeFromString<OpenIdConfiguration>(json)
         assertEquals("https://auth.example.com", config.authorizationEndpoint)
+        assertEquals("https://par.example.com", config.pushAuthorizationRequestEndpoint)
         assertEquals("https://token.example.com", config.tokenEndpoint)
         assertEquals("https://userinfo.example.com", config.userinfoEndpoint)
         assertEquals("https://endsession.example.com", config.endSessionEndpoint)
@@ -71,6 +73,7 @@ class OpenIdConfigurationTest {
         val json = """{"authorization_endpoint":"https://auth.example.com"}"""
         val config = Json.decodeFromString<OpenIdConfiguration>(json)
         assertEquals("https://auth.example.com", config.authorizationEndpoint)
+        assertEquals("", config.pushAuthorizationRequestEndpoint)
         assertEquals("", config.tokenEndpoint)
         assertEquals("", config.userinfoEndpoint)
         assertEquals("", config.endSessionEndpoint)

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/Response.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -54,3 +54,25 @@ fun tokeErrorResponse() =
             "  \"error\" : \"Invalid Grant\"\n" +
             "}",
     )
+
+fun openIdConfigurationWithParResponse() =
+    ByteReadChannel(
+        "{\n" +
+            "  \"authorization_endpoint\" : \"http://auth.test-one-pingone.com/authorize\",\n" +
+            "  \"pushed_authorization_request_endpoint\" : \"https://auth.test-one-pingone.com/par\",\n" +
+            "  \"token_endpoint\" : \"https://auth.test-one-pingone.com/token\",\n" +
+            "  \"userinfo_endpoint\" : \"https://auth.test-one-pingone.com/userinfo\",\n" +
+            "  \"end_session_endpoint\" : \"https://auth.test-one-pingone.com/signoff\",\n" +
+            "  \"ping_end_idp_session_endpoint\" : \"https://auth.test-one-pingone.com/idp/signoff\",\n" +
+            "  \"revocation_endpoint\" : \"https://auth.test-one-pingone.com/revoke\"\n" +
+            "}",
+    )
+
+fun parResponse() =
+    ByteReadChannel(
+        "{\n" +
+            "  \"request_uri\" : \"urn:ietf:params:oauth:request_uri:test-request-uri\",\n" +
+            "  \"expires_in\" : 60\n" +
+            "}",
+    )
+

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Agent.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Agent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -13,22 +13,10 @@ import com.pingidentity.journey.Constants.ACCEPT_API_VERSION
 import com.pingidentity.journey.Constants.RESOURCE_2_1_PROTOCOL_1_0
 import com.pingidentity.oidc.Agent
 import com.pingidentity.oidc.AuthCode
-import com.pingidentity.oidc.Constants
-import com.pingidentity.oidc.Constants.ACR_VALUES
-import com.pingidentity.oidc.Constants.CLIENT_ID
-import com.pingidentity.oidc.Constants.CODE
-import com.pingidentity.oidc.Constants.CODE_CHALLENGE
-import com.pingidentity.oidc.Constants.CODE_CHALLENGE_METHOD
-import com.pingidentity.oidc.Constants.DISPLAY
-import com.pingidentity.oidc.Constants.LOGIN_HINT
-import com.pingidentity.oidc.Constants.NONCE
-import com.pingidentity.oidc.Constants.PROMPT
-import com.pingidentity.oidc.Constants.REDIRECT_URI
-import com.pingidentity.oidc.Constants.RESPONSE_TYPE
-import com.pingidentity.oidc.Constants.UI_LOCATES
 import com.pingidentity.oidc.OidcConfig
 import com.pingidentity.oidc.Pkce
 import com.pingidentity.oidc.exception.AuthorizeException
+import com.pingidentity.oidc.module.populateRequest
 import com.pingidentity.orchestrate.EmptySession
 import com.pingidentity.orchestrate.Session
 import java.net.HttpURLConnection
@@ -56,38 +44,16 @@ internal fun sessionAgent(
                 throw AuthorizeException("No Session, please start Journey flow to authenticate.")
             }
             val pkce = Pkce.generate()
-            val response = oidcConfig.oidcClientConfig.httpClient.request {
-                url = oidcConfig.oidcClientConfig.openId.authorizationEndpoint
-                parameter(CLIENT_ID, oidcConfig.oidcClientConfig.clientId)
-                parameter(Constants.SCOPE, oidcConfig.oidcClientConfig.scopes.joinToString(" "))
-                parameter(RESPONSE_TYPE, CODE)
-                parameter(REDIRECT_URI, oidcConfig.oidcClientConfig.redirectUri)
-                parameter(CODE_CHALLENGE, pkce.codeChallenge)
-                parameter(CODE_CHALLENGE_METHOD, pkce.codeChallengeMethod)
-                oidcConfig.oidcClientConfig.acrValues?.let {
-                    parameter(ACR_VALUES, it)
-                }
-                oidcConfig.oidcClientConfig.display?.let {
-                    parameter(DISPLAY, it)
-                }
-                oidcConfig.oidcClientConfig.additionalParameters.forEach { (key, value) ->
-                    parameter(key, value)
-                }
-                oidcConfig.oidcClientConfig.loginHint?.let {
-                    parameter(LOGIN_HINT, it)
-                }
-                oidcConfig.oidcClientConfig.nonce?.let {
-                    parameter(NONCE, it)
-                }
-                oidcConfig.oidcClientConfig.prompt?.let {
-                    parameter(PROMPT, it)
-                }
-                oidcConfig.oidcClientConfig.uiLocales?.let {
-                    parameter(UI_LOCATES, it)
-                }
-                header(ACCEPT_API_VERSION, RESOURCE_2_1_PROTOCOL_1_0)
-                header(cookieName, session.value)
-            }
+
+            // Create a fresh request, populate it (handles both PAR and standard flow),
+            // then attach Journey-specific headers before sending.
+            val request = oidcConfig.oidcClientConfig.httpClient.request()
+            with(oidcConfig.oidcClientConfig) { populateRequest(request, emptyMap(), pkce) }
+            request.header(ACCEPT_API_VERSION, RESOURCE_2_1_PROTOCOL_1_0)
+            request.header(cookieName, session.value)
+
+            val response = oidcConfig.oidcClientConfig.httpClient.request(request)
+
             if (response.status == HttpURLConnection.HTTP_MOVED_TEMP) { // Check if the status is redirect
                 val locationHeader = response.header("Location")
                 locationHeader?.let {

--- a/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.Response.kt
+++ b/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.Response.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,7 +22,8 @@ fun openIdConfigurationResponse() =
           "token_endpoint" : "https://auth.test-one-pingone.com/access_token",
           "userinfo_endpoint" : "https://auth.test-one-pingone.com/userinfo",
           "end_session_endpoint" : "https://auth.test-one-pingone.com/signoff",
-          "revocation_endpoint" : "https://auth.test-one-pingone.com/revoke"
+          "revocation_endpoint" : "https://auth.test-one-pingone.com/revoke",
+          "pushed_authorization_request_endpoint" : "https://auth.test-one-pingone.com/par"
         }
         """,
     )

--- a/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
+++ b/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -101,6 +101,10 @@ class JourneyTest {
 
                     "/am/json/realms/root/sessions" -> {
                         respond("", HttpStatusCode.OK, headers)
+                    }
+
+                    "/par" -> {
+                        respond(parResponse(), HttpStatusCode.Created, headers)
                     }
 
                     "/am/json/realms/root/authenticate" -> {
@@ -874,4 +878,77 @@ class JourneyTest {
 
         customMockEngine.close()
     }
+
+    @Test
+    fun `Journey with PAR enabled`() = runTest {
+        val tokenStorage = MemoryStorage<Token>()
+        val sessionStorage = MemoryStorage<SSOToken>()
+        val journey =
+            Journey {
+                serverUrl = "http://localhost/am"
+                logger = Logger.CONSOLE
+                httpClient = KtorHttpClient(HttpClient(mockEngine) {
+                    followRedirects = false
+                })
+                // Oidc as module with PAR enabled
+                module(Oidc) {
+                    clientId = "test"
+                    discoveryEndpoint =
+                        "http://localhost/.well-known/openid-configuration"
+                    scopes = mutableSetOf("openid", "email", "address")
+                    redirectUri = "http://localhost:8080"
+                    storage = { tokenStorage }
+                    par = true // Enable PAR
+                }
+                module(Session) {
+                    storage = { sessionStorage }
+                }
+            }
+
+        var node = journey.start("myLogin") // Return first Node
+        assertTrue(node is ContinueNode)
+        assertTrue { (node as ContinueNode).callbacks.size == 2 }
+
+        (node.callbacks[0] as? NameCallback)?.name = "My First Name"
+        (node.callbacks[1] as? PasswordCallback)?.password = "My Password"
+
+        node = node.next()
+        assertTrue(node is SuccessNode)
+
+        mockEngine.requestHistory[0] // well-known
+        val startRequest = mockEngine.requestHistory[1] // authenticate
+        assertContains(startRequest.url.encodedQuery, "authIndexValue=myLogin")
+        assertContains(startRequest.url.encodedQuery, "authIndexType=service")
+
+        val user = journey.user()
+        assertEquals("Dummy AccessToken", (user?.token() as Result.Success).value.accessToken)
+        assertEquals("Dummy Session Token", user.session().value)
+
+        // Verify PAR request was made
+        val parRequest = mockEngine.requestHistory[3] // PAR request
+        assertEquals("https://auth.test-one-pingone.com/par", parRequest.url.toString())
+        assertTrue(parRequest.body is FormDataContent)
+
+        // Verify client_id and other parameters are in the POST body, not URL
+        val parBody = parRequest.body as FormDataContent
+        assertEquals("test", parBody.formData["client_id"])
+        assertEquals("code", parBody.formData["response_type"])
+        assertEquals("openid email address", parBody.formData["scope"])
+        assertEquals("http://localhost:8080", parBody.formData["redirect_uri"])
+        assertNotNull(parBody.formData["code_challenge"])
+        assertEquals("S256", parBody.formData["code_challenge_method"])
+
+        // Verify authorize request uses request_uri parameter
+        val authorizeRequest = mockEngine.requestHistory[4] // authorize request
+        assertContains(authorizeRequest.url.encodedQuery, "request_uri=urn%3Aietf%3Aparams%3Aoauth%3Arequest_uri%3Atest-request-uri")
+        assertContains(authorizeRequest.url.encodedQuery, "client_id=test")
+    }
+
+    private fun parResponse(): String =
+        """
+        {
+            "request_uri": "urn:ietf:params:oauth:request_uri:test-request-uri",
+            "expires_in": 60
+        }
+        """.trimIndent()
 }


### PR DESCRIPTION


# JIRA Ticket

[SDKS-4231](https://pingidentity.atlassian.net/browse/SDKS-4231)

# Description

Introduced support for PAR (RFC 9126) to improve security and handle large authorization request payloads by pushing parameters to the server prior to authorization.

Key changes:
- Added `par` configuration flag to `OidcClientConfig` and updated `OpenIdConfiguration` to include the `pushed_authorization_request_endpoint`.
- Refactored authorization request building logic into `buildAuthorizeParams` and updated `populateRequest` to handle both standard and PAR flows.
- Implemented PAR logic to POST parameters to the provider and utilize the returned `request_uri` in the subsequent authorization call.
- Updated `Agent.kt` in the Journey module to use the centralized `populateRequest` logic, ensuring PAR support is available across modules.
- Added comprehensive unit and integration tests in `DaVinciTest`, `JourneyTest`, and `OidcWebClientTest` to verify PAR execution and parameter handling.
- Updated license headers to include 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pushed Authorization Request (PAR) support. Enable via the OIDC config (par = true) to POST authorization parameters to the PAR endpoint; authorize URLs will reference a returned request_uri.
  * OpenID discovery now exposes the pushed_authorization_request_endpoint.

* **Tests**
  * Added comprehensive PAR unit/integration tests and updated test coverage for discovery and client flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->