### PR TITLE
SDKS-4937: App parity with iOS

### DIFF
--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/Env.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/Env.kt
@@ -404,6 +404,7 @@ private fun ConfigRow(
             .fillMaxWidth()
             .combinedClickable(
                 onClick = onTap,
+                onLongClickLabel = "Show actions",
                 onLongClick = { menuExpanded = true },
             )
             .padding(vertical = 4.dp),

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/Env.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/Env.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -30,6 +31,8 @@ import androidx.compose.material.icons.filled.RadioButtonUnchecked
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -135,6 +138,7 @@ fun Env(
                     onSelect = { envViewModel.selectJourneyConfig(it) },
                     onEdit = { cfg, idx -> sheetContent = SheetContent.JourneySheet(cfg, idx) },
                     onDelete = { envViewModel.deleteCustomJourneyConfig(it) },
+                    onDuplicate = { envViewModel.duplicateJourneyConfig(it) },
                     onAdd = { sheetContent = SheetContent.JourneySheet() },
                 )
 
@@ -147,6 +151,7 @@ fun Env(
                     onSelect = { envViewModel.selectDaVinciConfig(it) },
                     onEdit = { cfg, idx -> sheetContent = SheetContent.DaVinciSheet(cfg, idx) },
                     onDelete = { envViewModel.deleteCustomDaVinciConfig(it) },
+                    onDuplicate = { envViewModel.duplicateDaVinciConfig(it) },
                     onAdd = { sheetContent = SheetContent.DaVinciSheet() },
                 )
 
@@ -159,8 +164,10 @@ fun Env(
                     onSelect = { envViewModel.selectWebConfig(it) },
                     onEdit = { cfg, idx -> sheetContent = SheetContent.WebSheet(cfg, idx) },
                     onDelete = { envViewModel.deleteCustomWebConfig(it) },
+                    onDuplicate = { envViewModel.duplicateWebConfig(it) },
                     onAdd = { sheetContent = SheetContent.WebSheet() },
                 )
+
 
                 Spacer(Modifier.height(8.dp))
             }
@@ -220,8 +227,9 @@ private fun JourneyCard(
     customConfigs: List<JourneyConfigState>,
     appliedConfig: JourneyConfigState?,
     onSelect: (JourneyConfigState) -> Unit,
-    onEdit: (JourneyConfigState, Int) -> Unit,
+    onEdit: (JourneyConfigState, Int?) -> Unit,
     onDelete: (Int) -> Unit,
+    onDuplicate: (JourneyConfigState) -> Unit,
     onAdd: () -> Unit,
 ) {
     ConfigCard(title = "Journey", appliedDisplay = appliedConfig?.display, onAdd = onAdd) {
@@ -233,9 +241,11 @@ private fun JourneyCard(
                     subtitle = "${extractHost(config.discoveryEndpoint)} · ${config.clientId}",
                     isApplied = appliedConfig == config,
                     isPreset = true,
+                    onTap = { onEdit(config, null) },
                     onSelect = { onSelect(config) },
                     onEdit = null,
                     onDelete = null,
+                    onDuplicate = { onDuplicate(config) },
                 )
             }
         }
@@ -248,9 +258,11 @@ private fun JourneyCard(
                     subtitle = "${extractHost(config.discoveryEndpoint)} · ${config.clientId}",
                     isApplied = appliedConfig == config,
                     isPreset = false,
+                    onTap = { onEdit(config, index) },
                     onSelect = { onSelect(config) },
                     onEdit = { onEdit(config, index) },
                     onDelete = { onDelete(index) },
+                    onDuplicate = { onDuplicate(config) },
                 )
             }
         }
@@ -268,8 +280,9 @@ private fun OidcCard(
     customConfigs: List<OidcConfigState>,
     appliedConfig: OidcConfigState?,
     onSelect: (OidcConfigState) -> Unit,
-    onEdit: (OidcConfigState, Int) -> Unit,
+    onEdit: (OidcConfigState, Int?) -> Unit,
     onDelete: (Int) -> Unit,
+    onDuplicate: (OidcConfigState) -> Unit,
     onAdd: () -> Unit,
 ) {
     ConfigCard(title = title, appliedDisplay = appliedConfig?.display, onAdd = onAdd) {
@@ -281,9 +294,11 @@ private fun OidcCard(
                     subtitle = "${extractHost(config.discoveryEndpoint)} · ${config.clientId}",
                     isApplied = appliedConfig == config,
                     isPreset = true,
+                    onTap = { onEdit(config, null) },
                     onSelect = { onSelect(config) },
                     onEdit = null,
                     onDelete = null,
+                    onDuplicate = { onDuplicate(config) },
                 )
             }
         }
@@ -296,9 +311,11 @@ private fun OidcCard(
                     subtitle = "${extractHost(config.discoveryEndpoint)} · ${config.clientId}",
                     isApplied = appliedConfig == config,
                     isPreset = false,
+                    onTap = { onEdit(config, index) },
                     onSelect = { onSelect(config) },
                     onEdit = { onEdit(config, index) },
                     onDelete = { onDelete(index) },
+                    onDuplicate = { onDuplicate(config) },
                 )
             }
         }
@@ -367,19 +384,28 @@ private fun ConfigCard(
 // Single config row
 // ---------------------------------------------------------------------------
 
+@OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
 private fun ConfigRow(
     display: String,
     subtitle: String,
     isApplied: Boolean,
     isPreset: Boolean,
+    onTap: () -> Unit,
     onSelect: () -> Unit,
     onEdit: (() -> Unit)?,
     onDelete: (() -> Unit)?,
+    onDuplicate: () -> Unit,
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .combinedClickable(
+                onClick = onTap,
+                onLongClick = { menuExpanded = true },
+            )
             .padding(vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -427,6 +453,19 @@ private fun ConfigRow(
                 imageVector = if (isApplied) Icons.Filled.CheckCircle else Icons.Filled.RadioButtonUnchecked,
                 contentDescription = if (isApplied) "Applied" else "Select",
                 tint = if (isApplied) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false },
+        ) {
+            DropdownMenuItem(
+                text = { Text("Duplicate") },
+                onClick = {
+                    menuExpanded = false
+                    onDuplicate()
+                },
             )
         }
     }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -404,6 +404,21 @@ class EnvViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) { persistCustomWebConfigs(customWebConfigs) }
     }
 
+    fun duplicateJourneyConfig(config: JourneyConfigState) {
+        customJourneyConfigs = customJourneyConfigs + config.copy(display = "Copy of ${config.display}")
+        viewModelScope.launch(Dispatchers.IO) { persistCustomJourneyConfigs(customJourneyConfigs) }
+    }
+
+    fun duplicateDaVinciConfig(config: OidcConfigState) {
+        customDaVinciConfigs = customDaVinciConfigs + config.copy(display = "Copy of ${config.display}")
+        viewModelScope.launch(Dispatchers.IO) { persistCustomDaVinciConfigs(customDaVinciConfigs) }
+    }
+
+    fun duplicateWebConfig(config: OidcConfigState) {
+        customWebConfigs = customWebConfigs + config.copy(display = "Copy of ${config.display}")
+        viewModelScope.launch(Dispatchers.IO) { persistCustomWebConfigs(customWebConfigs) }
+    }
+
     // -- SDK instance builders (delegate to package-level functions) ---------
 
     private fun buildJourneyInstance(config: JourneyConfigState) = buildJourney(config)

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/home/HomeApp.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/home/HomeApp.kt
@@ -12,7 +12,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -47,6 +49,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -134,16 +137,15 @@ fun HomeApp(
                 .statusBarsPadding()
                 .navigationBarsPadding()
         ) {
-            // Header row with red background, logo, and version
-            Row(
+            // Header with red background, logo, version, and settings icon
+            Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .background(colorResource(R.color.primary_dark))
                     .padding(vertical = 24.dp),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(
+                    modifier = Modifier.align(Alignment.Center),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center
                 ) {
@@ -183,6 +185,19 @@ fun HomeApp(
                         color = Color.White,
                         fontSize = 14.sp,
                         modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+                IconButton(
+                    onClick = onConfigurationClick,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(end = 12.dp)
+                        .border(1.dp, Color.White, MaterialTheme.shapes.small)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = stringResource(R.string.text_configuration_title),
+                        tint = Color.White
                     )
                 }
             }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/Token.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/Token.kt
@@ -7,25 +7,27 @@
 
 package com.pingidentity.samples.pingsampleapp.token
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.RemoveCircleOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -39,30 +41,26 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.pingidentity.oidc.Token
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TokenScreen(
     tokenViewModel: TokenViewModel = viewModel<TokenViewModel>(),
     onBack: (() -> Unit)? = null,
 ) {
-    val formattedToken by tokenViewModel.formattedToken.collectAsState(initial = "Loading...")
     val tokenState by tokenViewModel.state.collectAsState()
-    val scroll = rememberScrollState(0)
-    var expanded by remember { mutableStateOf(false) }
 
     LaunchedEffect(true) {
-        // Not relaunch when recomposition
-        // Load all tokens to display all sessions
         tokenViewModel.loadAllTokens()
     }
 
@@ -78,6 +76,36 @@ fun TokenScreen(
                                 contentDescription = "Back"
                             )
                         }
+                    },
+                    actions = {
+                        IconButton(onClick = { tokenViewModel.accessToken() }) {
+                            Icon(
+                                imageVector = Icons.Default.Key,
+                                contentDescription = "Access Token",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        IconButton(onClick = { tokenViewModel.refresh() }) {
+                            Icon(
+                                imageVector = Icons.Default.Refresh,
+                                contentDescription = "Refresh",
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        IconButton(onClick = { tokenViewModel.revoke() }) {
+                            Icon(
+                                imageVector = Icons.Default.RemoveCircleOutline,
+                                contentDescription = "Revoke",
+                                tint = MaterialTheme.colorScheme.error,
+                            )
+                        }
+                        IconButton(onClick = { tokenViewModel.reset() }) {
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = "Clear",
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
                     }
                 )
             }
@@ -85,13 +113,12 @@ fun TokenScreen(
     ) { paddingValues ->
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .padding(paddingValues)
         ) {
-            // Tab Row for Journey, DaVinci, and OIDC
             TabRow(
                 selectedTabIndex = tokenState.selectedTab.ordinal,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier.fillMaxWidth(),
             ) {
                 Tab(
                     selected = tokenState.selectedTab == TokenType.JOURNEY,
@@ -99,7 +126,7 @@ fun TokenScreen(
                         tokenViewModel.selectTab(TokenType.JOURNEY)
                         tokenViewModel.loadAllTokens()
                     },
-                    text = { Text("Journey") }
+                    text = { Text("Journey") },
                 )
                 Tab(
                     selected = tokenState.selectedTab == TokenType.DAVINCI,
@@ -107,7 +134,7 @@ fun TokenScreen(
                         tokenViewModel.selectTab(TokenType.DAVINCI)
                         tokenViewModel.loadAllTokens()
                     },
-                    text = { Text("DaVinci") }
+                    text = { Text("DaVinci") },
                 )
                 Tab(
                     selected = tokenState.selectedTab == TokenType.OIDC,
@@ -115,108 +142,171 @@ fun TokenScreen(
                         tokenViewModel.selectTab(TokenType.OIDC)
                         tokenViewModel.loadAllTokens()
                     },
-                    text = { Text("OIDC") }
+                    text = { Text("OIDC") },
                 )
             }
 
-            // Content
-            Box(
+            val token = when (tokenState.selectedTab) {
+                TokenType.JOURNEY -> tokenState.journeyToken
+                TokenType.DAVINCI -> tokenState.daVinciToken
+                TokenType.OIDC -> tokenState.oidcToken
+            }
+            val error = when (tokenState.selectedTab) {
+                TokenType.JOURNEY -> tokenState.journeyError
+                TokenType.DAVINCI -> tokenState.daVinciError
+                TokenType.OIDC -> tokenState.oidcError
+            }
+
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(8.dp)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                Column(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    Card(
-                        elevation =
-                        CardDefaults.cardElevation(
-                            defaultElevation = 10.dp,
-                        ),
-                        modifier =
-                        Modifier
-                            .height(400.dp)
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                            .combinedClickable(
-                                onClick = { },
-                                onLongClick = {
-                                    expanded = !expanded
-                                }
-                            ),
-                        border = BorderStroke(2.dp, Color.Black),
-                        shape = MaterialTheme.shapes.medium,
-                    ) {
-                        Text(
-                            modifier =
-                                Modifier
-                                    .padding(4.dp)
-                                    .verticalScroll(scroll),
-                            text = formattedToken,
-                        )
-                    }
-
-                    Row(
-                        modifier =
-                        Modifier
-                            .padding(8.dp)
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.aligned(Alignment.Start),
-                    ) {
-                        Button(
-                            modifier = Modifier.padding(4.dp),
-                            onClick = { tokenViewModel.accessToken() },
-                        ) {
-                            Text(text = "AccessToken")
-                        }
-                        Button(
-                            modifier = Modifier.padding(4.dp),
-                            onClick = { tokenViewModel.reset() },
-                        ) {
-                            Text(text = "Clear")
-                        }
-                    }
-                    Row(
-                        modifier = Modifier.padding(8.dp)
-                            .fillMaxWidth(),
-                        horizontalArrangement = Arrangement.aligned(Alignment.Start),
-                    ) {
-                        Button(
-                            modifier = Modifier.padding(4.dp),
-                            onClick = { tokenViewModel.refresh() }
-                        ) {
-                            Text(text = "Refresh")
-                        }
-                        Button(
-                            modifier = Modifier.padding(4.dp),
-                            onClick = { tokenViewModel.revoke() }
-                        ) {
-                            Text(text = "Revoke")
-                        }
-                    }
-                }
-
-                DropdownMenu(
-                    expanded = expanded,
-                    onDismissRequest = { expanded = false }
-                ) {
-                    DropdownMenuItem(
-                        text = { Text("Refresh") },
-                        onClick = {
-                            tokenViewModel.refresh()
-                            expanded = false
-                        }
-                    )
-                    DropdownMenuItem(
-                        text = { Text("Revoke") },
-                        onClick = {
-                            tokenViewModel.revoke()
-                            expanded = false
-                        }
-                    )
+                when {
+                    token != null -> TokenCard(token)
+                    error != null -> ErrorCard(error.toString())
+                    else -> EmptyCard(tokenState.selectedTab)
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun TokenCard(token: Token) {
+    TokenFieldCard(label = "Access Token", value = token.accessToken)
+    token.refreshToken?.let { TokenFieldCard(label = "Refresh Token", value = it) }
+    token.idToken?.let { TokenFieldCard(label = "ID Token", value = it) }
+    token.tokenType?.let { TokenFieldCard(label = "Token Type", value = it, truncate = false, copyable = false) }
+    token.scope?.let { TokenFieldCard(label = "Scope", value = it, truncate = false, copyable = false) }
+    ExpiryCountdownCard(token = token)
+}
+
+@Composable
+private fun ExpiryCountdownCard(token: Token) {
+    // Derive remaining seconds via the public isExpired(threshold) API:
+    // isExpired(threshold) == true  →  now >= expireAt - threshold  →  threshold >= expireAt - now
+    // So the smallest threshold where isExpired returns true equals the remaining seconds.
+    fun remainingSeconds(): Long {
+        if (token.isExpired) return 0L
+        var lo = 0L
+        var hi = token.expiresIn
+        while (lo < hi) {
+            val mid = (lo + hi) / 2
+            if (token.isExpired(mid)) hi = mid else lo = mid + 1
+        }
+        return lo
+    }
+
+    val secondsLeft = remember(token) { remainingSeconds() }
+
+    val expired = secondsLeft <= 0
+    val days = secondsLeft / 86400
+    val hours = (secondsLeft % 86400) / 3600
+    val minutes = (secondsLeft % 3600) / 60
+    val seconds = secondsLeft % 60
+    val countdownText = if (expired) "Expired"
+        else if (days > 0) "%dd %02d:%02d:%02d".format(days, hours, minutes, seconds)
+        else "%02d:%02d:%02d".format(hours, minutes, seconds)
+    val valueColor = if (expired) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.tertiary
+
+    TokenFieldCard(
+        label = "Expires In",
+        value = countdownText,
+        truncate = false,
+        copyable = false,
+        valueColor = valueColor,
+    )
+}
+
+@Composable
+private fun TokenFieldCard(
+    label: String,
+    value: String,
+    truncate: Boolean = true,
+    copyable: Boolean = true,
+    valueColor: androidx.compose.ui.graphics.Color = MaterialTheme.colorScheme.onSurface,
+) {
+    val context = LocalContext.current
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = androidx.compose.ui.text.font.FontWeight.Bold,
+            color = MaterialTheme.colorScheme.onBackground,
+            modifier = Modifier.padding(bottom = 6.dp),
+        )
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.Top,
+            ) {
+                Text(
+                    text = value,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                    color = valueColor,
+                    maxLines = if (truncate) 2 else Int.MAX_VALUE,
+                    overflow = if (truncate) TextOverflow.Ellipsis else TextOverflow.Clip,
+                    modifier = Modifier.weight(1f),
+                )
+                if (copyable) {
+                    IconButton(
+                        onClick = {
+                            val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                            clipboard.setPrimaryClip(ClipData.newPlainText(label, value))
+                        },
+                        modifier = Modifier.size(36.dp),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.ContentCopy,
+                            contentDescription = "Copy $label",
+                            modifier = Modifier.size(16.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ErrorCard(message: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+        ),
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier.padding(16.dp),
+        )
+    }
+}
+
+@Composable
+private fun EmptyCard(tab: TokenType) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+    ) {
+        Text(
+            text = "No ${tab.name.lowercase().replaceFirstChar { it.uppercase() }} token available",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(16.dp),
+        )
     }
 }
 

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/TokenViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/TokenViewModel.kt
@@ -12,47 +12,18 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.pingidentity.journey.user as journeyUser
 import com.pingidentity.davinci.user as davinciUser
-import com.pingidentity.oidc.Token
 import com.pingidentity.samples.pingsampleapp.config.daVinci
 import com.pingidentity.samples.pingsampleapp.config.journey
 import com.pingidentity.samples.pingsampleapp.config.web
 import com.pingidentity.utils.Result.Failure
 import com.pingidentity.utils.Result.Success
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.Json
 
 class TokenViewModel : ViewModel() {
-    private val json: Json = Json {
-        prettyPrint = true
-        ignoreUnknownKeys = true
-        encodeDefaults = true
-    }
-
     var state = MutableStateFlow(TokenState())
         private set
-
-    val formattedToken = state.map { tokenState ->
-        when (tokenState.selectedTab) {
-            TokenType.JOURNEY -> {
-                tokenState.journeyToken?.let {
-                    json.encodeToString(Token.serializer(), it)
-                } ?: tokenState.journeyError?.toString() ?: "No Journey token information is available"
-            }
-            TokenType.DAVINCI -> {
-                tokenState.daVinciToken?.let {
-                    json.encodeToString(Token.serializer(), it)
-                } ?: tokenState.daVinciError?.toString() ?: "No DaVinci token information is available"
-            }
-            TokenType.OIDC -> {
-                tokenState.oidcToken?.let {
-                    json.encodeToString(Token.serializer(), it)
-                } ?: tokenState.oidcError?.toString() ?: "No OIDC token information is available"
-            }
-        }
-    }
 
     fun selectTab(tabType: TokenType) {
         state.update { it.copy(selectedTab = tabType) }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/userprofile/UserProfile.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/userprofile/UserProfile.kt
@@ -9,6 +9,7 @@ package com.pingidentity.samples.pingsampleapp.userprofile
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -35,6 +36,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -189,50 +193,70 @@ fun UserProfile(
 @Composable
 private fun UserInfoCard(
     title: String,
-    user: kotlinx.serialization.json.JsonObject?,
+    user: JsonObject?,
     showRawInfo: Boolean,
     formattedInfo: String,
     onToggle: () -> Unit
 ) {
-    Card(
-        elevation = CardDefaults.cardElevation(defaultElevation = 10.dp),
-        modifier = Modifier.fillMaxWidth().padding(8.dp),
-        shape = MaterialTheme.shapes.medium,
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
     ) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(8.dp)
+            modifier = Modifier.padding(bottom = 12.dp)
         )
-        Text(
-            "First name: ${user?.get("name") ?: "N/A"}",
-            Modifier.fillMaxWidth().padding(4.dp)
-        )
-        Spacer(modifier = Modifier.padding(horizontal = 4.dp))
-        Text(
-            "Family name: ${user?.get("family_name") ?: "N/A"}",
-            Modifier.fillMaxWidth().padding(4.dp)
-        )
-        Spacer(modifier = Modifier.padding(horizontal = 4.dp))
-        Text(
-            "Email: ${user?.get("email") ?: "N/A"}",
-            Modifier.fillMaxWidth().padding(4.dp)
-        )
+        UserInfoField("First Name", user?.stringClaim("given_name")
+            ?: user?.stringClaim("name"))
+        UserInfoField("Family Name", user?.stringClaim("family_name"))
+        UserInfoField("Email", user?.stringClaim("email"))
+        UserInfoField("Username", user?.stringClaim("preferred_username"))
 
         Button(
-            modifier = Modifier.padding(8.dp).align(Alignment.End),
+            modifier = Modifier
+                .padding(top = 12.dp)
+                .align(Alignment.End),
             onClick = onToggle
         ) {
-            Text(text = if (showRawInfo) "Hide Info" else "Show Raw User Info")
+            Text(text = if (showRawInfo) "Hide Raw Info" else "Show Raw Info")
         }
 
         if (showRawInfo) {
             Text(
-                modifier = Modifier.padding(4.dp),
+                modifier = Modifier.padding(top = 8.dp),
                 text = formattedInfo,
+                style = MaterialTheme.typography.bodySmall,
             )
         }
     }
+}
+
+@Composable
+private fun UserInfoField(label: String, value: String?) {
+    if (value == null) return
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+    ) {
+        Text(
+            text = label.uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(2.dp))
+        Text(
+            text = value.ifBlank { "N/A" },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+    androidx.compose.material3.HorizontalDivider(
+        modifier = Modifier.padding(vertical = 4.dp),
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f),
+    )
 }
 
 @Composable
@@ -313,3 +337,6 @@ fun PreviewUserProfile() {
         onBack = {}
     )
 }
+
+private fun JsonObject.stringClaim(key: String): String? =
+    this[key]?.jsonPrimitive?.contentOrNull


### PR DESCRIPTION
# JIRA Ticket
[SDKS-4937](https://pingidentity.atlassian.net/browse/SDKS-4937)

# Description
Match Android and iOS Sample Apps
|Token|User Profile|
|-|-|
|<img width="1080" height="2400" alt="Token" src="https://github.com/user-attachments/assets/422ece5c-1797-4436-8512-c5268fb579c7" /> | <img width="1080" height="2400" alt="UserProfile" src="https://github.com/user-attachments/assets/0f2381fb-1d9c-4e57-a3e1-2eac41820734" />|



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Token screen: tab-driven navigation, card-based token views, top-bar icon actions, clipboard copy for token fields, and an expiry countdown.
  * Env screen: “Duplicate” action for Journey and OIDC configs via row menu/long-press; duplication persists to custom configs.
  * Header: settings button added to home header.

* **Refactor**
  * User profile view reorganized to field-based layout with improved labeling, fallbacks, dividers, and raw-info toggle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->