### PR TITLE
SDKS-4919: Match iOS and change richText to content.

### DIFF
--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -106,7 +106,7 @@ class FormFieldsTest {
         // labelCollector1: HTML content — richText falls back to the raw HTML content string
         val richContent1 = labelCollector1.richContent
         assertNotNull(richContent1)
-        assertTrue(richContent1.richText.contains("Rich Text fields produce LABELs"))
+        assertTrue(richContent1.content.contains("Rich Text fields produce LABELs"))
         // No richContent on this label so replacements must be empty
         assertTrue(richContent1.replacements.isEmpty())
 
@@ -114,14 +114,14 @@ class FormFieldsTest {
         // (without the trailing newlines present in the top-level content field)
         val richContent2 = labelCollector2.richContent
         assertNotNull(richContent2)
-        assertEquals("Translatable Rich Text produce LABELs too!", richContent2.richText)
+        assertEquals("Translatable Rich Text produce LABELs too!", richContent2.content)
         // No replacement tokens on this label
         assertTrue(richContent2.replacements.isEmpty())
 
         // labelCollector3: translatable link — richText contains {{token}} placeholders and replacements map contains corresponding entries
         val richContent3 = labelCollector3.richContent
         assertNotNull(richContent3)
-        assertEquals("A translatable rich text to take the user to {{link1}}", richContent3.richText)
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent3.content)
         assertTrue(richContent3.replacements.containsKey("link1"))
         val replacement = richContent3.replacements["link1"]
         assertNotNull(replacement)
@@ -144,11 +144,11 @@ class FormFieldsTest {
         if (linkLabel != null) {
             // richText must contain at least one {{token}} placeholder
             assertTrue(
-                tokenPattern.containsMatchIn(linkLabel.richContent?.richText ?: ""),
-                "Expected richText to contain {{token}} placeholders, was: ${linkLabel.richContent?.richText}"
+                tokenPattern.containsMatchIn(linkLabel.richContent?.content ?: ""),
+                "Expected richText to contain {{token}} placeholders, was: ${linkLabel.richContent?.content}"
             )
             // Every token present in richText must have a corresponding replacement entry
-            for (match in tokenPattern.findAll(linkLabel.richContent?.richText ?: "")) {
+            for (match in tokenPattern.findAll(linkLabel.richContent?.content ?: "")) {
                 val token = match.groupValues[1]
                 val replacement = linkLabel.richContent?.replacements[token]
                 assertNotNull(replacement, "Missing replacement for token '$token'")
@@ -428,7 +428,7 @@ class FormFieldsTest {
         assertEquals("I agree to the Terms and Conditions", singleCheckbox.label)
         val richContent = singleCheckbox.richContent
         assertNotNull(richContent)
-        assertEquals("I agree to the {{link1}}", richContent.richText)
+        assertEquals("I agree to the {{link1}}", richContent.content)
         assertEquals(1, richContent.replacements.size)
         assertTrue(richContent.replacements.containsKey("link1"))
         assertEquals(true, singleCheckbox.required)

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -95,7 +95,6 @@ class FormFieldsTest {
         val labelCollector3 = node.collectors[LABEL_RICH_TEXT_INDEX] as LabelCollector
 
         // TODO: Update the following assertion to be more specific when the bug in DaVinci is fixed - see: https://pingidentity.slack.com/archives/C06CCT3NSP5/p1736897937860359
-        assertTrue(labelCollector1.content.contains("Rich Text fields produce LABELs"))
         assertEquals("Translatable Rich Text produce LABELs too!\n\n", labelCollector2.content)
 
         // SDKS-3957 Add support for key attribute in Label Collectors
@@ -103,12 +102,17 @@ class FormFieldsTest {
         // Note that the Rich Text component has been deprecated, so the key is not set
         assertEquals("", labelCollector1.key)
 
-        // labelCollector1: HTML content — richText falls back to the raw HTML content string
+        // labelCollector1: No richContent field in the input → richContent should be null and
+        // content should contain the plain text (with HTML tags, since it's a TEXTBLOB)
         val richContent1 = labelCollector1.richContent
-        assertNotNull(richContent1)
-        assertTrue(richContent1.content.contains("Rich Text fields produce LABELs"))
-        // No richContent on this label so replacements must be empty
-        assertTrue(richContent1.replacements.isEmpty())
+        assertNull(richContent1)
+        assertTrue(labelCollector1.content.contains("Rich Text fields produce LABELs"))
+        // TEXTBLOB content is raw HTML — verify HTML tags are present so that buildRichTextLabel
+        // can parse it correctly when richContent is null
+        assertTrue(
+            labelCollector1.content.contains("<"),
+            "Expected TEXTBLOB content to contain HTML tags, was: ${labelCollector1.content}"
+        )
 
         // labelCollector2: plain translatable text — richText comes from richContent.content
         // (without the trailing newlines present in the top-level content field)

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/RichContent.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/RichContent.kt
@@ -32,11 +32,11 @@ data class RichContentReplacement(
 /**
  * Represents rich text content with optional token replacements.
  *
- * @property richText The rich text content, potentially containing `{{tokenName}}` placeholders.
+ * @property content The rich text content, potentially containing `{{tokenName}}` placeholders.
  * @property replacements Map of token name → [RichContentReplacement] parsed from
  * `richContent.replacements`.  Empty when there are no replacements.
  */
 data class RichContent(
-    val richText: String = "",
+    val content: String = "",
     val replacements: Map<String, RichContentReplacement> = emptyMap(),
 )

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/BooleanCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/BooleanCollector.kt
@@ -59,7 +59,7 @@ class BooleanCollector: FieldCollector<Boolean>() {
         val richContentJson = input[RICH_CONTENT] as? JsonObject
         richContentJson?.let {
             richContent = RichContent(
-                content = it["content"]?.jsonPrimitive?.contentOrNull ?: label,
+                content = it["content"]?.jsonPrimitive?.contentOrNull ?: "",
                 replacements = (it[REPLACEMENTS] as? JsonObject)
                     ?.mapValues { (_, element) ->
                         val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/BooleanCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/BooleanCollector.kt
@@ -59,7 +59,7 @@ class BooleanCollector: FieldCollector<Boolean>() {
         val richContentJson = input[RICH_CONTENT] as? JsonObject
         richContentJson?.let {
             richContent = RichContent(
-                richText = it["content"]?.jsonPrimitive?.contentOrNull ?: label,
+                content = it["content"]?.jsonPrimitive?.contentOrNull ?: label,
                 replacements = (it[REPLACEMENTS] as? JsonObject)
                     ?.mapValues { (_, element) ->
                         val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
@@ -55,7 +55,7 @@ class LabelCollector : Collector<Nothing> {
 
         val richContentJson = input[RICH_CONTENT] as? JsonObject
         richContent = RichContent(
-            richText = richContentJson?.get(CONTENT)?.jsonPrimitive?.contentOrNull ?: content,
+            content = richContentJson?.get(CONTENT)?.jsonPrimitive?.contentOrNull ?: content,
             replacements = (richContentJson?.get(REPLACEMENTS) as? JsonObject)
                 ?.mapValues { (_, element) ->
                     val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/LabelCollector.kt
@@ -54,19 +54,21 @@ class LabelCollector : Collector<Nothing> {
         key = input[KEY]?.jsonPrimitive?.contentOrNull ?: ""
 
         val richContentJson = input[RICH_CONTENT] as? JsonObject
-        richContent = RichContent(
-            content = richContentJson?.get(CONTENT)?.jsonPrimitive?.contentOrNull ?: content,
-            replacements = (richContentJson?.get(REPLACEMENTS) as? JsonObject)
-                ?.mapValues { (_, element) ->
-                    val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()
-                    RichContentReplacement(
-                        value = (obj[VALUE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                        href = (obj[HREF] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                        type = (obj[TYPE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                        target = (obj[TARGET] as? JsonPrimitive)?.contentOrNull.orEmpty(),
-                    )
-                } ?: emptyMap()
-        )
+        richContentJson?.let {
+            richContent = RichContent(
+                content = it[CONTENT]?.jsonPrimitive?.contentOrNull ?: "",
+                replacements = (it[REPLACEMENTS] as? JsonObject)
+                    ?.mapValues { (_, element) ->
+                        val obj = element as? JsonObject ?: return@mapValues RichContentReplacement()
+                        RichContentReplacement(
+                            value = (obj[VALUE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                            href = (obj[HREF] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                            type = (obj[TYPE] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                            target = (obj[TARGET] as? JsonPrimitive)?.contentOrNull.orEmpty(),
+                        )
+                    } ?: emptyMap()
+            )
+        }
 
         return this
     }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/BooleanCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/BooleanCollectorTest.kt
@@ -88,7 +88,7 @@ class BooleanCollectorTest {
         collector.init(input)
         val richContent = collector.richContent
         assertNotNull(richContent)
-        assertEquals("This is a sample checkbox test.", richContent.richText)
+        assertEquals("This is a sample checkbox test.", richContent.content)
     }
 
     @Test
@@ -110,7 +110,7 @@ class BooleanCollectorTest {
         collector.init(input)
         val richContent = collector.richContent
         assertNotNull(richContent)
-        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.richText)
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.content)
         assertTrue(richContent.replacements.isNotEmpty())
         assertEquals(1, richContent.replacements.size)
 

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
@@ -14,6 +14,7 @@ import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LabelCollectorTest {
@@ -39,17 +40,17 @@ class LabelCollectorTest {
     }
 
     @Test
-    fun `richText falls back to content when no richContent is present`() {
+    fun `richContent is null when no richContent field is present`() {
         val input = buildJsonObject {
             put("key", "label-key")
             put("content", "Plain text content")
         }
         val collector = LabelCollector()
         collector.init(input)
-        val richContent = collector.richContent
-        assertNotNull(richContent)
-        assertEquals("Plain text content", richContent.content)
-        assertTrue(richContent.replacements.isEmpty())
+        // richContent is only populated when a richContent JSON object is present.
+        // The rendering layer (buildRichTextLabel) handles the null fallback to content.
+        assertNull(collector.richContent)
+        assertEquals("Plain text content", collector.content)
     }
 
     @Test
@@ -121,19 +122,17 @@ class LabelCollectorTest {
     }
 
     @Test
-    fun `richText is set to HTML content when content contains HTML tags`() {
+    fun `richContent is null and content retains HTML when no richContent field is present`() {
         val input = buildJsonObject {
             put("content", "<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>")
         }
         val collector = LabelCollector()
         collector.init(input)
-        val richContent = collector.richContent
-        assertNotNull(richContent)
+        // TEXTBLOB-style labels have no richContent JSON → richContent is null.
+        // The raw HTML is stored in content; buildRichTextLabel parses it at render time.
+        assertNull(collector.richContent)
         assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", collector.content)
-        // richText falls back to content since no richContent is present
-        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", richContent.content)
         assertEquals("", collector.key)
-        assertTrue(richContent.replacements.isEmpty())
     }
 
     @Test

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/LabelCollectorTest.kt
@@ -48,7 +48,7 @@ class LabelCollectorTest {
         collector.init(input)
         val richContent = collector.richContent
         assertNotNull(richContent)
-        assertEquals("Plain text content", richContent.richText)
+        assertEquals("Plain text content", richContent.content)
         assertTrue(richContent.replacements.isEmpty())
     }
 
@@ -67,7 +67,7 @@ class LabelCollectorTest {
         val richContent = collector.richContent
         assertNotNull(richContent)
         val replacement = richContent.replacements
-        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.richText)
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.content)
         assertTrue(replacement.isEmpty())
     }
 
@@ -93,7 +93,7 @@ class LabelCollectorTest {
         val richContent = collector.richContent
 
         assertNotNull(richContent)
-        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.richText)
+        assertEquals("A translatable rich text to take the user to {{link1}}", richContent.content)
         assertEquals(1, richContent.replacements.size)
 
         val link1 = richContent.replacements["link1"]
@@ -131,7 +131,7 @@ class LabelCollectorTest {
         assertNotNull(richContent)
         assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", collector.content)
         // richText falls back to content since no richContent is present
-        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", richContent.richText)
+        assertEquals("<p><strong><em>Rich Text fields produce LABELs</em></strong></p><hr><p><br></p>", richContent.content)
         assertEquals("", collector.key)
         assertTrue(richContent.replacements.isEmpty())
     }
@@ -152,7 +152,7 @@ class LabelCollectorTest {
         // content retains the original value including trailing newlines
         assertEquals("Translatable Rich Text produce LABELs too!\n\n", collector.content)
         // richText is trimmed to the richContent value
-        assertEquals("Translatable Rich Text produce LABELs too!", richContent.richText)
+        assertEquals("Translatable Rich Text produce LABELs too!", richContent.content)
         assertEquals("translatable-rich-text-key", collector.key)
         assertTrue(richContent.replacements.isEmpty())
     }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/RichText.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/RichText.kt
@@ -33,9 +33,9 @@ object RichText {
         richContent: RichContent,
     ) = buildAnnotatedString {
         var lastIndex = 0
-        for (match in tokenPattern.findAll(richContent.richText)) {
+        for (match in tokenPattern.findAll(richContent.content)) {
             // Append any plain text before this token
-            append(richContent.richText.substring(lastIndex, match.range.first))
+            append(richContent.content.substring(lastIndex, match.range.first))
 
             val token = match.groupValues[1]
             val replacement = richContent.replacements[token]
@@ -59,7 +59,7 @@ object RichText {
             lastIndex = match.range.last + 1
         }
         // Append any remaining plain text after the last token
-        append(richContent.richText.substring(lastIndex))
+        append(richContent.content.substring(lastIndex))
     }
 
     /**
@@ -82,13 +82,13 @@ object RichText {
         fallbackContent: String = "",
     ): AnnotatedString {
         if (richContent == null) return AnnotatedString(fallbackContent)
-        val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
-        val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
+        val hasTokens = tokenPattern.containsMatchIn(richContent.content)
+        val hasHtml = htmlTagPattern.containsMatchIn(richContent.content)
         return when {
             hasTokens && hasHtml ->
                 AnnotatedString
                     .fromHtml(
-                        tokenPattern.replace(richContent.richText) { match ->
+                        tokenPattern.replace(richContent.content) { match ->
                             val token = match.groupValues[1]
                             val replacement = richContent.replacements[token]
                             when {
@@ -105,9 +105,9 @@ object RichText {
             hasTokens ->
                 buildRichAnnotatedString(richContent)
             hasHtml ->
-                AnnotatedString.fromHtml(richContent.richText)
+                AnnotatedString.fromHtml(richContent.content)
             else ->
-                AnnotatedString(richContent.richText)
+                AnnotatedString(richContent.content)
         }
     }
 }

--- a/samples/app/src/main/java/com/pingidentity/samples/app/davinci/RichText.kt
+++ b/samples/app/src/main/java/com/pingidentity/samples/app/davinci/RichText.kt
@@ -81,7 +81,13 @@ object RichText {
         richContent: RichContent?,
         fallbackContent: String = "",
     ): AnnotatedString {
-        if (richContent == null) return AnnotatedString(fallbackContent)
+        if (richContent == null) {
+            return if (htmlTagPattern.containsMatchIn(fallbackContent)) {
+                AnnotatedString.fromHtml(fallbackContent)
+            } else {
+                AnnotatedString(fallbackContent)
+            }
+        }
         val hasTokens = tokenPattern.containsMatchIn(richContent.content)
         val hasHtml = htmlTagPattern.containsMatchIn(richContent.content)
         return when {

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/RichText.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/RichText.kt
@@ -33,9 +33,9 @@ object RichText {
         richContent: RichContent,
     ) = buildAnnotatedString {
         var lastIndex = 0
-        for (match in tokenPattern.findAll(richContent.richText)) {
+        for (match in tokenPattern.findAll(richContent.content)) {
             // Append any plain text before this token
-            append(richContent.richText.substring(lastIndex, match.range.first))
+            append(richContent.content.substring(lastIndex, match.range.first))
 
             val token = match.groupValues[1]
             val replacement = richContent.replacements[token]
@@ -59,7 +59,7 @@ object RichText {
             lastIndex = match.range.last + 1
         }
         // Append any remaining plain text after the last token
-        append(richContent.richText.substring(lastIndex))
+        append(richContent.content.substring(lastIndex))
     }
 
     /**
@@ -82,13 +82,13 @@ object RichText {
         fallbackContent: String = "",
     ): AnnotatedString {
         if (richContent == null) return AnnotatedString(fallbackContent)
-        val hasTokens = tokenPattern.containsMatchIn(richContent.richText)
-        val hasHtml = htmlTagPattern.containsMatchIn(richContent.richText)
+        val hasTokens = tokenPattern.containsMatchIn(richContent.content)
+        val hasHtml = htmlTagPattern.containsMatchIn(richContent.content)
         return when {
             hasTokens && hasHtml ->
                 AnnotatedString
                     .fromHtml(
-                        tokenPattern.replace(richContent.richText) { match ->
+                        tokenPattern.replace(richContent.content) { match ->
                             val token = match.groupValues[1]
                             val replacement = richContent.replacements[token]
                             when {
@@ -105,9 +105,9 @@ object RichText {
             hasTokens ->
                 buildRichAnnotatedString(richContent)
             hasHtml ->
-                AnnotatedString.fromHtml(richContent.richText)
+                AnnotatedString.fromHtml(richContent.content)
             else ->
-                AnnotatedString(richContent.richText)
+                AnnotatedString(richContent.content)
         }
     }
 }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/RichText.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/RichText.kt
@@ -81,7 +81,13 @@ object RichText {
         richContent: RichContent?,
         fallbackContent: String = "",
     ): AnnotatedString {
-        if (richContent == null) return AnnotatedString(fallbackContent)
+        if (richContent == null) {
+            return if (htmlTagPattern.containsMatchIn(fallbackContent)) {
+                AnnotatedString.fromHtml(fallbackContent)
+            } else {
+                AnnotatedString(fallbackContent)
+            }
+        }
         val hasTokens = tokenPattern.containsMatchIn(richContent.content)
         val hasHtml = htmlTagPattern.containsMatchIn(richContent.content)
         return when {


### PR DESCRIPTION
# JIRA Ticket
(SDKS-4919)[https://pingidentity.atlassian.net/browse/SDKS-4919]

# Description
Match iOS variable naming to keep `content` instead of `richText` as part of the json response parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified rich-text handling across the SDK and samples for more consistent label and token rendering.
* **Bug Fixes**
  * Token placeholders and HTML in labels now render consistently, including correct trailing text and link placeholders.
  * When rich content is missing, fallback label content will render as HTML if it contains HTML tags.
* **Tests**
  * Updated tests to align with the revised rich-text behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->