### PR TITLE
SDKS-4246 Support links coming from Translatable Rich Text (Forms)

### DIFF
--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -29,8 +29,11 @@ import org.junit.Rule
 import org.junit.rules.TestWatcher
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertNotNull
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+
+private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
 
 @SmallTest
 class FormFieldsTest {
@@ -98,8 +101,46 @@ class FormFieldsTest {
         // Note that the Rich Text component has been deprecated, so the key is not set
         assertEquals("", labelCollector1.key)
 
-        // labelCollector3: SLATE_TEXTBLOB with translatable link, key = "rich-text"
-        assertEquals("rich-text", labelCollector3.key)
+        // labelCollector1: HTML content — richText falls back to the raw HTML content string
+        assertTrue(labelCollector1.richText.contains("Rich Text fields produce LABELs"))
+        // No richContent on this label so replacements must be empty
+        assertTrue(labelCollector1.replacements.isEmpty())
+
+        // labelCollector2: plain translatable text — richText comes from richContent.content
+        // (without the trailing newlines present in the top-level content field)
+        assertEquals("Translatable Rich Text produce LABELs too!", labelCollector2.richText)
+        // No replacement tokens on this label
+        assertTrue(labelCollector2.replacements.isEmpty())
+    }
+
+    @Test
+    fun labelCollectorWithTranslatableLinkTest() = runTest {
+        // Go to the "Form Fields" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        // Find a LabelCollector that has replacements (translatable link label)
+        val linkLabel = node.collectors
+            .filterIsInstance<LabelCollector>()
+            .firstOrNull { it.replacements.isNotEmpty() }
+
+        if (linkLabel != null) {
+            // richText must contain at least one {{token}} placeholder
+            assertTrue(
+                tokenPattern.containsMatchIn(linkLabel.richText),
+                "Expected richText to contain {{token}} placeholders, was: ${linkLabel.richText}"
+            )
+            // Every token present in richText must have a corresponding replacement entry
+            for (match in tokenPattern.findAll(linkLabel.richText)) {
+                val token = match.groupValues[1]
+                val replacement = linkLabel.replacements[token]
+                assertNotNull(replacement, "Missing replacement for token '$token'")
+                assertTrue(replacement.value.isNotEmpty(), "Replacement value for '$token' must not be empty")
+                assertTrue(replacement.href.isNotEmpty(), "Replacement href for '$token' must not be empty")
+            }
+        }
+        // If no such label is present in the current form, the test is a no-op (no assertion failure)
     }
 
     @TestRailCase(26032, 26031)
@@ -127,7 +168,7 @@ class FormFieldsTest {
         // Validate should return list with 2 validation errors since the value is empty
         // and does not match the configured regex
         val validationResult = textCollector.validate()
-        assertTrue(validationResult.size == 1)
+        assertEquals(1, validationResult.size)
         assertEquals("Required", validationResult[0].toString())
 
         textCollector.value = "Sometext123"

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -102,15 +102,29 @@ class FormFieldsTest {
         assertEquals("", labelCollector1.key)
 
         // labelCollector1: HTML content — richText falls back to the raw HTML content string
-        assertTrue(labelCollector1.richText.contains("Rich Text fields produce LABELs"))
+        val richContent1 = labelCollector1.richContent
+        assertNotNull(richContent1)
+        assertTrue(richContent1.richText.contains("Rich Text fields produce LABELs"))
         // No richContent on this label so replacements must be empty
-        assertTrue(labelCollector1.replacements.isEmpty())
+        assertTrue(richContent1.replacements.isEmpty())
 
         // labelCollector2: plain translatable text — richText comes from richContent.content
         // (without the trailing newlines present in the top-level content field)
-        assertEquals("Translatable Rich Text produce LABELs too!", labelCollector2.richText)
+        val richContent2 = labelCollector2.richContent
+        assertNotNull(richContent2)
+        assertEquals("Translatable Rich Text produce LABELs too!", richContent2.richText)
         // No replacement tokens on this label
-        assertTrue(labelCollector2.replacements.isEmpty())
+        assertTrue(richContent2.replacements.isEmpty())
+
+        // labelCollector3: translatable link — richText contains {{token}} placeholders and replacements map contains corresponding entries
+        val richContent3 = labelCollector3.richContent
+        assertNotNull(richContent3)
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent3.richText)
+        assertTrue(richContent3.replacements.containsKey("link1"))
+        val replacement = richContent3.replacements["link1"]
+        assertNotNull(replacement)
+        assertEquals("google.com", replacement.value)
+        assertEquals("https://www.google.com", replacement.href)
     }
 
     @Test
@@ -123,18 +137,18 @@ class FormFieldsTest {
         // Find a LabelCollector that has replacements (translatable link label)
         val linkLabel = node.collectors
             .filterIsInstance<LabelCollector>()
-            .firstOrNull { it.replacements.isNotEmpty() }
+            .firstOrNull { it.richContent?.replacements?.isNotEmpty() ?: false }
 
         if (linkLabel != null) {
             // richText must contain at least one {{token}} placeholder
             assertTrue(
-                tokenPattern.containsMatchIn(linkLabel.richText),
-                "Expected richText to contain {{token}} placeholders, was: ${linkLabel.richText}"
+                tokenPattern.containsMatchIn(linkLabel.richContent?.richText ?: ""),
+                "Expected richText to contain {{token}} placeholders, was: ${linkLabel.richContent?.richText}"
             )
             // Every token present in richText must have a corresponding replacement entry
-            for (match in tokenPattern.findAll(linkLabel.richText)) {
+            for (match in tokenPattern.findAll(linkLabel.richContent?.richText ?: "")) {
                 val token = match.groupValues[1]
-                val replacement = linkLabel.replacements[token]
+                val replacement = linkLabel.richContent?.replacements[token]
                 assertNotNull(replacement, "Missing replacement for token '$token'")
                 assertTrue(replacement.value.isNotEmpty(), "Replacement value for '$token' must not be empty")
                 assertTrue(replacement.href.isNotEmpty(), "Replacement href for '$token' must not be empty")

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/RichContent.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/RichContent.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+const val RICH_CONTENT = "richContent"
+const val REPLACEMENTS = "replacements"
+const val VALUE = "value"
+const val HREF = "href"
+const val TYPE = "type"
+const val TARGET = "target"
+
+
+/**
+ * Represents a single replacement token inside a rich-text label.
+ *
+ * @property value The display text of the replacement (e.g. "google.com").
+ * @property href  The URL the replacement links to (empty string if not a link).
+ * @property type  The replacement type (e.g. "link").
+ * @property target The link target (e.g. "_self", "_blank").
+ */
+data class RichContentReplacement(
+    val value: String = "",
+    val href: String = "",
+    val type: String = "",
+    val target: String = "",
+)
+
+/**
+ * Represents rich text content with optional token replacements.
+ *
+ * @property richText The rich text content, potentially containing `{{tokenName}}` placeholders.
+ * @property replacements Map of token name → [RichContentReplacement] parsed from
+ * `richContent.replacements`.  Empty when there are no replacements.
+ */
+data class RichContent(
+    val richText: String = "",
+    val replacements: Map<String, RichContentReplacement> = emptyMap(),
+)

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/HtmlEscaper.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/HtmlEscaper.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+/**
+ * Escapes characters that are unsafe inside HTML text content or attribute values.
+ *
+ * The `&` replacement **must** run first to prevent any subsequent replacement from
+ * producing an entity that then gets double-escaped (e.g. `<` → `&lt;` → `&amp;lt;`).
+ *
+ * Characters escaped:
+ * - `&`  → `&amp;`
+ * - `<`  → `&lt;`
+ * - `>`  → `&gt;`
+ * - `"`  → `&quot;`
+ * - `'`  → `&#39;`
+ */
+fun String.escapeHtml(): String = this
+    .replace("&", "&amp;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;")
+    .replace("\"", "&quot;")
+    .replace("'", "&#39;")
+

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
@@ -7,6 +7,14 @@
 
 package com.pingidentity.davinci.collector
 
+import com.pingidentity.davinci.HREF
+import com.pingidentity.davinci.REPLACEMENTS
+import com.pingidentity.davinci.RICH_CONTENT
+import com.pingidentity.davinci.RichContent
+import com.pingidentity.davinci.RichContentReplacement
+import com.pingidentity.davinci.TARGET
+import com.pingidentity.davinci.TYPE
+import com.pingidentity.davinci.VALUE
 import com.pingidentity.davinci.plugin.Collector
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -15,33 +23,14 @@ import kotlinx.serialization.json.contentOrNull
 
 private const val CONTENT = "content"
 private const val KEY = "key"
-private const val RICH_CONTENT = "richContent"
-private const val REPLACEMENTS = "replacements"
-private const val VALUE = "value"
-private const val HREF = "href"
-private const val TYPE = "type"
-private const val TARGET = "target"
-
-/**
- * Represents a single replacement token inside a rich-text label.
- *
- * @property value The display text of the replacement (e.g. "google.com").
- * @property href  The URL the replacement links to (empty string if not a link).
- * @property type  The replacement type (e.g. "link").
- * @property target The link target (e.g. "_self", "_blank").
- */
-data class RichContentReplacement(
-    val value: String = "",
-    val href: String = "",
-    val type: String = "",
-    val target: String = "",
-)
 
 /**
  * Class representing a LABEL type.
  *
  * This class inherits from the [Collector] class. It is used to display a label on the form.
  * @constructor Creates a new LabelCollector.
+ * @see RichContent
+ * @see RichContentReplacement
  */
 class LabelCollector : Collector<Nothing> {
 
@@ -53,37 +42,31 @@ class LabelCollector : Collector<Nothing> {
         private set
 
     /**
-     * Rich-text content string, potentially containing `{{tokenName}}` placeholders
-     * that should be substituted with entries from [replacements].
+     * Rich content, potentially containing `{{tokenName}}` placeholders
+     * that should be substituted with entries from [RichContentReplacement].
      * Falls back to [content] if no `richContent` is present.
      */
-    var richText = ""
-        private set
-
-    /**
-     * Map of token name → [RichContentReplacement] parsed from
-     * `richContent.replacements`.  Empty when there are no replacements.
-     */
-    var replacements: Map<String, RichContentReplacement> = emptyMap()
+    var richContent: RichContent? = null
         private set
 
     override fun init(input: JsonObject): LabelCollector {
         content = input[CONTENT]?.jsonPrimitive?.contentOrNull ?: ""
         key = input[KEY]?.jsonPrimitive?.contentOrNull ?: ""
 
-        val richContent = input[RICH_CONTENT] as? JsonObject
-        richText = richContent?.get(CONTENT)?.jsonPrimitive?.contentOrNull ?: content
-
-        replacements = (richContent?.get(REPLACEMENTS) as? JsonObject)
-            ?.mapValues { (_, element) ->
-                val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()
-                RichContentReplacement(
-                    value  = (obj[VALUE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                    href   = (obj[HREF] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                    type   = (obj[TYPE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                    target = (obj[TARGET] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                )
-            } ?: emptyMap()
+        val richContentJson = input[RICH_CONTENT] as? JsonObject
+        richContent = RichContent(
+            richText = richContentJson?.get(CONTENT)?.jsonPrimitive?.contentOrNull ?: content,
+            replacements = (richContentJson?.get(REPLACEMENTS) as? JsonObject)
+                ?.mapValues { (_, element) ->
+                    val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()
+                    RichContentReplacement(
+                        value = (obj[VALUE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                        href = (obj[HREF] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                        type = (obj[TYPE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                        target = (obj[TARGET] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                    )
+                } ?: emptyMap()
+        )
 
         return this
     }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
@@ -9,10 +9,33 @@ package com.pingidentity.davinci.collector
 
 import com.pingidentity.davinci.plugin.Collector
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 
 private const val CONTENT = "content"
 private const val KEY = "key"
+private const val RICH_CONTENT = "richContent"
+private const val REPLACEMENTS = "replacements"
+private const val VALUE = "value"
+private const val HREF = "href"
+private const val TYPE = "type"
+private const val TARGET = "target"
+
+/**
+ * Represents a single replacement token inside a rich-text label.
+ *
+ * @property value The display text of the replacement (e.g. "google.com").
+ * @property href  The URL the replacement links to (empty string if not a link).
+ * @property type  The replacement type (e.g. "link").
+ * @property target The link target (e.g. "_self", "_blank").
+ */
+data class RichContentReplacement(
+    val value: String = "",
+    val href: String = "",
+    val type: String = "",
+    val target: String = "",
+)
 
 /**
  * Class representing a LABEL type.
@@ -24,17 +47,46 @@ class LabelCollector : Collector<Nothing> {
 
     var key = ""
         private set
+
+    /** Plain-text fallback content (top-level `content` field). */
     var content = ""
         private set
 
+    /**
+     * Rich-text content string, potentially containing `{{tokenName}}` placeholders
+     * that should be substituted with entries from [replacements].
+     * Falls back to [content] if no `richContent` is present.
+     */
+    var richText = ""
+        private set
 
-    override fun init(input: JsonObject) : LabelCollector{
-        content = input[CONTENT]?.jsonPrimitive?.content ?: ""
-        key = input[KEY]?.jsonPrimitive?.content ?: ""
+    /**
+     * Map of token name → [RichContentReplacement] parsed from
+     * `richContent.replacements`.  Empty when there are no replacements.
+     */
+    var replacements: Map<String, RichContentReplacement> = emptyMap()
+        private set
+
+    override fun init(input: JsonObject): LabelCollector {
+        content = input[CONTENT]?.jsonPrimitive?.contentOrNull ?: ""
+        key = input[KEY]?.jsonPrimitive?.contentOrNull ?: ""
+
+        val richContent = input[RICH_CONTENT] as? JsonObject
+        richText = richContent?.get(CONTENT)?.jsonPrimitive?.contentOrNull ?: content
+
+        replacements = (richContent?.get(REPLACEMENTS) as? JsonObject)
+            ?.mapValues { (_, element) ->
+                val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()
+                RichContentReplacement(
+                    value  = (obj[VALUE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                    href   = (obj[HREF] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                    type   = (obj[TYPE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                    target = (obj[TARGET] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                )
+            } ?: emptyMap()
+
         return this
     }
 
-    override fun id(): String {
-        return key
-    }
+    override fun id(): String = key
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/HtmlEscaperTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/HtmlEscaperTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.escapeHtml
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HtmlEscaperTest {
+
+    // ── individual character escapes ──────────────────────────────────────────
+
+    @Test
+    fun `escapeHtml escapes ampersand`() {
+        assertEquals("AT&amp;T", "AT&T".escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml escapes less-than`() {
+        assertEquals("&lt;script&gt;", "<script>".escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml escapes greater-than`() {
+        assertEquals("1 &gt; 0", "1 > 0".escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml escapes double-quote`() {
+        assertEquals("say &quot;hello&quot;", """say "hello"""".escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml escapes single-quote`() {
+        assertEquals("it&#39;s fine", "it's fine".escapeHtml())
+    }
+
+    // ── order-of-operations: & must be replaced before any other char ─────────
+
+    @Test
+    fun `escapeHtml does not double-escape ampersand`() {
+        // "&amp;" already contains "&"; a naïve second pass would produce "&amp;amp;"
+        assertEquals("&amp;amp;", "&amp;".escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml does not produce double-encoded entities for lt`() {
+        // Input: "&lt;" — the & becomes &amp; first, then < is absent, so result is "&amp;lt;"
+        assertEquals("&amp;lt;", "&lt;".escapeHtml())
+    }
+
+    // ── realistic href scenarios ──────────────────────────────────────────────
+
+    @Test
+    fun `escapeHtml makes URL with query params safe for href attribute`() {
+        val raw = "https://example.com?a=1&b=2"
+        assertEquals("https://example.com?a=1&amp;b=2", raw.escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml neutralises href injection attempt via double-quote`() {
+        val malicious = """https://evil.com" onclick="stealData()"""
+        val escaped = malicious.escapeHtml()
+        // The closing " must be escaped so it cannot terminate the href attribute
+        assertEquals("""https://evil.com&quot; onclick=&quot;stealData()""", escaped)
+    }
+
+    @Test
+    fun `escapeHtml neutralises href injection attempt via single-quote`() {
+        val malicious = "https://evil.com' onclick='stealData()"
+        val escaped = malicious.escapeHtml()
+        assertEquals("https://evil.com&#39; onclick=&#39;stealData()", escaped)
+    }
+
+    // ── realistic display-text scenarios ─────────────────────────────────────
+
+    @Test
+    fun `escapeHtml neutralises script injection in display text`() {
+        val malicious = "<script>alert(1)</script>"
+        assertEquals("&lt;script&gt;alert(1)&lt;/script&gt;", malicious.escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml leaves plain text unchanged`() {
+        val plain = "Visit google.com for more info"
+        assertEquals(plain, plain.escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml handles empty string`() {
+        assertEquals("", "".escapeHtml())
+    }
+
+    @Test
+    fun `escapeHtml escapes all dangerous characters together`() {
+        val input = """<a href="bad'url&more">text</a>"""
+        assertEquals("""&lt;a href=&quot;bad&#39;url&amp;more&quot;&gt;text&lt;/a&gt;""", input.escapeHtml())
+    }
+}
+

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
@@ -8,11 +8,13 @@
 package com.pingidentity.davinci
 
 import com.pingidentity.davinci.collector.LabelCollector
+import com.pingidentity.davinci.collector.RichContentReplacement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class LabelCollectorTest {
 
@@ -36,4 +38,184 @@ class LabelCollectorTest {
         assertEquals("", collector.content)
     }
 
+    @Test
+    fun `richText falls back to content when no richContent is present`() {
+        val input = buildJsonObject {
+            put("key", "label-key")
+            put("content", "Plain text content")
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+        assertEquals("Plain text content", collector.richText)
+        assertTrue(collector.replacements.isEmpty())
+    }
+
+    @Test
+    fun `richText is read from richContent content when present`() {
+        val input = buildJsonObject {
+            put("key", "rich-text")
+            put("content", "A translatable rich text to take the user to google.com")
+            put("richContent", buildJsonObject {
+                put("content", "A translatable rich text to take the user to {{link1}}")
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+        assertEquals("A translatable rich text to take the user to google.com", collector.content)
+        assertEquals("A translatable rich text to take the user to {{link1}}", collector.richText)
+        assertTrue(collector.replacements.isEmpty())
+    }
+
+    @Test
+    fun `replacements are parsed from richContent when present`() {
+        val input = buildJsonObject {
+            put("key", "rich-text")
+            put("content", "A translatable rich text to take the user to google.com")
+            put("richContent", buildJsonObject {
+                put("content", "A translatable rich text to take the user to {{link1}}")
+                put("replacements", buildJsonObject {
+                    put("link1", buildJsonObject {
+                        put("value", "google.com")
+                        put("href", "https://www.google.com")
+                        put("type", "link")
+                        put("target", "_self")
+                    })
+                })
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+
+        assertEquals("A translatable rich text to take the user to {{link1}}", collector.richText)
+        assertEquals(1, collector.replacements.size)
+
+        val link1 = collector.replacements["link1"]
+        assertEquals(RichContentReplacement(
+            value = "google.com",
+            href = "https://www.google.com",
+            type = "link",
+            target = "_self"
+        ), link1)
+    }
+
+    @Test
+    fun `replacements map is empty when richContent has no replacements`() {
+        val input = buildJsonObject {
+            put("key", "rich-text")
+            put("richContent", buildJsonObject {
+                put("content", "Some rich text")
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+        assertTrue(collector.replacements.isEmpty())
+    }
+
+    @Test
+    fun `richText is set to HTML content when content contains HTML tags`() {
+        val input = buildJsonObject {
+            put("content", "<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>")
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", collector.content)
+        // richText falls back to content since no richContent is present
+        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", collector.richText)
+        assertEquals("", collector.key)
+        assertTrue(collector.replacements.isEmpty())
+    }
+
+    @Test
+    fun `richText is set from richContent when content has trailing whitespace`() {
+        val input = buildJsonObject {
+            put("key", "translatable-rich-text-key")
+            put("content", "Translatable Rich Text produce LABELs too!\n\n")
+            put("richContent", buildJsonObject {
+                put("content", "Translatable Rich Text produce LABELs too!")
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+        // content retains the original value including trailing newlines
+        assertEquals("Translatable Rich Text produce LABELs too!\n\n", collector.content)
+        // richText is trimmed to the richContent value
+        assertEquals("Translatable Rich Text produce LABELs too!", collector.richText)
+        assertEquals("translatable-rich-text-key", collector.key)
+        assertTrue(collector.replacements.isEmpty())
+    }
+
+    @Test
+    fun `replacement href with query params is stored as-is`() {
+        // The server sends raw URLs; escaping is the rendering layer's job
+        val input = buildJsonObject {
+            put("key", "rich-text")
+            put("richContent", buildJsonObject {
+                put("content", "Search on {{searchLink}}")
+                put("replacements", buildJsonObject {
+                    put("searchLink", buildJsonObject {
+                        put("value", "Google")
+                        put("href", "https://google.com/search?q=hello&lang=en")
+                        put("type", "link")
+                        put("target", "_self")
+                    })
+                })
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+
+        val replacement = collector.replacements["searchLink"]
+        // href must be raw — escaping happens at render time, not parse time
+        assertEquals("https://google.com/search?q=hello&lang=en", replacement?.href)
+        assertEquals("Google", replacement?.value)
+    }
+
+    @Test
+    fun `replacement value with special HTML characters is stored as-is`() {
+        val input = buildJsonObject {
+            put("key", "rich-text")
+            put("richContent", buildJsonObject {
+                put("content", "Learn about {{company}}")
+                put("replacements", buildJsonObject {
+                    put("company", buildJsonObject {
+                        put("value", "AT&T <Wireless>")
+                        put("href", "https://att.com")
+                        put("type", "link")
+                        put("target", "_blank")
+                    })
+                })
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+
+        val replacement = collector.replacements["company"]
+        // value must be raw — rendering layer calls escapeHtml() before injecting into HTML
+        assertEquals("AT&T <Wireless>", replacement?.value)
+    }
+
+    @Test
+    fun `replacement href with injection attempt is stored as-is`() {
+        // The collector must not modify the server payload — escaping is deferred to render time
+        val maliciousHref = """https://evil.com" onclick="stealData()"""
+        val input = buildJsonObject {
+            put("key", "rich-text")
+            put("richContent", buildJsonObject {
+                put("content", "Click {{link}}")
+                put("replacements", buildJsonObject {
+                    put("link", buildJsonObject {
+                        put("value", "here")
+                        put("href", maliciousHref)
+                        put("type", "link")
+                        put("target", "_self")
+                    })
+                })
+            })
+        }
+        val collector = LabelCollector()
+        collector.init(input)
+
+        // Collector stores raw value; Label.kt's escapeHtml() neutralises it at render time
+        assertEquals(maliciousHref, collector.replacements["link"]?.href)
+    }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
@@ -8,12 +8,12 @@
 package com.pingidentity.davinci
 
 import com.pingidentity.davinci.collector.LabelCollector
-import com.pingidentity.davinci.collector.RichContentReplacement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class LabelCollectorTest {
@@ -46,8 +46,10 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
-        assertEquals("Plain text content", collector.richText)
-        assertTrue(collector.replacements.isEmpty())
+        val richContent = collector.richContent
+        assertNotNull(richContent)
+        assertEquals("Plain text content", richContent.richText)
+        assertTrue(richContent.replacements.isEmpty())
     }
 
     @Test
@@ -62,8 +64,11 @@ class LabelCollectorTest {
         val collector = LabelCollector()
         collector.init(input)
         assertEquals("A translatable rich text to take the user to google.com", collector.content)
-        assertEquals("A translatable rich text to take the user to {{link1}}", collector.richText)
-        assertTrue(collector.replacements.isEmpty())
+        val richContent = collector.richContent
+        assertNotNull(richContent)
+        val replacement = richContent.replacements
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.richText)
+        assertTrue(replacement.isEmpty())
     }
 
     @Test
@@ -85,11 +90,13 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
+        val richContent = collector.richContent
 
-        assertEquals("A translatable rich text to take the user to {{link1}}", collector.richText)
-        assertEquals(1, collector.replacements.size)
+        assertNotNull(richContent)
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.richText)
+        assertEquals(1, richContent.replacements.size)
 
-        val link1 = collector.replacements["link1"]
+        val link1 = richContent.replacements["link1"]
         assertEquals(RichContentReplacement(
             value = "google.com",
             href = "https://www.google.com",
@@ -108,7 +115,9 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
-        assertTrue(collector.replacements.isEmpty())
+        val richContent = collector.richContent
+        assertNotNull(richContent)
+        assertTrue(richContent.replacements.isEmpty())
     }
 
     @Test
@@ -118,11 +127,13 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
+        val richContent = collector.richContent
+        assertNotNull(richContent)
         assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", collector.content)
         // richText falls back to content since no richContent is present
-        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", collector.richText)
+        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", richContent.richText)
         assertEquals("", collector.key)
-        assertTrue(collector.replacements.isEmpty())
+        assertTrue(richContent.replacements.isEmpty())
     }
 
     @Test
@@ -136,12 +147,14 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
+        val richContent = collector.richContent
+        assertNotNull(richContent)
         // content retains the original value including trailing newlines
         assertEquals("Translatable Rich Text produce LABELs too!\n\n", collector.content)
         // richText is trimmed to the richContent value
-        assertEquals("Translatable Rich Text produce LABELs too!", collector.richText)
+        assertEquals("Translatable Rich Text produce LABELs too!", richContent.richText)
         assertEquals("translatable-rich-text-key", collector.key)
-        assertTrue(collector.replacements.isEmpty())
+        assertTrue(richContent.replacements.isEmpty())
     }
 
     @Test
@@ -163,8 +176,10 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
+        val richContent = collector.richContent
+        assertNotNull(richContent)
 
-        val replacement = collector.replacements["searchLink"]
+        val replacement = richContent.replacements["searchLink"]
         // href must be raw — escaping happens at render time, not parse time
         assertEquals("https://google.com/search?q=hello&lang=en", replacement?.href)
         assertEquals("Google", replacement?.value)
@@ -188,8 +203,10 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
+        val richContent = collector.richContent
+        assertNotNull(richContent)
 
-        val replacement = collector.replacements["company"]
+        val replacement = richContent.replacements["company"]
         // value must be raw — rendering layer calls escapeHtml() before injecting into HTML
         assertEquals("AT&T <Wireless>", replacement?.value)
     }
@@ -214,8 +231,10 @@ class LabelCollectorTest {
         }
         val collector = LabelCollector()
         collector.init(input)
+        val richContent = collector.richContent
+        assertNotNull(richContent)
 
         // Collector stores raw value; Label.kt's escapeHtml() neutralises it at render time
-        assertEquals(maliciousHref, collector.replacements["link"]?.href)
+        assertEquals(maliciousHref, richContent.replacements["link"]?.href)
     }
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/RichText.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/RichText.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.app.davinci
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.style.TextDecoration
+import com.pingidentity.davinci.RichContent
+import com.pingidentity.davinci.RichContentReplacement
+import com.pingidentity.davinci.collector.escapeHtml
+
+object RichText {
+
+    val tokenPattern = Regex("""\{\{(\w+)\}\}""")
+    val htmlTagPattern = Regex("""<[a-zA-Z][^>]*>""")
+
+    /**
+     * Builds an [AnnotatedString] from a [richContent] template that may contain
+     * `{{tokenName}}` placeholders. Each token found in [com.pingidentity.davinci.REPLACEMENTS] is
+     * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
+     * and [RichContentReplacement.value]. Unresolved tokens fall back to their
+     * raw placeholder text.
+     */
+    fun buildRichAnnotatedString(
+        richContent: RichContent,
+    ) = buildAnnotatedString {
+        var lastIndex = 0
+        for (match in tokenPattern.findAll(richContent.richText)) {
+            // Append any plain text before this token
+            append(richContent.richText.substring(lastIndex, match.range.first))
+
+            val token = match.groupValues[1]
+            val replacement = richContent.replacements[token]
+
+            if (replacement != null && replacement.href.isNotEmpty()) {
+                pushLink(
+                    LinkAnnotation.Url(
+                        url = replacement.href,
+                        styles = TextLinkStyles(
+                            style = SpanStyle(textDecoration = TextDecoration.Underline)
+                        )
+                    )
+                )
+                append(replacement.value)
+                pop()
+            } else {
+                // No replacement found – render the raw placeholder or display value
+                append(replacement?.value?.takeIf { it.isNotEmpty() } ?: match.value)
+            }
+
+            lastIndex = match.range.last + 1
+        }
+        // Append any remaining plain text after the last token
+        append(richContent.richText.substring(lastIndex))
+    }
+
+    /**
+     * Overload for building rich text from a generic [RichContent] with an optional fallback string
+     * if the content is null. This can be used for any field that supports rich content, not just labels.
+     *
+     * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
+     *    inline clickable links are substituted from [richContent].
+     * 2. **HTML** — `richText` contains HTML tags →
+     *    rendered via [AnnotatedString.Companion.fromHtml].
+     * 3. **Plain text** — everything else → rendered as-is.
+     *
+     * @param richContent The [RichContent] to render, which may contain tokens and/or HTML.
+     * @param fallbackContent A plain string to use if [richContent] is null.
+     *
+     * @return An [AnnotatedString] with tokens replaced and HTML rendered as appropriate, or the fallback content if [richContent] is null.
+     */
+    fun buildRichTextLabel(
+        richContent: RichContent?,
+        fallbackContent: String = "",
+    ): AnnotatedString {
+        if (richContent == null) return AnnotatedString(fallbackContent)
+        val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
+        val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
+        return when {
+            hasTokens && hasHtml ->
+                AnnotatedString
+                    .fromHtml(
+                        tokenPattern.replace(richContent.richText) { match ->
+                            val token = match.groupValues[1]
+                            val replacement = richContent.replacements[token]
+                            when {
+                                replacement?.href?.isNotEmpty() == true -> {
+                                    val label = replacement.value.ifEmpty { match.value }.escapeHtml()
+                                    val safeHref = replacement.href.escapeHtml()
+                                    """<a href="$safeHref">$label</a>"""
+                                }
+                                replacement?.value?.isNotEmpty() == true -> replacement.value.escapeHtml()
+                                else -> match.value
+                            }
+                        }
+                    )
+            hasTokens ->
+                buildRichAnnotatedString(richContent)
+            hasHtml ->
+                AnnotatedString.fromHtml(richContent.richText)
+            else ->
+                AnnotatedString(richContent.richText)
+        }
+    }
+}

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
@@ -23,8 +23,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.RichContent
+import com.pingidentity.davinci.RichContentReplacement
 import com.pingidentity.davinci.collector.LabelCollector
-import com.pingidentity.davinci.collector.RichContentReplacement
 import com.pingidentity.davinci.collector.escapeHtml
 
 private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
@@ -51,22 +52,22 @@ fun Label(field: LabelCollector) {
  * Selects the appropriate rendering strategy for a [LabelCollector]:
  *
  * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
- *    inline clickable links are substituted from [LabelCollector.replacements].
+ *    inline clickable links are substituted from [LabelCollector.richContent].
  * 2. **HTML** — `richText` contains HTML tags →
  *    rendered via [AnnotatedString.Companion.fromHtml].
  * 3. **Plain text** — everything else → rendered as-is.
  */
 private fun buildLabelText(field: LabelCollector): AnnotatedString {
-    val text = field.richText
-    val hasTokens = tokenPattern.containsMatchIn(text)
-    val hasHtml = htmlTagPattern.containsMatchIn(text)
+    val richContent = field.richContent ?: return AnnotatedString(field.content)
+    val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
+    val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
     return when {
         hasTokens && hasHtml ->
             AnnotatedString
                 .fromHtml(
-                    tokenPattern.replace(text) { match ->
+                    tokenPattern.replace(richContent.richText) { match ->
                         val token = match.groupValues[1]
-                        val replacement = field.replacements[token]
+                        val replacement = richContent.replacements[token]
                         when {
                             replacement?.href?.isNotEmpty() == true -> {
                                 val label = replacement.value.ifEmpty { match.value }.escapeHtml()
@@ -79,32 +80,31 @@ private fun buildLabelText(field: LabelCollector): AnnotatedString {
                     }
                 )
         hasTokens ->
-            buildRichAnnotatedString(text, field.replacements)
+            buildRichAnnotatedString(richContent)
         hasHtml ->
-            AnnotatedString.fromHtml(text)
+            AnnotatedString.fromHtml(richContent.richText)
         else ->
-            AnnotatedString(text)
+            AnnotatedString(richContent.richText)
     }
 }
 
 /**
- * Builds an [AnnotatedString] from a [richText] template that may contain
- * `{{tokenName}}` placeholders. Each token found in [replacements] is
+ * Builds an [AnnotatedString] from a [richContent] template that may contain
+ * `{{tokenName}}` placeholders. Each token found in [com.pingidentity.davinci.REPLACEMENTS] is
  * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
  * and [RichContentReplacement.value]. Unresolved tokens fall back to their
  * raw placeholder text.
  */
 private fun buildRichAnnotatedString(
-    richText: String,
-    replacements: Map<String, RichContentReplacement>,
+    richContent: RichContent,
 ) = buildAnnotatedString {
     var lastIndex = 0
-    for (match in tokenPattern.findAll(richText)) {
+    for (match in tokenPattern.findAll(richContent.richText)) {
         // Append any plain text before this token
-        append(richText.substring(lastIndex, match.range.first))
+        append(richContent.richText.substring(lastIndex, match.range.first))
 
         val token = match.groupValues[1]
-        val replacement = replacements[token]
+        val replacement = richContent.replacements[token]
 
         if (replacement != null && replacement.href.isNotEmpty()) {
             pushLink(
@@ -125,5 +125,5 @@ private fun buildRichAnnotatedString(
         lastIndex = match.range.last + 1
     }
     // Append any remaining plain text after the last token
-    append(richText.substring(lastIndex))
+    append(richContent.richText.substring(lastIndex))
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
@@ -15,25 +15,115 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.pingidentity.davinci.collector.LabelCollector
+import com.pingidentity.davinci.collector.RichContentReplacement
+import com.pingidentity.davinci.collector.escapeHtml
+
+private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
+private val htmlTagPattern = Regex("""<[a-zA-Z][^>]*>""")
 
 @Composable
-fun Label(
-    field: LabelCollector
-) {
+fun Label(field: LabelCollector) {
     Row(
-        modifier =
-        Modifier
+        modifier = Modifier
             .padding(4.dp)
             .fillMaxWidth(),
     ) {
         androidx.compose.material3.Text(
-            text = field.content,
+            text = buildLabelText(field),
             style = MaterialTheme.typography.labelLarge,
             modifier = Modifier
                 .wrapContentWidth(Alignment.CenterHorizontally)
                 .weight(1f)
         )
     }
+}
+
+/**
+ * Selects the appropriate rendering strategy for a [LabelCollector]:
+ *
+ * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
+ *    inline clickable links are substituted from [LabelCollector.replacements].
+ * 2. **HTML** — `richText` contains HTML tags →
+ *    rendered via [AnnotatedString.Companion.fromHtml].
+ * 3. **Plain text** — everything else → rendered as-is.
+ */
+private fun buildLabelText(field: LabelCollector): AnnotatedString {
+    val text = field.richText
+    val hasTokens = tokenPattern.containsMatchIn(text)
+    val hasHtml = htmlTagPattern.containsMatchIn(text)
+    return when {
+        hasTokens && hasHtml ->
+            AnnotatedString
+                .fromHtml(
+                    tokenPattern.replace(text) { match ->
+                        val token = match.groupValues[1]
+                        val replacement = field.replacements[token]
+                        when {
+                            replacement?.href?.isNotEmpty() == true -> {
+                                val label = replacement.value.ifEmpty { match.value }.escapeHtml()
+                                val safeHref = replacement.href.escapeHtml()
+                                """<a href="$safeHref">$label</a>"""
+                            }
+                            replacement?.value?.isNotEmpty() == true -> replacement.value.escapeHtml()
+                            else -> match.value
+                        }
+                    }
+                )
+        hasTokens ->
+            buildRichAnnotatedString(text, field.replacements)
+        hasHtml ->
+            AnnotatedString.fromHtml(text)
+        else ->
+            AnnotatedString(text)
+    }
+}
+
+/**
+ * Builds an [AnnotatedString] from a [richText] template that may contain
+ * `{{tokenName}}` placeholders. Each token found in [replacements] is
+ * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
+ * and [RichContentReplacement.value]. Unresolved tokens fall back to their
+ * raw placeholder text.
+ */
+private fun buildRichAnnotatedString(
+    richText: String,
+    replacements: Map<String, RichContentReplacement>,
+) = buildAnnotatedString {
+    var lastIndex = 0
+    for (match in tokenPattern.findAll(richText)) {
+        // Append any plain text before this token
+        append(richText.substring(lastIndex, match.range.first))
+
+        val token = match.groupValues[1]
+        val replacement = replacements[token]
+
+        if (replacement != null && replacement.href.isNotEmpty()) {
+            pushLink(
+                LinkAnnotation.Url(
+                    url = replacement.href,
+                    styles = TextLinkStyles(
+                        style = SpanStyle(textDecoration = TextDecoration.Underline)
+                    )
+                )
+            )
+            append(replacement.value)
+            pop()
+        } else {
+            // No replacement found – render the raw placeholder or display value
+            append(replacement?.value?.takeIf { it.isNotEmpty() } ?: match.value)
+        }
+
+        lastIndex = match.range.last + 1
+    }
+    // Append any remaining plain text after the last token
+    append(richText.substring(lastIndex))
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/Label.kt
@@ -15,21 +15,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.fromHtml
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.RichContent
-import com.pingidentity.davinci.RichContentReplacement
 import com.pingidentity.davinci.collector.LabelCollector
-import com.pingidentity.davinci.collector.escapeHtml
-
-private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
-private val htmlTagPattern = Regex("""<[a-zA-Z][^>]*>""")
+import com.pingidentity.samples.app.davinci.RichText.buildRichTextLabel
 
 @Composable
 fun Label(field: LabelCollector) {
@@ -39,91 +27,14 @@ fun Label(field: LabelCollector) {
             .fillMaxWidth(),
     ) {
         androidx.compose.material3.Text(
-            text = buildLabelText(field),
+            text = buildRichTextLabel(
+                richContent = field.richContent,
+                fallbackContent = field.content,
+            ),
             style = MaterialTheme.typography.labelLarge,
             modifier = Modifier
                 .wrapContentWidth(Alignment.CenterHorizontally)
                 .weight(1f)
         )
     }
-}
-
-/**
- * Selects the appropriate rendering strategy for a [LabelCollector]:
- *
- * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
- *    inline clickable links are substituted from [LabelCollector.richContent].
- * 2. **HTML** — `richText` contains HTML tags →
- *    rendered via [AnnotatedString.Companion.fromHtml].
- * 3. **Plain text** — everything else → rendered as-is.
- */
-private fun buildLabelText(field: LabelCollector): AnnotatedString {
-    val richContent = field.richContent ?: return AnnotatedString(field.content)
-    val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
-    val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
-    return when {
-        hasTokens && hasHtml ->
-            AnnotatedString
-                .fromHtml(
-                    tokenPattern.replace(richContent.richText) { match ->
-                        val token = match.groupValues[1]
-                        val replacement = richContent.replacements[token]
-                        when {
-                            replacement?.href?.isNotEmpty() == true -> {
-                                val label = replacement.value.ifEmpty { match.value }.escapeHtml()
-                                val safeHref = replacement.href.escapeHtml()
-                                """<a href="$safeHref">$label</a>"""
-                            }
-                            replacement?.value?.isNotEmpty() == true -> replacement.value.escapeHtml()
-                            else -> match.value
-                        }
-                    }
-                )
-        hasTokens ->
-            buildRichAnnotatedString(richContent)
-        hasHtml ->
-            AnnotatedString.fromHtml(richContent.richText)
-        else ->
-            AnnotatedString(richContent.richText)
-    }
-}
-
-/**
- * Builds an [AnnotatedString] from a [richContent] template that may contain
- * `{{tokenName}}` placeholders. Each token found in [com.pingidentity.davinci.REPLACEMENTS] is
- * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
- * and [RichContentReplacement.value]. Unresolved tokens fall back to their
- * raw placeholder text.
- */
-private fun buildRichAnnotatedString(
-    richContent: RichContent,
-) = buildAnnotatedString {
-    var lastIndex = 0
-    for (match in tokenPattern.findAll(richContent.richText)) {
-        // Append any plain text before this token
-        append(richContent.richText.substring(lastIndex, match.range.first))
-
-        val token = match.groupValues[1]
-        val replacement = richContent.replacements[token]
-
-        if (replacement != null && replacement.href.isNotEmpty()) {
-            pushLink(
-                LinkAnnotation.Url(
-                    url = replacement.href,
-                    styles = TextLinkStyles(
-                        style = SpanStyle(textDecoration = TextDecoration.Underline)
-                    )
-                )
-            )
-            append(replacement.value)
-            pop()
-        } else {
-            // No replacement found – render the raw placeholder or display value
-            append(replacement?.value?.takeIf { it.isNotEmpty() } ?: match.value)
-        }
-
-        lastIndex = match.range.last + 1
-    }
-    // Append any remaining plain text after the last token
-    append(richContent.richText.substring(lastIndex))
 }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/RichText.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/RichText.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.style.TextDecoration
+import com.pingidentity.davinci.RichContent
+import com.pingidentity.davinci.RichContentReplacement
+import com.pingidentity.davinci.collector.escapeHtml
+
+object RichText {
+
+    val tokenPattern = Regex("""\{\{(\w+)\}\}""")
+    val htmlTagPattern = Regex("""<[a-zA-Z][^>]*>""")
+
+    /**
+     * Builds an [AnnotatedString] from a [richContent] template that may contain
+     * `{{tokenName}}` placeholders. Each token found in [com.pingidentity.davinci.REPLACEMENTS] is
+     * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
+     * and [RichContentReplacement.value]. Unresolved tokens fall back to their
+     * raw placeholder text.
+     */
+    fun buildRichAnnotatedString(
+        richContent: RichContent,
+    ) = buildAnnotatedString {
+        var lastIndex = 0
+        for (match in tokenPattern.findAll(richContent.richText)) {
+            // Append any plain text before this token
+            append(richContent.richText.substring(lastIndex, match.range.first))
+
+            val token = match.groupValues[1]
+            val replacement = richContent.replacements[token]
+
+            if (replacement != null && replacement.href.isNotEmpty()) {
+                pushLink(
+                    LinkAnnotation.Url(
+                        url = replacement.href,
+                        styles = TextLinkStyles(
+                            style = SpanStyle(textDecoration = TextDecoration.Underline)
+                        )
+                    )
+                )
+                append(replacement.value)
+                pop()
+            } else {
+                // No replacement found – render the raw placeholder or display value
+                append(replacement?.value?.takeIf { it.isNotEmpty() } ?: match.value)
+            }
+
+            lastIndex = match.range.last + 1
+        }
+        // Append any remaining plain text after the last token
+        append(richContent.richText.substring(lastIndex))
+    }
+
+    /**
+     * Overload for building rich text from a generic [RichContent] with an optional fallback string
+     * if the content is null. This can be used for any field that supports rich content, not just labels.
+     *
+     * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
+     *    inline clickable links are substituted from [richContent].
+     * 2. **HTML** — `richText` contains HTML tags →
+     *    rendered via [AnnotatedString.Companion.fromHtml].
+     * 3. **Plain text** — everything else → rendered as-is.
+     *
+     * @param richContent The [RichContent] to render, which may contain tokens and/or HTML.
+     * @param fallbackContent A plain string to use if [richContent] is null.
+     *
+     * @return An [AnnotatedString] with tokens replaced and HTML rendered as appropriate, or the fallback content if [richContent] is null.
+     */
+    fun buildRichTextLabel(
+        richContent: RichContent?,
+        fallbackContent: String = "",
+    ): AnnotatedString {
+        if (richContent == null) return AnnotatedString(fallbackContent)
+        val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
+        val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
+        return when {
+            hasTokens && hasHtml ->
+                AnnotatedString
+                    .fromHtml(
+                        tokenPattern.replace(richContent.richText) { match ->
+                            val token = match.groupValues[1]
+                            val replacement = richContent.replacements[token]
+                            when {
+                                replacement?.href?.isNotEmpty() == true -> {
+                                    val label = replacement.value.ifEmpty { match.value }.escapeHtml()
+                                    val safeHref = replacement.href.escapeHtml()
+                                    """<a href="$safeHref">$label</a>"""
+                                }
+                                replacement?.value?.isNotEmpty() == true -> replacement.value.escapeHtml()
+                                else -> match.value
+                            }
+                        }
+                    )
+            hasTokens ->
+                buildRichAnnotatedString(richContent)
+            hasHtml ->
+                AnnotatedString.fromHtml(richContent.richText)
+            else ->
+                AnnotatedString(richContent.richText)
+        }
+    }
+}

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Label.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Label.kt
@@ -23,8 +23,9 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.RichContent
+import com.pingidentity.davinci.RichContentReplacement
 import com.pingidentity.davinci.collector.LabelCollector
-import com.pingidentity.davinci.collector.RichContentReplacement
 import com.pingidentity.davinci.collector.escapeHtml
 
 private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
@@ -51,22 +52,22 @@ fun Label(field: LabelCollector) {
  * Selects the appropriate rendering strategy for a [LabelCollector]:
  *
  * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
- *    inline clickable links are substituted from [LabelCollector.replacements].
+ *    inline clickable links are substituted from [LabelCollector.richContent].
  * 2. **HTML** — `richText` contains HTML tags →
  *    rendered via [AnnotatedString.Companion.fromHtml].
  * 3. **Plain text** — everything else → rendered as-is.
  */
 private fun buildLabelText(field: LabelCollector): AnnotatedString {
-    val text = field.richText
-    val hasTokens = tokenPattern.containsMatchIn(text)
-    val hasHtml = htmlTagPattern.containsMatchIn(text)
+    val richContent = field.richContent ?: return AnnotatedString(field.content)
+    val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
+    val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
     return when {
         hasTokens && hasHtml ->
             AnnotatedString
                 .fromHtml(
-                    tokenPattern.replace(text) { match ->
+                    tokenPattern.replace(richContent.richText) { match ->
                         val token = match.groupValues[1]
-                        val replacement = field.replacements[token]
+                        val replacement = richContent.replacements[token]
                         when {
                             replacement?.href?.isNotEmpty() == true -> {
                                 val label = replacement.value.ifEmpty { match.value }.escapeHtml()
@@ -78,36 +79,31 @@ private fun buildLabelText(field: LabelCollector): AnnotatedString {
                         }
                     }
                 )
-
         hasTokens ->
-            buildRichAnnotatedString(text, field.replacements)
-
+            buildRichAnnotatedString(richContent)
         hasHtml ->
-            AnnotatedString.fromHtml(text)
-
+            AnnotatedString.fromHtml(richContent.richText)
         else ->
-            AnnotatedString(text)
+            AnnotatedString(richContent.richText)
     }
 }
-
 /**
- * Builds an [AnnotatedString] from a [richText] template that may contain
- * `{{tokenName}}` placeholders. Each token found in [replacements] is
+ * Builds an [AnnotatedString] from a [richContent] template that may contain
+ * `{{tokenName}}` placeholders. Each token found in [com.pingidentity.davinci.REPLACEMENTS] is
  * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
  * and [RichContentReplacement.value]. Unresolved tokens fall back to their
  * raw placeholder text.
  */
 private fun buildRichAnnotatedString(
-    richText: String,
-    replacements: Map<String, RichContentReplacement>,
+    richContent: RichContent,
 ) = buildAnnotatedString {
     var lastIndex = 0
-    for (match in tokenPattern.findAll(richText)) {
+    for (match in tokenPattern.findAll(richContent.richText)) {
         // Append any plain text before this token
-        append(richText.substring(lastIndex, match.range.first))
+        append(richContent.richText.substring(lastIndex, match.range.first))
 
         val token = match.groupValues[1]
-        val replacement = replacements[token]
+        val replacement = richContent.replacements[token]
 
         if (replacement != null && replacement.href.isNotEmpty()) {
             pushLink(
@@ -128,5 +124,5 @@ private fun buildRichAnnotatedString(
         lastIndex = match.range.last + 1
     }
     // Append any remaining plain text after the last token
-    append(richText.substring(lastIndex))
+    append(richContent.richText.substring(lastIndex))
 }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Label.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Label.kt
@@ -15,21 +15,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.TextLinkStyles
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.fromHtml
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.RichContent
-import com.pingidentity.davinci.RichContentReplacement
 import com.pingidentity.davinci.collector.LabelCollector
-import com.pingidentity.davinci.collector.escapeHtml
+import com.pingidentity.samples.pingsampleapp.davinci.RichText.buildRichTextLabel
 
-private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
-private val htmlTagPattern = Regex("""<[a-zA-Z][^>]*>""")
 
 @Composable
 fun Label(field: LabelCollector) {
@@ -39,90 +28,14 @@ fun Label(field: LabelCollector) {
             .fillMaxWidth(),
     ) {
         androidx.compose.material3.Text(
-            text = buildLabelText(field),
+            text = buildRichTextLabel(
+                richContent = field.richContent,
+                fallbackContent = field.content,
+            ),
             style = MaterialTheme.typography.labelLarge,
             modifier = Modifier
                 .wrapContentWidth(Alignment.CenterHorizontally)
                 .weight(1f)
         )
     }
-}
-
-/**
- * Selects the appropriate rendering strategy for a [LabelCollector]:
- *
- * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
- *    inline clickable links are substituted from [LabelCollector.richContent].
- * 2. **HTML** — `richText` contains HTML tags →
- *    rendered via [AnnotatedString.Companion.fromHtml].
- * 3. **Plain text** — everything else → rendered as-is.
- */
-private fun buildLabelText(field: LabelCollector): AnnotatedString {
-    val richContent = field.richContent ?: return AnnotatedString(field.content)
-    val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
-    val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
-    return when {
-        hasTokens && hasHtml ->
-            AnnotatedString
-                .fromHtml(
-                    tokenPattern.replace(richContent.richText) { match ->
-                        val token = match.groupValues[1]
-                        val replacement = richContent.replacements[token]
-                        when {
-                            replacement?.href?.isNotEmpty() == true -> {
-                                val label = replacement.value.ifEmpty { match.value }.escapeHtml()
-                                val safeHref = replacement.href.escapeHtml()
-                                """<a href="$safeHref">$label</a>"""
-                            }
-                            replacement?.value?.isNotEmpty() == true -> replacement.value.escapeHtml()
-                            else -> match.value
-                        }
-                    }
-                )
-        hasTokens ->
-            buildRichAnnotatedString(richContent)
-        hasHtml ->
-            AnnotatedString.fromHtml(richContent.richText)
-        else ->
-            AnnotatedString(richContent.richText)
-    }
-}
-/**
- * Builds an [AnnotatedString] from a [richContent] template that may contain
- * `{{tokenName}}` placeholders. Each token found in [com.pingidentity.davinci.REPLACEMENTS] is
- * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
- * and [RichContentReplacement.value]. Unresolved tokens fall back to their
- * raw placeholder text.
- */
-private fun buildRichAnnotatedString(
-    richContent: RichContent,
-) = buildAnnotatedString {
-    var lastIndex = 0
-    for (match in tokenPattern.findAll(richContent.richText)) {
-        // Append any plain text before this token
-        append(richContent.richText.substring(lastIndex, match.range.first))
-
-        val token = match.groupValues[1]
-        val replacement = richContent.replacements[token]
-
-        if (replacement != null && replacement.href.isNotEmpty()) {
-            pushLink(
-                LinkAnnotation.Url(
-                    url = replacement.href,
-                    styles = TextLinkStyles(
-                        style = SpanStyle(textDecoration = TextDecoration.Underline)
-                    )
-                )
-            )
-            append(replacement.value)
-            pop()
-        } else {
-            // No replacement found – render the raw placeholder or display value
-            append(replacement?.value?.takeIf { it.isNotEmpty() } ?: match.value)
-        }
-
-        lastIndex = match.range.last + 1
-    }
-    // Append any remaining plain text after the last token
-    append(richContent.richText.substring(lastIndex))
 }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Label.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Label.kt
@@ -15,25 +15,118 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.fromHtml
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.pingidentity.davinci.collector.LabelCollector
+import com.pingidentity.davinci.collector.RichContentReplacement
+import com.pingidentity.davinci.collector.escapeHtml
+
+private val tokenPattern = Regex("""\{\{(\w+)\}\}""")
+private val htmlTagPattern = Regex("""<[a-zA-Z][^>]*>""")
 
 @Composable
-fun Label(
-    field: LabelCollector
-) {
+fun Label(field: LabelCollector) {
     Row(
-        modifier =
-        Modifier
+        modifier = Modifier
             .padding(4.dp)
             .fillMaxWidth(),
     ) {
         androidx.compose.material3.Text(
-            text = field.content,
+            text = buildLabelText(field),
             style = MaterialTheme.typography.labelLarge,
             modifier = Modifier
                 .wrapContentWidth(Alignment.CenterHorizontally)
                 .weight(1f)
         )
     }
+}
+
+/**
+ * Selects the appropriate rendering strategy for a [LabelCollector]:
+ *
+ * 1. **Token replacement** — `richText` contains `{{token}}` placeholders →
+ *    inline clickable links are substituted from [LabelCollector.replacements].
+ * 2. **HTML** — `richText` contains HTML tags →
+ *    rendered via [AnnotatedString.Companion.fromHtml].
+ * 3. **Plain text** — everything else → rendered as-is.
+ */
+private fun buildLabelText(field: LabelCollector): AnnotatedString {
+    val text = field.richText
+    val hasTokens = tokenPattern.containsMatchIn(text)
+    val hasHtml = htmlTagPattern.containsMatchIn(text)
+    return when {
+        hasTokens && hasHtml ->
+            AnnotatedString
+                .fromHtml(
+                    tokenPattern.replace(text) { match ->
+                        val token = match.groupValues[1]
+                        val replacement = field.replacements[token]
+                        when {
+                            replacement?.href?.isNotEmpty() == true -> {
+                                val label = replacement.value.ifEmpty { match.value }.escapeHtml()
+                                val safeHref = replacement.href.escapeHtml()
+                                """<a href="$safeHref">$label</a>"""
+                            }
+                            replacement?.value?.isNotEmpty() == true -> replacement.value.escapeHtml()
+                            else -> match.value
+                        }
+                    }
+                )
+
+        hasTokens ->
+            buildRichAnnotatedString(text, field.replacements)
+
+        hasHtml ->
+            AnnotatedString.fromHtml(text)
+
+        else ->
+            AnnotatedString(text)
+    }
+}
+
+/**
+ * Builds an [AnnotatedString] from a [richText] template that may contain
+ * `{{tokenName}}` placeholders. Each token found in [replacements] is
+ * rendered as a clickable hyperlink using the token's [RichContentReplacement.href]
+ * and [RichContentReplacement.value]. Unresolved tokens fall back to their
+ * raw placeholder text.
+ */
+private fun buildRichAnnotatedString(
+    richText: String,
+    replacements: Map<String, RichContentReplacement>,
+) = buildAnnotatedString {
+    var lastIndex = 0
+    for (match in tokenPattern.findAll(richText)) {
+        // Append any plain text before this token
+        append(richText.substring(lastIndex, match.range.first))
+
+        val token = match.groupValues[1]
+        val replacement = replacements[token]
+
+        if (replacement != null && replacement.href.isNotEmpty()) {
+            pushLink(
+                LinkAnnotation.Url(
+                    url = replacement.href,
+                    styles = TextLinkStyles(
+                        style = SpanStyle(textDecoration = TextDecoration.Underline)
+                    )
+                )
+            )
+            append(replacement.value)
+            pop()
+        } else {
+            // No replacement found – render the raw placeholder or display value
+            append(replacement?.value?.takeIf { it.isNotEmpty() } ?: match.value)
+        }
+
+        lastIndex = match.range.last + 1
+    }
+    // Append any remaining plain text after the last token
+    append(richText.substring(lastIndex))
 }


### PR DESCRIPTION
# JIRA Ticket
[SDKS-4246](https://pingidentity.atlassian.net/browse/SDKS-4246)

# Description
This PR includes changes for Rich text forms which may contain URLs and other rich content text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich-text support for form labels, including HTML markup and token-driven dynamic links
  * Token replacements (e.g., {{link1}}) render as clickable links when provided, with proper fallback text when not

* **Bug Fixes**
  * Safer handling of label content and link attributes to preserve exact values and avoid injection/escaping issues

* **Tests**
  * Expanded unit tests covering rich-text parsing, link replacements, and HTML-escaping behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->