### PR TITLE
[fix] SDKS-5037 - bump bcpkix-jdk18on to 1.84 to address CVE-2026-5588

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ captures
 local.properties
 xcuserdata
 .kotlin
+.polaris/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.1]
+
+#### Fixed
+- Upgraded `bcpkix-jdk18on` from `1.81` to `1.84` to address a security vulnerability (CVE-2026-5588). [SDKS-5037]
+
 ## [2.0.0]
 #### Added
 - Added new `network` module [SDKS-4505]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,7 @@ mockk = "1.14.5"
 mockwebserver = "5.1.0"
 mockkAndroid = "1.14.5"
 testLogger = "4.0.0"
-bcpkix-jdk18on = "1.82"
+bcpkix-jdk18on = "1.84"
 androidx-annotation = "1.9.1"
 
 activityKtx = "1.10.1"


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5037](https://pingidentity.atlassian.net/browse/SDKS-5037) Vulnerability in android SDK 4.8.3 bcpkix-jdk18on version 1.81

# Description

CVE-2026-5588 affects `org.bouncycastle:bcpkix-jdk18on` at versions < 1.84.
The catalog pin in `gradle/libs.versions.toml` is the single source of truth
for this dependency (no transitive consumer drags in a different version
and no resolutionStrategy.force entry exists for it), so a one-line bump
in the version catalog is sufficient.

The only production consumer of bcpkix-jdk18on in this repo is
`mfa/binding`'s AppPinAuthenticator (X.509 v1 certificate construction
for the APPLICATION_PIN device-binding flow). The Bouncy Castle PKIX
API surface used there has been stable across the 1.7x-1.8x line and
no source changes are required.

Verified:
- :mfa:binding:testDebugUnitTestCoverage (201 passing)
- :journey:testDebugUnitTestCoverage (69 passing)
- full --rerun-tasks testDebugUnitTestCoverage (BUILD SUCCESSFUL,
  940 actionable tasks)
- :mfa:binding:dependencies shows bcpkix-jdk18on:1.84 resolved on every
  configuration that references it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applied a security-related dependency update to improve safety and stability.

* **Chores**
  * Updated dependency versions in build configuration.

* **Documentation**
  * Added a new 2.0.1 changelog entry reflecting the dependency update.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-android-sdk/pull/201)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->