### PR TITLE
SDKS-4919: Add SingleCheckboxCollector for handling single checkbox type

### DIFF
--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -12,6 +12,7 @@ import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -45,8 +46,9 @@ class FormFieldsTest {
         const val RADIO_INDEX = 6
         const val COMBOBOX_INDEX = 7
         const val PHONE_NUMBER_INDEX = 8
-        const val FLOW_BUTTON_INDEX = 9
-        const val FLOW_LINK_INDEX = 10
+        const val SINGLE_CHECKBOX_INDEX = 9
+        const val FLOW_BUTTON_INDEX = 10
+        const val FLOW_LINK_INDEX = 11
     }
 
     private var daVinci = DaVinci {
@@ -353,6 +355,36 @@ class FormFieldsTest {
         assertTrue(validationResult.isEmpty())
     }
 
+    @TestRailCase(/* Add test rail IDs */)
+    @Test
+    fun singleCheckboxCollectorTest() = runTest {
+        // Go to the "Form Fields" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        // 10th collector in the form is a SingleCheckbox (index 9)
+        assertTrue(node.collectors[SINGLE_CHECKBOX_INDEX] is BooleanCollector)
+        val singleCheckbox = (node.collectors[SINGLE_CHECKBOX_INDEX] as BooleanCollector)
+
+        // Assert the properties
+        assertEquals("SINGLE_CHECKBOX", singleCheckbox.type)
+        assertEquals("single-checkbox-field", singleCheckbox.key)
+        assertEquals("This is a sample checkbox test. ", singleCheckbox.label)
+        assertEquals("This is a sample checkbox test. ", singleCheckbox.richContent)
+        assertEquals(true, singleCheckbox.required)
+
+        // Default value should be false
+        assertEquals(false, singleCheckbox.value)
+        val requiredErrors = singleCheckbox.validate()
+        assertTrue(requiredErrors.isNotEmpty())
+
+        // Set the value to true and validate
+        singleCheckbox.value = true
+        val validationResult = singleCheckbox.validate() // Should return empty list since it's valid
+        assertTrue(validationResult.isEmpty())
+    }
+
     @TestRailCase(26033)
     @Test
     fun flowButtonCollectorTest() = runTest {
@@ -361,7 +393,7 @@ class FormFieldsTest {
         (node.collectors[0] as? SubmitCollector)?.value = "click"
         node = node.next() as ContinueNode
 
-        // 10th collector in the form is a FlowButton (index 9)
+        // 11th collector in the form is a FlowButton (index 10)
         assertTrue(node.collectors[FLOW_BUTTON_INDEX] is FlowCollector)
         val flowButton = (node.collectors[FLOW_BUTTON_INDEX] as FlowCollector)
 
@@ -385,7 +417,7 @@ class FormFieldsTest {
         (node.collectors[0] as? SubmitCollector)?.value = "click"
         node = node.next() as ContinueNode
 
-        // 11th collector in the form is a FlowLink (index 10)
+        // 12th collector in the form is a FlowLink (index 11)
         assertTrue(node.collectors[FLOW_LINK_INDEX] is FlowCollector)
         val flowLink = (node.collectors[FLOW_LINK_INDEX] as FlowCollector)
 

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -15,6 +15,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -50,6 +51,7 @@ internal class CollectorRegistry : ModuleInitializer() {
 
         CollectorFactory.register("SINGLE_SELECT", ::SingleSelectCollector)
         CollectorFactory.register("MULTI_SELECT", ::MultiSelectCollector)
+        CollectorFactory.register("BOOLEAN", ::BooleanCollector)
 
         CollectorFactory.register("DEVICE_REGISTRATION", ::DeviceRegistrationCollector)
         CollectorFactory.register("DEVICE_AUTHENTICATION", ::DeviceAuthenticationCollector)

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/BooleanCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/BooleanCollector.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * A Collector implementation for a single checkbox field.
+ *
+ * ```json
+ * {
+ *    "type": "SINGLE_CHECKBOX",
+ *    "key": "single-checkbox-field",
+ *    "label": "This is a sample checkbox test. ",
+ *    "required": true,
+ *    "inputType": "BOOLEAN",
+ *    "appearance": "CHECKBOX", # Optional, defaults to CHECKBOX. Can be either CHECKBOX or SWITCH.
+ *    "errorMessage": "Select the checkbox to continue.",
+ *    "richContent": {
+ *        "content": "This is a sample checkbox test. "
+ *    }
+ * }
+ *
+ */
+class BooleanCollector: FieldCollector<Boolean>() {
+    var appearance: SingleCheckboxAppearance = SingleCheckboxAppearance.CHECKBOX
+        private set
+
+    var errorMessage: String = ""
+        private set
+
+    var value: Boolean = false
+    var richContent: String? = null
+        private set
+
+    override fun init(input: JsonObject): BooleanCollector {
+        super.init(input)
+        appearance = when (input["appearance"]?.jsonPrimitive?.contentOrNull ?: SingleCheckboxAppearance.CHECKBOX.value) {
+            SingleCheckboxAppearance.CHECKBOX.value -> SingleCheckboxAppearance.CHECKBOX
+            SingleCheckboxAppearance.SWITCH.value -> SingleCheckboxAppearance.SWITCH
+            else -> SingleCheckboxAppearance.CHECKBOX
+        }
+        errorMessage = input["errorMessage"]?.jsonPrimitive?.contentOrNull ?: "This field is required."
+        richContent = input["richContent"]?.jsonObject?.get("content")?.jsonPrimitive?.contentOrNull
+        return this
+    }
+
+    override fun validate(): List<ValidationError> {
+        val errors = mutableListOf<ValidationError>()
+        val result = super.validate()
+        errors.addAll(result)
+        if (required && !value) {
+            errors.add(SingleCheckboxRequiredError(key, errorMessage))
+        }
+        return errors
+    }
+
+    override fun payload(): Boolean {
+        return value
+    }
+}
+
+enum class SingleCheckboxAppearance(val value: String) {
+    CHECKBOX("CHECKBOX"),
+    SWITCH("SWITCH")
+}
+
+class SingleCheckboxRequiredError(val key: String, val message: String) : ValidationError() {
+    override fun toString(): String {
+        return "SingleCheckboxRequiredError(key='$key', message='$message')"
+    }
+}

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/BooleanCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/BooleanCollectorTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.SingleCheckboxAppearance
+import com.pingidentity.davinci.collector.BooleanCollector
+import com.pingidentity.davinci.collector.SingleCheckboxRequiredError
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+
+class BooleanCollectorTest {
+
+    @Test
+    fun initializesDefaultValuesWhenNoInputProvided() {
+        val input = buildJsonObject {}
+        val collector = BooleanCollector()
+        collector.init(input)
+
+        assertEquals(SingleCheckboxAppearance.CHECKBOX, collector.appearance)
+        assertEquals("This field is required.", collector.errorMessage)
+        assertNull(collector.richContent)
+        assertFalse(collector.value)
+    }
+
+    @Test
+    fun initializesAppearanceAsCheckbox() {
+        val input = buildJsonObject {
+            put("appearance", "CHECKBOX")
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+
+        assertEquals(SingleCheckboxAppearance.CHECKBOX, collector.appearance)
+    }
+
+    @Test
+    fun initializesAppearanceAsSwitch() {
+        val input = buildJsonObject {
+            put("appearance", "SWITCH")
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+
+        assertEquals(SingleCheckboxAppearance.SWITCH, collector.appearance)
+    }
+
+    @Test
+    fun initializesAppearanceAsCheckboxWhenUnknownValueProvided() {
+        val input = buildJsonObject {
+            put("appearance", "UNKNOWN")
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+
+        assertEquals(SingleCheckboxAppearance.CHECKBOX, collector.appearance)
+    }
+
+    @Test
+    fun initializesErrorMessage() {
+        val input = buildJsonObject {
+            put("errorMessage", "Select the checkbox to continue.")
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+
+        assertEquals("Select the checkbox to continue.", collector.errorMessage)
+    }
+
+    @Test
+    fun initializesRichContent() {
+        val input = buildJsonObject {
+            put("richContent", buildJsonObject {
+                put("content", "This is a sample checkbox test.")
+            })
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+
+        assertEquals("This is a sample checkbox test.", collector.richContent)
+    }
+
+
+    @Test
+    fun validateReturnsNoErrorsWhenRequiredAndChecked() {
+        val input = buildJsonObject {
+            put("required", true)
+            put("errorMessage", "Select the checkbox to continue.")
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+        collector.value = true
+
+        val errors = collector.validate()
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun validateReturnsErrorWhenRequiredAndUnchecked() {
+        val input = buildJsonObject {
+            put("required", true)
+            put("errorMessage", "Select the checkbox to continue.")
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+        collector.value = false
+
+        val errors = collector.validate()
+
+        assertTrue(errors.isNotEmpty())
+        assertIs<SingleCheckboxRequiredError>(errors[0])
+        assertEquals("Select the checkbox to continue.", (errors[0] as SingleCheckboxRequiredError).message)
+    }
+
+    @Test
+    fun validateReturnsNoErrorsWhenNotRequired() {
+        val input = buildJsonObject {
+            put("required", false)
+        }
+        val collector = BooleanCollector()
+        collector.init(input)
+        collector.value = false
+
+        val errors = collector.validate()
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun payloadReturnsTrueWhenChecked() {
+        val collector = BooleanCollector()
+        collector.value = true
+
+        assertTrue(collector.payload())
+    }
+
+    @Test
+    fun payloadReturnsFalseWhenUnchecked() {
+        val collector = BooleanCollector()
+        collector.value = false
+
+        assertFalse(collector.payload())
+    }
+
+    @Test
+    fun singleCheckboxRequiredErrorToString() {
+        val error = SingleCheckboxRequiredError("test-key", "Select the checkbox to continue.")
+
+        assertEquals("SingleCheckboxRequiredError(key='test-key', message='Select the checkbox to continue.')", error.toString())
+    }
+}
+

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
@@ -29,6 +29,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -119,7 +120,7 @@ fun ContinueNode(
                 is FidoAuthenticationCollector -> FidoAuthentication(it, onStart, onNext)
                 is PhoneNumberCollector -> PhoneNumber(it, onNodeUpdated)
                 is ProtectCollector -> Protect(it, onNodeUpdated)
-
+                is BooleanCollector -> SingleCheckbox(it, onNodeUpdated)
             }
             if (it is Submittable) {
                 hasAction = true

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ErrorMessage.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ErrorMessage.kt
@@ -18,6 +18,7 @@ import com.pingidentity.davinci.collector.MaxRepeat
 import com.pingidentity.davinci.collector.MinCharacters
 import com.pingidentity.davinci.collector.RegexError
 import com.pingidentity.davinci.collector.Required
+import com.pingidentity.davinci.collector.SingleCheckboxRequiredError
 import com.pingidentity.davinci.collector.UniqueCharacter
 import com.pingidentity.davinci.collector.ValidationError
 
@@ -45,5 +46,6 @@ fun getErrorMessage(error: ValidationError): String {
         is UniqueCharacter -> "The input must contain at least ${error.min} unique characters."
         is MaxRepeat -> "The input contains too many repeated characters. Maximum allowed repeats: ${error.max}."
         is MinCharacters -> "The input must include at least ${error.min} character(s) from this set: '${error.character}'."
+        is SingleCheckboxRequiredError -> "This checkbox must be checked."
     }
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/SingleCheckbox.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/SingleCheckbox.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.app.davinci.collector
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.SingleCheckboxAppearance
+import com.pingidentity.davinci.collector.BooleanCollector
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SingleCheckbox(field: BooleanCollector, onNodeUpdated: () -> Unit) {
+    var isValid by remember(field) {
+        mutableStateOf(true)
+    }
+    var isChecked by remember(field) {
+        mutableStateOf(field.value)
+    }
+
+    OutlinedCard (
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val onChange: (Boolean) -> Unit = { checked ->
+                isChecked = checked
+                field.value = checked
+                isValid = field.validate().isEmpty()
+                onNodeUpdated()
+            }
+            if (field.appearance ==  SingleCheckboxAppearance.SWITCH) {
+                Switch(checked = isChecked, onCheckedChange = onChange)
+            } else {
+                Checkbox(checked = isChecked, onCheckedChange = onChange)
+            }
+            val text = if (field.richContent != null) {
+                if (field.required) "${field.richContent}*" else field.richContent
+            } else {
+                if (field.required) "${field.label}*" else field.label
+            }
+            Text(text = text ?: "")
+        }
+        if (!isValid) {
+            ErrorMessage(field.validate())
+        }
+    }
+}

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
@@ -29,6 +29,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -119,7 +120,7 @@ fun DaVinciContinueNode(
                 is FidoAuthenticationCollector -> FidoAuthentication(it, onStart, onNext)
                 is PhoneNumberCollector -> PhoneNumber(it, onNodeUpdated)
                 is ProtectCollector -> Protect(it, onNodeUpdated)
-
+                is BooleanCollector -> SingleCheckbox(it, onNodeUpdated)
             }
             if (it is Submittable) {
                 hasAction = true

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/ErrorMessage.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/ErrorMessage.kt
@@ -18,6 +18,7 @@ import com.pingidentity.davinci.collector.MaxRepeat
 import com.pingidentity.davinci.collector.MinCharacters
 import com.pingidentity.davinci.collector.RegexError
 import com.pingidentity.davinci.collector.Required
+import com.pingidentity.davinci.collector.SingleCheckboxRequiredError
 import com.pingidentity.davinci.collector.UniqueCharacter
 import com.pingidentity.davinci.collector.ValidationError
 
@@ -45,5 +46,6 @@ fun getErrorMessage(error: ValidationError): String {
         is UniqueCharacter -> "The input must contain at least ${error.min} unique characters."
         is MaxRepeat -> "The input contains too many repeated characters. Maximum allowed repeats: ${error.max}."
         is MinCharacters -> "The input must include at least ${error.min} character(s) from this set: '${error.character}'."
+        is SingleCheckboxRequiredError -> error.message
     }
 }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/SingleCheckbox.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/SingleCheckbox.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.SingleCheckboxAppearance
+import com.pingidentity.davinci.collector.BooleanCollector
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SingleCheckbox(field: BooleanCollector, onNodeUpdated: () -> Unit) {
+    var isValid by remember(field) {
+        mutableStateOf(true)
+    }
+    var isChecked by remember(field) {
+        mutableStateOf(field.value)
+    }
+
+    OutlinedCard (
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val onChange: (Boolean) -> Unit = { checked ->
+                isChecked = checked
+                field.value = checked
+                isValid = field.validate().isEmpty()
+                onNodeUpdated()
+            }
+            if (field.appearance ==  SingleCheckboxAppearance.SWITCH) {
+                Switch(checked = isChecked, onCheckedChange = onChange)
+            } else {
+                Checkbox(checked = isChecked, onCheckedChange = onChange)
+            }
+            val text = if (field.richContent != null) {
+                if (field.required) "${field.richContent}*" else field.richContent
+            } else {
+                if (field.required) "${field.label}*" else field.label
+            }
+            Text(text = text ?: "")
+        }
+        if (!isValid) {
+            ErrorMessage(field.validate())
+        }
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4919](https://pingidentity.atlassian.net/browse/SDKS-4919)

# Description
This PR adds DaVinci SDK support for the SINGLE_CHECKBOX field type to be used by the AgreementCollector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Single-checkbox field type now available with customizable appearance (checkbox or switch display options)
  * Required field validation for checkboxes with custom error messaging
  * Real-time validation feedback with error display beneath the field

* **Tests**
  * Added comprehensive test coverage for checkbox validation, rendering, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->