### PR TITLE
SDKS-4930: Fix accounts not displaying after Auth migration.

### DIFF
--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/PingSampleApplication.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/PingSampleApplication.kt
@@ -96,7 +96,7 @@ class PingSampleApplication : Application() {
             }
             initializeSdkClients()
             initializeManagers()
-            initializeViewModel()
+            initializeAuthenticatorViewModel()
         }
     }
 
@@ -171,7 +171,7 @@ class PingSampleApplication : Application() {
     /**
      * Initializes the AuthenticatorViewModel.
      */
-    private fun initializeViewModel() {
+    private fun initializeAuthenticatorViewModel() {
         try {
             authenticatorViewModel = AuthenticatorViewModel(
                 application = this,
@@ -222,6 +222,32 @@ class PingSampleApplication : Application() {
                 return instance.viewModelDeferred.getCompleted()
             }
             return instance.viewModelDeferred.await()
+        }
+
+        /**
+         * Closes the existing MFA clients (clearing their in-memory credential caches and
+         * SQLite database connections), then re-initializes fresh instances and wires them
+         * back into the managers.
+         *
+         * Call this after a data migration so that stale caches are purged and the new
+         * database connections can see the migrated credentials. Follow up with a call to
+         * [AuthenticatorViewModel.refreshCredentials] to push the new data into the UI.
+         */
+        suspend fun reinitializeMfaClients() {
+            with(instance) {
+                // Close old clients — this clears the in-memory credential caches and
+                // releases the SQLite database connections.
+                oathManager.close()
+                pushManager.close()
+
+                // Create fresh clients with new database connections.
+                initializeSdkClients()
+
+                // Wire the new client instances into the managers so subsequent
+                // operations use the freshly-opened databases.
+                oathManager.setClient(oathClient)
+                pushManager.setClient(pushClient)
+            }
         }
     }
 }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/navigation/Navigation.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/navigation/Navigation.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +42,7 @@ import com.pingidentity.samples.pingsampleapp.authenticator.data.AuthenticatorVi
 import com.pingidentity.samples.pingsampleapp.authenticator.ui.AboutScreen
 import com.pingidentity.samples.pingsampleapp.authmigration.AuthMigrationScreen
 import com.pingidentity.samples.pingsampleapp.authmigration.AuthMigrationViewModel
+import com.pingidentity.samples.pingsampleapp.authmigration.MigrationStatus
 import com.pingidentity.samples.pingsampleapp.authenticator.ui.AccountDetailScreen
 import com.pingidentity.samples.pingsampleapp.authenticator.ui.AccountsScreen
 import com.pingidentity.samples.pingsampleapp.authenticator.ui.EditAccountsScreen
@@ -502,6 +504,18 @@ fun AppNavigation(
 
         composable(Route.AUTH_MIGRATION) {
             val authMigrationViewModel = viewModel<AuthMigrationViewModel>()
+            val migrationState by authMigrationViewModel.state.collectAsState()
+
+            // When migration finishes successfully, close and re-initialize the MFA clients so
+            // their in-memory credential caches are cleared and fresh database connections are
+            // opened — then reload credentials into the UI-bound AuthenticatorViewModel.
+            LaunchedEffect(migrationState.migrationStatus) {
+                if (migrationState.migrationStatus == MigrationStatus.COMPLETED) {
+                    PingSampleApplication.reinitializeMfaClients()
+                    authenticatorViewModel?.refreshCredentials()
+                }
+            }
+
             AuthMigrationScreen(
                 viewModel = authMigrationViewModel,
                 onBack = { navController.popBackStack() }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4930](https://pingidentity.atlassian.net/browse/SDKS-4930)

# Description

When performing an auth migration and reloading the authentication screen, the accounts were not being loaded. This fix checks that when migration finishes successfully, close and re-initialize the MFA clients so their in-memory credential caches are cleared and fresh database connections are opened — then reload credentials into the UI-bound AuthenticatorViewModel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication migration now automatically reinitializes multi-factor authentication clients and refreshes credentials upon completion for a seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->