### PR TITLE
SDKS-4927 Rename `AgreementCollector` to `ReadOnlyTextCollector` to align with the DaVinci `READ_ONLY_TEXT` input type

### DIFF
--- a/davinci/README.md
+++ b/davinci/README.md
@@ -119,7 +119,7 @@ when (node) {
 For a `ContinueNode`, you can access the list of collectors using `node.collectors()` and provide input to the desired
 `Collector`.
 Currently, the available collectors include `TextCollector`, `PasswordCollector`, `SubmitCollector`, `FlowCollector`,
-`LabelCollector`, `MultiSelectCollector`, `SingleSelectCollector`, `AgreementCollector`. Additional collectors, such as `Fido` and
+`LabelCollector`, `MultiSelectCollector`, `SingleSelectCollector`, `ReadOnlyTextCollector`. Additional collectors, such as `Fido` and
 `IdpCollector`, will be added in the future.
 
 To access the collectors, you can use the following code:

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -8,7 +8,6 @@
 package com.pingidentity.davinci
 
 import com.pingidentity.android.ModuleInitializer
-import com.pingidentity.davinci.collector.AgreementCollector
 import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
 import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
@@ -16,6 +15,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
@@ -60,10 +60,8 @@ internal class CollectorRegistry : ModuleInitializer() {
         CollectorFactory.register("DEVICE_AUTHENTICATION", ::DeviceAuthenticationCollector)
         CollectorFactory.register("PHONE_NUMBER", ::PhoneNumberCollector)
 
+        CollectorFactory.register("READ_ONLY_TEXT", ::ReadOnlyTextCollector)
         CollectorFactory.register("POLLING", ::PollingCollector)
         CollectorFactory.register("QR_CODE", ::QRCodeCollector)
-
-        // AGREEMENT fields use inputType "READ_ONLY_TEXT" which is the factory lookup key
-        CollectorFactory.register("READ_ONLY_TEXT", ::AgreementCollector)
     }
 }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ReadOnlyTextCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ReadOnlyTextCollector.kt
@@ -24,10 +24,10 @@ private const val ID = "id"
 private const val USE_DYNAMIC_AGREEMENT = "useDynamicAgreement"
 
 /**
- * Class representing an AGREEMENT type collector.
+ * Class representing a READ_ONLY_TEXT type collector.
  *
- * This class handles the response from a DaVinci form field of type AGREEMENT.
- * It displays agreement/terms-of-service text and collects the user's acceptance.
+ * This class handles the response from a DaVinci form field of type READ_ONLY_TEXT (inputType).
+ * It displays read-only text content such as agreement/terms-of-service text.
  *
  * Example JSON:
  * ```json
@@ -46,9 +46,9 @@ private const val USE_DYNAMIC_AGREEMENT = "useDynamicAgreement"
  * }
  * ```
  *
- * @constructor Creates a new AgreementCollector.
+ * @constructor Creates a new ReadOnlyTextCollector.
  */
-class AgreementCollector : Collector<Nothing> {
+class ReadOnlyTextCollector : Collector<Nothing> {
 
     /**
      * The key identifier for this collector, used as the form field key during submission.
@@ -63,19 +63,19 @@ class AgreementCollector : Collector<Nothing> {
         private set
 
     /**
-     * The agreement text content to display to the user.
+     * The text content to display to the user.
      */
     var content = ""
         private set
 
     /**
-     * The title of the agreement (shown when [titleEnabled] is true).
+     * The title (shown when [titleEnabled] is true).
      */
     var title = ""
         private set
 
     /**
-     * Whether to display the [title] above the agreement content.
+     * Whether to display the [title] above the content.
      */
     var titleEnabled = false
         private set
@@ -98,7 +98,7 @@ class AgreementCollector : Collector<Nothing> {
     var useDynamicAgreement = false
         private set
 
-    override fun init(input: JsonObject): AgreementCollector {
+    override fun init(input: JsonObject): ReadOnlyTextCollector {
         key = input[KEY]?.jsonPrimitive?.content ?: ""
         type = input[TYPE]?.jsonPrimitive?.content ?: ""
         content = input[CONTENT]?.jsonPrimitive?.content ?: ""
@@ -116,4 +116,3 @@ class AgreementCollector : Collector<Nothing> {
 
     override fun id(): String = key
 }
-

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/ReadOnlyTextCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/ReadOnlyTextCollectorTest.kt
@@ -7,7 +7,7 @@
 
 package com.pingidentity.davinci
 
-import com.pingidentity.davinci.collector.AgreementCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -17,7 +17,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class AgreementCollectorTest {
+class ReadOnlyTextCollectorTest {
 
     // Full JSON as returned by the DaVinci server
     private fun buildFullAgreementJson(): JsonObject = buildJsonObject {
@@ -36,19 +36,19 @@ class AgreementCollectorTest {
 
     @Test
     fun initializesKeyFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertEquals("agreement", collector.key)
     }
 
     @Test
     fun initializesTypeFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertEquals("AGREEMENT", collector.type)
     }
 
     @Test
     fun initializesContentFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertEquals(
             "This is example agreement text, you can edit this text in the agreements section.",
             collector.content
@@ -57,43 +57,43 @@ class AgreementCollectorTest {
 
     @Test
     fun initializesTitleFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertEquals("Terms of Service Agreement", collector.title)
     }
 
     @Test
     fun initializesTitleEnabledFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertTrue(collector.titleEnabled)
     }
 
     @Test
     fun initializesEnabledFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertTrue(collector.enabled)
     }
 
     @Test
     fun initializesAgreementIdFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertEquals("6ff30c9e-cd98-4fe5-85ca-01111ca20702", collector.agreementId)
     }
 
     @Test
     fun initializesUseDynamicAgreementFromJson() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertFalse(collector.useDynamicAgreement)
     }
 
     @Test
     fun idReturnsKey() {
-        val collector = AgreementCollector().apply { init(buildFullAgreementJson()) }
+        val collector = ReadOnlyTextCollector().apply { init(buildFullAgreementJson()) }
         assertEquals("agreement", collector.id())
     }
 
     @Test
     fun initializesWithDefaultsWhenJsonIsEmpty() {
-        val collector = AgreementCollector().apply { init(JsonObject(emptyMap())) }
+        val collector = ReadOnlyTextCollector().apply { init(JsonObject(emptyMap())) }
         assertEquals("", collector.key)
         assertEquals("", collector.type)
         assertEquals("", collector.content)
@@ -107,9 +107,8 @@ class AgreementCollectorTest {
     @Test
     fun titleEnabledFalseWhenNotProvided() {
         val input = buildJsonObject { put("key", "agreement") }
-        val collector = AgreementCollector().apply { init(input) }
+        val collector = ReadOnlyTextCollector().apply { init(input) }
         assertFalse(collector.titleEnabled)
     }
 
 }
-

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ContinueNode.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.collector.AgreementCollector
 import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
 import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
@@ -30,6 +29,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
@@ -100,7 +100,7 @@ fun ContinueNode(
                 is SubmitCollector -> SubmitButton(it, onNext)
                 is TextCollector -> Text(it, onNodeUpdated)
                 is LabelCollector -> Label(it)
-                is AgreementCollector -> Agreement(it)
+                is ReadOnlyTextCollector -> ReadOnlyText(it)
                 is MultiSelectCollector -> {
                     if (it.type == "COMBOBOX") {
                         ComboBox(it, onNodeUpdated)

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ReadOnlyText.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/collector/ReadOnlyText.kt
@@ -25,10 +25,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.collector.AgreementCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 
 @Composable
-fun Agreement(field: AgreementCollector) {
+fun ReadOnlyText(field: ReadOnlyTextCollector) {
 
     OutlinedCard(
         modifier = Modifier

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.collector.AgreementCollector
 import com.pingidentity.davinci.collector.DeviceAuthenticationCollector
 import com.pingidentity.davinci.collector.DeviceRegistrationCollector
 import com.pingidentity.davinci.collector.FlowCollector
@@ -30,6 +29,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
@@ -100,7 +100,7 @@ fun DaVinciContinueNode(
                 is SubmitCollector -> SubmitButton(it, onNext)
                 is TextCollector -> Text(it, onNodeUpdated)
                 is LabelCollector -> Label(it)
-                is AgreementCollector -> Agreement(it)
+                is ReadOnlyTextCollector -> ReadOnlyText(it)
                 is MultiSelectCollector -> {
                     if (it.type == "COMBOBOX") {
                         ComboBox(it, onNodeUpdated)

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/ReadOnlyText.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/ReadOnlyText.kt
@@ -25,10 +25,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.pingidentity.davinci.collector.AgreementCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 
 @Composable
-fun Agreement(field: AgreementCollector ) {
+fun ReadOnlyText(field: ReadOnlyTextCollector) {
 
     OutlinedCard(
         modifier = Modifier


### PR DESCRIPTION




# JIRA Ticket

[SDKS-4927](https://pingidentity.atlassian.net/browse/SDKS-4927)

# Description

- Rename `AgreementCollector` to `ReadOnlyTextCollector` across the library and sample applications to better represent its function of displaying read-only content.
- Update `CollectorRegistry` to map the `READ_ONLY_TEXT` factory key to the renamed `ReadOnlyTextCollector`.
- Rename the `Agreement` Compose UI component to `ReadOnlyText` and update its references in both sample apps.
- Update `ContinueNode` in sample applications to handle the `ReadOnlyTextCollector` type.
- Migrate and rename unit tests from `AgreementCollectorTest.kt` to `ReadOnlyTextCollectorTest.kt`.
- Update documentation in `davinci/README.md` to list `ReadOnlyTextCollector` as an available collector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the agreement-style collector to "ReadOnlyText" across the SDK and sample apps; runtime dispatch and UI now use the new collector and render read-only title/content.

* **Documentation**
  * README updated to list ReadOnlyText in the available collectors.

* **Tests**
  * Test suite updated to target and validate the renamed ReadOnlyText collector.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-android-sdk/pull/195)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->