### PR TITLE
SDKS-4927 Implement `AgreementCollector` for DaVinci forms to support Terms of Service and agreement displays

### DIFF
--- a/davinci/README.md
+++ b/davinci/README.md
@@ -105,7 +105,7 @@ when (node) {
 For a `ContinueNode`, you can access the list of collectors using `node.collectors()` and provide input to the desired
 `Collector`.
 Currently, the available collectors include `TextCollector`, `PasswordCollector`, `SubmitCollector`, `FlowCollector`,
-`LabelCollector`, `MultiSelectCollector`, and `SingleSelectCollector`. Additional collectors, such as `Fido` and
+`LabelCollector`, `MultiSelectCollector`, `SingleSelectCollector`, `AgreementCollector`. Additional collectors, such as `Fido` and
 `IdpCollector`, will be added in the future.
 
 To access the collectors, you can use the following code:

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,7 @@
 package com.pingidentity.davinci
 
 import com.pingidentity.android.ModuleInitializer
+import com.pingidentity.davinci.collector.AgreementCollector
 import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
 import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
@@ -54,5 +55,8 @@ internal class CollectorRegistry : ModuleInitializer() {
         CollectorFactory.register("DEVICE_REGISTRATION", ::DeviceRegistrationCollector)
         CollectorFactory.register("DEVICE_AUTHENTICATION", ::DeviceAuthenticationCollector)
         CollectorFactory.register("PHONE_NUMBER", ::PhoneNumberCollector)
+
+        // AGREEMENT fields use inputType "READ_ONLY_TEXT" which is the factory lookup key
+        CollectorFactory.register("READ_ONLY_TEXT", ::AgreementCollector)
     }
 }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/AgreementCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/AgreementCollector.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import com.pingidentity.davinci.plugin.Collector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+private const val KEY = "key"
+private const val TYPE = "type"
+private const val CONTENT = "content"
+private const val TITLE = "title"
+private const val TITLE_ENABLED = "titleEnabled"
+private const val ENABLED = "enabled"
+private const val AGREEMENT = "agreement"
+private const val ID = "id"
+private const val USE_DYNAMIC_AGREEMENT = "useDynamicAgreement"
+
+/**
+ * Class representing an AGREEMENT type collector.
+ *
+ * This class handles the response from a DaVinci form field of type AGREEMENT.
+ * It displays agreement/terms-of-service text and collects the user's acceptance.
+ *
+ * Example JSON:
+ * ```json
+ * {
+ *   "type": "AGREEMENT",
+ *   "inputType": "READ_ONLY_TEXT",
+ *   "key": "agreement",
+ *   "content": "This is example agreement text...",
+ *   "titleEnabled": true,
+ *   "title": "Terms of Service Agreement",
+ *   "agreement": {
+ *     "id": "6ff30c9e-cd98-4fe5-85ca-01111ca20702",
+ *     "useDynamicAgreement": false
+ *   },
+ *   "enabled": true
+ * }
+ * ```
+ *
+ * @constructor Creates a new AgreementCollector.
+ */
+class AgreementCollector : Collector<Nothing> {
+
+    /**
+     * The key identifier for this collector, used as the form field key during submission.
+     */
+    var key = ""
+        private set
+
+    /**
+     * The type of this collector (e.g., "AGREEMENT").
+     */
+    var type = ""
+        private set
+
+    /**
+     * The agreement text content to display to the user.
+     */
+    var content = ""
+        private set
+
+    /**
+     * The title of the agreement (shown when [titleEnabled] is true).
+     */
+    var title = ""
+        private set
+
+    /**
+     * Whether to display the [title] above the agreement content.
+     */
+    var titleEnabled = false
+        private set
+
+    /**
+     * Whether this collector is enabled.
+     */
+    var enabled = true
+        private set
+
+    /**
+     * The unique ID of the agreement definition.
+     */
+    var agreementId = ""
+        private set
+
+    /**
+     * Whether the agreement content is loaded dynamically.
+     */
+    var useDynamicAgreement = false
+        private set
+
+    override fun init(input: JsonObject): AgreementCollector {
+        key = input[KEY]?.jsonPrimitive?.content ?: ""
+        type = input[TYPE]?.jsonPrimitive?.content ?: ""
+        content = input[CONTENT]?.jsonPrimitive?.content ?: ""
+        title = input[TITLE]?.jsonPrimitive?.content ?: ""
+        titleEnabled = input[TITLE_ENABLED]?.jsonPrimitive?.boolean ?: false
+        enabled = input[ENABLED]?.jsonPrimitive?.boolean ?: true
+
+        input[AGREEMENT]?.jsonObject?.let { agreement ->
+            agreementId = agreement[ID]?.jsonPrimitive?.content ?: ""
+            useDynamicAgreement = agreement[USE_DYNAMIC_AGREEMENT]?.jsonPrimitive?.boolean ?: false
+        }
+
+        return this
+    }
+
+    override fun id(): String = key
+}
+

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/AgreementCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/AgreementCollectorTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.AgreementCollector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AgreementCollectorTest {
+
+    // Full JSON as returned by the DaVinci server
+    private fun buildFullAgreementJson(): JsonObject = buildJsonObject {
+        put("type", "AGREEMENT")
+        put("inputType", "READ_ONLY_TEXT")
+        put("key", "agreement")
+        put("content", "This is example agreement text, you can edit this text in the agreements section.")
+        put("titleEnabled", true)
+        put("title", "Terms of Service Agreement")
+        putJsonObject("agreement") {
+            put("id", "6ff30c9e-cd98-4fe5-85ca-01111ca20702")
+            put("useDynamicAgreement", false)
+        }
+        put("enabled", true)
+    }
+
+    @Test
+    fun initializesKeyFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertEquals("agreement", collector.key)
+    }
+
+    @Test
+    fun initializesTypeFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertEquals("AGREEMENT", collector.type)
+    }
+
+    @Test
+    fun initializesContentFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertEquals(
+            "This is example agreement text, you can edit this text in the agreements section.",
+            collector.content
+        )
+    }
+
+    @Test
+    fun initializesTitleFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertEquals("Terms of Service Agreement", collector.title)
+    }
+
+    @Test
+    fun initializesTitleEnabledFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertTrue(collector.titleEnabled)
+    }
+
+    @Test
+    fun initializesEnabledFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertTrue(collector.enabled)
+    }
+
+    @Test
+    fun initializesAgreementIdFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertEquals("6ff30c9e-cd98-4fe5-85ca-01111ca20702", collector.agreementId)
+    }
+
+    @Test
+    fun initializesUseDynamicAgreementFromJson() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertFalse(collector.useDynamicAgreement)
+    }
+
+    @Test
+    fun idReturnsKey() {
+        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        assertEquals("agreement", collector.id())
+    }
+
+    @Test
+    fun initializesWithDefaultsWhenJsonIsEmpty() {
+        val collector = AgreementCollector().apply { init(JsonObject(emptyMap())) }
+        assertEquals("", collector.key)
+        assertEquals("", collector.type)
+        assertEquals("", collector.content)
+        assertEquals("", collector.title)
+        assertFalse(collector.titleEnabled)
+        assertTrue(collector.enabled)   // defaults to true
+        assertEquals("", collector.agreementId)
+        assertFalse(collector.useDynamicAgreement)
+    }
+
+    @Test
+    fun titleEnabledFalseWhenNotProvided() {
+        val input = buildJsonObject { put("key", "agreement") }
+        val collector = AgreementCollector().apply { init(input) }
+        assertFalse(collector.titleEnabled)
+    }
+
+}
+

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Agreement.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Agreement.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.app.davinci.collector
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.AgreementCollector
+
+@Composable
+fun Agreement(field: AgreementCollector) {
+
+    OutlinedCard(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+
+            // Title (shown only when titleEnabled is true)
+            if (field.titleEnabled && field.title.isNotEmpty()) {
+                Text(
+                    text = field.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // Scrollable agreement content
+            val scrollState = rememberScrollState()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 200.dp)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                    .verticalScroll(scrollState)
+                    .padding(8.dp),
+            ) {
+                Text(
+                    text = field.content,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.AgreementCollector
 import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
 import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
@@ -96,6 +97,7 @@ fun ContinueNode(
                 is SubmitCollector -> SubmitButton(it, onNext)
                 is TextCollector -> Text(it, onNodeUpdated)
                 is LabelCollector -> Label(it)
+                is AgreementCollector -> Agreement(it)
                 is MultiSelectCollector -> {
                     if (it.type == "COMBOBOX") {
                         ComboBox(it, onNodeUpdated)

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Agreement.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Agreement.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.AgreementCollector
+
+@Composable
+fun Agreement(field: AgreementCollector ) {
+
+    OutlinedCard(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+
+            // Title (shown only when titleEnabled is true)
+            if (field.titleEnabled && field.title.isNotEmpty()) {
+                Text(
+                    text = field.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            // Scrollable agreement content
+            val scrollState = rememberScrollState()
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 200.dp)
+                    .border(
+                        width = 1.dp,
+                        color = MaterialTheme.colorScheme.outline,
+                        shape = RoundedCornerShape(4.dp),
+                    )
+                    .verticalScroll(scrollState)
+                    .padding(8.dp),
+            ) {
+                Text(
+                    text = field.content,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+        }
+    }
+}
+

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.AgreementCollector
 import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
 import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
@@ -96,6 +97,7 @@ fun DaVinciContinueNode(
                 is SubmitCollector -> SubmitButton(it, onNext)
                 is TextCollector -> Text(it, onNodeUpdated)
                 is LabelCollector -> Label(it)
+                is AgreementCollector -> Agreement(it)
                 is MultiSelectCollector -> {
                     if (it.type == "COMBOBOX") {
                         ComboBox(it, onNodeUpdated)


### PR DESCRIPTION


# JIRA Ticket

[SDKS-4927](https://pingidentity.atlassian.net/browse/SDKS-4927)

# Description

SDKS-4927 Implement `AgreementCollector` for DaVinci forms to support Terms of Service and agreement displays

Key changes:
- Created `AgreementCollector` to handle `AGREEMENT` type form fields, supporting properties like `content`, `title`, and `agreementId`.
- Registered `AgreementCollector` in `CollectorRegistry` using the `READ_ONLY_TEXT` factory key.
- Added a scrollable `Agreement` Compose UI component to both sample applications for rendering agreement text.
- Updated `ContinueNode` in sample apps to include `AgreementCollector` in the collector dispatch logic.
- Added comprehensive unit tests in `AgreementCollectorTest.kt` to verify JSON initialization and default values.
- Updated documentation in `davinci/README.md` to include `AgreementCollector` in the list of available collectors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an agreement collector type to display user agreements in forms.
  * Sample apps now render agreement cards with optional titles and scrollable agreement text.

* **Tests**
  * Added tests validating agreement collector initialization and defaults.

* **Documentation**
  * README updated to list the agreement collector among available collectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->