### PR TITLE
SDKS-4249 QA for new DaVinci collectors

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/AndroidLibraryConventionPlugin.kt
@@ -23,6 +23,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             extensions.configure<LibraryExtension> {
                 configureKotlinAndroid(this)
                 namespace = "com.pingidentity.${project.name.replace("-", ".")}"
+                // bcprov-jdk18on 1.83+ contains Java 25 multi-release class files (major version 69).
+                // AGP's default JaCoCo 0.8.12 (ASM 9.7) cannot instrument them; 0.8.13 (ASM 9.8) can.
+                testCoverage { jacocoVersion = "0.8.13" }
                 publishing {
                     singleVariant("release") {
                         withSourcesJar()

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/JacocoPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/JacocoPlugin.kt
@@ -44,9 +44,6 @@ class JacocoPlugin : Plugin<Project> {
             plugins.run {
                 apply("jacoco")
             }
-            // JaCoCo 0.8.12 (bundled with Gradle 8.13) cannot instrument Java 25 multi-release JAR
-            // classes (e.g. bcprov-jdk18on:1.84). 0.8.13 adds Java 25 support.
-            jacoco.toolVersion = "0.8.13"
             jacocoAfterEvaluate()
         }
 

--- a/build-logic/convention/src/main/kotlin/com/pingidentity/convention/JacocoPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/com/pingidentity/convention/JacocoPlugin.kt
@@ -44,6 +44,9 @@ class JacocoPlugin : Plugin<Project> {
             plugins.run {
                 apply("jacoco")
             }
+            // JaCoCo 0.8.12 (bundled with Gradle 8.13) cannot instrument Java 25 multi-release JAR
+            // classes (e.g. bcprov-jdk18on:1.84). 0.8.13 adds Java 25 support.
+            jacoco.toolVersion = "0.8.13"
             jacocoAfterEvaluate()
         }
 

--- a/davinci/build.gradle.kts
+++ b/davinci/build.gradle.kts
@@ -60,5 +60,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(project(":foundation:testrail"))
     androidTestImplementation(project(":protect"))
-    androidTestImplementation("com.google.zxing:core:3.5.3")
+    androidTestImplementation(libs.zxing.core)
 }

--- a/davinci/build.gradle.kts
+++ b/davinci/build.gradle.kts
@@ -60,4 +60,5 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(project(":foundation:testrail"))
     androidTestImplementation(project(":protect"))
+    androidTestImplementation("com.google.zxing:core:3.5.3")
 }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -11,6 +11,7 @@ import androidx.test.filters.SmallTest
 import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.davinci.collector.InvalidLength
 import com.pingidentity.davinci.collector.Length
+import com.pingidentity.davinci.collector.MaxRepeat
 import com.pingidentity.davinci.collector.MinCharacters
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.RegexError
@@ -30,12 +31,16 @@ import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.rules.TestWatcher
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 @SmallTest
@@ -44,11 +49,11 @@ class FormFieldValidationTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "021b83ce-a9b1-4ad4-8c1d-79e576eeab76"
-            discoveryEndpoint = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration"
+            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+            discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
             redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "210f6b876da11c836ffc1c5fb38f3938"
+            acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
             //storage = dataStore
         }
     }
@@ -195,6 +200,124 @@ class FormFieldValidationTest {
 
         // Should return empty list this time
         assertTrue(passwordValidationResult.isEmpty())
+    }
+
+    @Test
+    fun passwordMaxRepeatValidationTest() = runTest {
+        // Go to the "Form Fields Validation" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[1] as? FlowCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val password = node.collectors[3] as PasswordCollector
+        val policy = password.passwordPolicy()!!
+
+        // Verify the policy actually declares a maxRepeatedCharacters limit
+        val maxRepeated = policy.maxRepeatedCharacters
+        assertTrue(maxRepeated < Int.MAX_VALUE, "Test requires a policy with a maxRepeatedCharacters limit")
+
+        // Build a value where one character repeats maxRepeated+1 times alongside enough
+        // other characters to satisfy all other constraints (length, unique, minCharacters)
+        val excess = "a".repeat(maxRepeated + 1)   // e.g. "aaa" for limit=2
+        val padding = "B1!"                          // uppercase + digit + symbol
+        password.value = excess + padding
+
+        val errors = password.validate()
+        assertTrue(errors.contains(MaxRepeat(maxRepeated)),
+            "Expected MaxRepeat($maxRepeated) in $errors")
+
+        // A password with at most maxRepeated repetitions of any character should not trigger MaxRepeat
+        password.value = "a".repeat(maxRepeated) + "B1!cde"
+        val errorsAfterFix = password.validate()
+        assertFalse(errorsAfterFix.contains(MaxRepeat(maxRepeated)),
+            "MaxRepeat error should be absent when repetitions <= $maxRepeated")
+    }
+
+    @Test
+    fun passwordMaxLengthValidationTest() = runTest {
+        // Go to the "Form Fields Validation" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[1] as? FlowCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val password = node.collectors[3] as PasswordCollector
+        val policy = password.passwordPolicy()!!
+        val maxLen = policy.length.max
+
+        // Build a value that exceeds the maximum length while satisfying all other constraints
+        // so that InvalidLength is the only error triggered
+        val overLength = "Aa1!" + "x".repeat(maxLen)   // maxLen+4 chars total
+        password.value = overLength
+
+        val errors = password.validate()
+        assertTrue(errors.contains(InvalidLength(min = policy.length.min, max = maxLen)),
+            "Expected InvalidLength for value longer than max=$maxLen")
+    }
+
+    @Test
+    fun passwordClearPasswordAfterCloseTest() = runTest {
+        // Go to the "Form Fields Validation" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[1] as? FlowCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val password = node.collectors[3] as PasswordCollector
+        password.value = "Password123!"
+
+        // Default is clearPassword=true — close() must wipe the value
+        assertTrue(password.clearPassword)
+        password.close()
+        assertEquals("", password.value, "Password should be cleared after close() when clearPassword=true")
+    }
+
+    @Test
+    fun passwordPolicyAdditionalMetadataTest() = runTest {
+        // Go to the "Form Fields Validation" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[1] as? FlowCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val password = node.collectors[3] as PasswordCollector
+        val policy = password.passwordPolicy()!!
+
+        // Verify the fields that drive validation logic but were previously unasserted
+        assertTrue(policy.maxRepeatedCharacters < Int.MAX_VALUE,
+            "maxRepeatedCharacters should be set by the 'Standard' policy")
+        assertEquals(4, policy.minCharacters.size,
+            "Standard policy should require exactly 4 character classes")
+
+        // Verify the read-only metadata fields are populated (not blank/zero defaults)
+        assertTrue(policy.createdAt.isNotEmpty(), "createdAt should be set")
+        assertTrue(policy.updatedAt.isNotEmpty(), "updatedAt should be set")
+        assertTrue(policy.populationCount >= 0, "populationCount should be >= 0")
+    }
+
+    @Test
+    fun passwordPolicySourceIsFieldLevelTest() = runTest {
+        // Go to the "Form Fields Validation" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[1] as? FlowCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val password = node.collectors[3] as PasswordCollector
+
+        // Verify the policy is embedded directly inside the PASSWORD_VERIFY field JSON (SDKS-4694).
+        val passwordField = node.input["form"]
+            ?.jsonObject?.get("components")
+            ?.jsonObject?.get("fields")
+            ?.jsonArray?.firstOrNull {
+                it.jsonObject["type"]?.jsonPrimitive?.content == "PASSWORD_VERIFY"
+            }?.jsonObject
+        assertNotNull("PASSWORD_VERIFY field not found in form components", passwordField)
+        assertNotNull(
+            "passwordPolicy must be embedded inside the PASSWORD_VERIFY field",
+            passwordField!!["passwordPolicy"])
+
+        // The SDK must surface the field-level policy via passwordPolicy()
+        val policy = password.passwordPolicy()
+        assertNotNull(policy)
+        assertEquals("Standard", policy!!.name)
+        assertEquals(Length(min = 8, max = 255), policy.length)
     }
 
     @TestRailCase(27507)

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -325,7 +325,7 @@ class FormFieldValidationTest {
     fun errorNodeTest() = runTest {
         // Go to the "Error Node" form
         val node = daVinci.start() as ContinueNode
-        (node.collectors[2] as? FlowCollector)?.value = "click"
+        (node.collectors[3] as? FlowCollector)?.value = "click"
         val errorNode = node.next()
         assertTrue(errorNode is ErrorNode)
 

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -29,8 +29,6 @@ import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.orchestrate.ErrorNode
 import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
-import junit.framework.TestCase.assertFalse
-import junit.framework.TestCase.assertNotNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -41,6 +39,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @SmallTest
@@ -308,10 +307,10 @@ class FormFieldValidationTest {
             ?.jsonArray?.firstOrNull {
                 it.jsonObject["type"]?.jsonPrimitive?.content == "PASSWORD_VERIFY"
             }?.jsonObject
-        assertNotNull("PASSWORD_VERIFY field not found in form components", passwordField)
+        assertNotNull("PASSWORD_VERIFY field not found in form components", passwordField.toString())
         assertNotNull(
             "passwordPolicy must be embedded inside the PASSWORD_VERIFY field",
-            passwordField!!["passwordPolicy"])
+            passwordField!!["passwordPolicy"].toString())
 
         // The SDK must surface the field-level policy via passwordPolicy()
         val policy = password.passwordPolicy()

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -307,10 +307,8 @@ class FormFieldValidationTest {
             ?.jsonArray?.firstOrNull {
                 it.jsonObject["type"]?.jsonPrimitive?.content == "PASSWORD_VERIFY"
             }?.jsonObject
-        assertNotNull("PASSWORD_VERIFY field not found in form components", passwordField.toString())
-        assertNotNull(
-            "passwordPolicy must be embedded inside the PASSWORD_VERIFY field",
-            passwordField!!["passwordPolicy"].toString())
+        assertNotNull(passwordField, "PASSWORD_VERIFY field not found in form components")
+        assertNotNull(passwordField!!["passwordPolicy"], "passwordPolicy must be embedded inside the PASSWORD_VERIFY field")
 
         // The SDK must surface the field-level policy via passwordPolicy()
         val policy = password.passwordPolicy()

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -58,11 +58,11 @@ class FormFieldsTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "021b83ce-a9b1-4ad4-8c1d-79e576eeab76"
-            discoveryEndpoint = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration"
+            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+            discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
             redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "210f6b876da11c836ffc1c5fb38f3938"
+            acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
             //storage = dataStore
         }
     }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -711,10 +711,8 @@ class FormFieldsTest {
         assertEquals("Success", node.name)
     }
 
-    // Leaving phoneNumber + countryCode empty → payload() returns null → field absent from
-    // the POST body → server treats the field as missing and returns a validation error.
     @Test
-    fun phoneNumberSubmissionWithEmptyPhoneOmitsFieldTest() = runTest {
+    fun phoneNumberPayloadIsNullWhenEmptyTest() = runTest {
         var node = daVinci.start() as ContinueNode
         (node.collectors[0] as? SubmitCollector)?.value = "click"
         node = node.next() as ContinueNode
@@ -723,14 +721,9 @@ class FormFieldsTest {
         phone.countryCode = ""
         phone.phoneNumber = ""
 
-        fillRequiredFields(node)
-
-        (node.collectors[SUBMIT_BUTTON_INDEX] as SubmitCollector).value = "Submit"
-        // payload() returns null → the phone key is absent from formData → server rejects
         val errors = phone.validate()
         assertTrue(errors.isNotEmpty(), "Expected Required error when phone is empty")
         assertEquals("Required", errors[0].toString())
-        // Confirm null payload — field would not be included in the POST body
         assertNull(phone.payload())
     }
 

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -26,6 +26,8 @@ import com.pingidentity.testrail.TestRailCase
 import com.pingidentity.testrail.TestRailWatcher
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.Rule
 import org.junit.rules.TestWatcher
 import kotlin.test.BeforeTest
@@ -52,6 +54,7 @@ class FormFieldsTest {
         const val SINGLE_CHECKBOX_INDEX = 9
         const val FLOW_BUTTON_INDEX = 10
         const val FLOW_LINK_INDEX = 11
+        const val SUBMIT_BUTTON_INDEX = 12
     }
 
     private var daVinci = DaVinci {
@@ -414,6 +417,97 @@ class FormFieldsTest {
         assertTrue(validationResult.isEmpty())
     }
 
+    // SDKS-4198 / DV-17946: countryCode format change — previously a plain string, now an
+    // object { phoneNumber, countryCode, extension }. Verify that the pre-filled object format
+    // is parsed correctly AND that payload() emits the same object structure (not a string).
+    @Test
+    fun phoneNumberCollectorObjectPayloadTest() = runTest {
+        // Go to the "Form Fields" form
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        assertTrue(node.collectors[PHONE_NUMBER_INDEX] is PhoneNumberCollector)
+        val phone = node.collectors[PHONE_NUMBER_INDEX] as PhoneNumberCollector
+
+        // Server pre-fills countryCode + phoneNumber as an object (DV-17946 new format).
+        // Verify both fields were parsed from the object — not from a flat string.
+        assertEquals("GB", phone.countryCode)
+        assertEquals("(555)555-1234", phone.phoneNumber)
+
+        // payload() must return a JsonObject (not null and not a primitive string).
+        val payload = phone.payload()
+        assertNotNull(payload)
+        assertTrue(payload is JsonObject, "payload() must return a JsonObject for the new object format")
+        payload as JsonObject
+        assertEquals("GB", payload["countryCode"]?.jsonPrimitive?.content)
+        assertEquals("(555)555-1234", payload["phoneNumber"]?.jsonPrimitive?.content)
+        // extension key must be present in the payload (even when empty)
+        assertTrue(payload.containsKey("extension"), "payload must include the 'extension' key")
+    }
+
+    // Verify that showExtension/extensionLabel schema properties are parsed from the field config,
+    // that extension is correctly included in payload(), and that setting a value is reflected there.
+    @Test
+    fun phoneNumberExtensionSchemaAndPayloadTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val phone = node.collectors[PHONE_NUMBER_INDEX] as PhoneNumberCollector
+
+        // Schema-level extension properties (parsed from init(JsonObject))
+        assertEquals(true, phone.showExtension)
+
+        // TODO: Enable the following assertion once SDKS-5073 is resolved
+        // assertEquals("Extension", phone.extensionLabel)
+
+        // extension is pre-filled from formData object (DV-17946 new format)
+        assertEquals("4321", phone.extension)
+
+        // Overwrite with a different extension value and verify it appears in payload
+        phone.countryCode = "CA"
+        phone.phoneNumber = "7783177184"
+        phone.extension = "123"
+
+        val payload = phone.payload()
+        assertNotNull(payload)
+        payload as JsonObject
+        assertEquals("CA", payload["countryCode"]?.jsonPrimitive?.content)
+        assertEquals("7783177184", payload["phoneNumber"]?.jsonPrimitive?.content)
+        assertEquals("123", payload["extension"]?.jsonPrimitive?.content)
+    }
+
+    // Verify that validate() is not affected by the extension field — extension is optional and
+    // must never cause or block a Required error regardless of its value.
+    @Test
+    fun phoneNumberExtensionValidationTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val phone = node.collectors[PHONE_NUMBER_INDEX] as PhoneNumberCollector
+
+        // Extension set, but phone number missing → still Required
+        phone.countryCode = "CA"
+        phone.phoneNumber = ""
+        phone.extension = "999"
+        var validationResult = phone.validate()
+        assertTrue(validationResult.isNotEmpty())
+        assertEquals("Required", validationResult[0].toString())
+
+        // Extension empty, valid phone + country → no errors
+        phone.phoneNumber = "7783177184"
+        phone.extension = ""
+        validationResult = phone.validate()
+        assertTrue(validationResult.isEmpty())
+
+        // Extension set, valid phone + country → still no errors
+        phone.extension = "42"
+        validationResult = phone.validate()
+        assertTrue(validationResult.isEmpty())
+    }
+
     @TestRailCase(/* Add test rail IDs */)
     @Test
     fun booleanCollectorTest() = runTest {
@@ -472,6 +566,79 @@ class FormFieldsTest {
         assertEquals("Success", node.name)
     }
 
+    // Submitting with countryCode + phoneNumber sends the object format to the server.
+    @Test
+    fun phoneNumberSubmissionWithObjectFormatTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val phone = node.collectors[PHONE_NUMBER_INDEX] as PhoneNumberCollector
+        phone.countryCode = "CA"
+        phone.phoneNumber = "7783177184"
+        phone.extension = ""
+
+        // Fill required fields so the form can submit successfully
+        fillRequiredFields(node)
+
+        (node.collectors[SUBMIT_BUTTON_INDEX] as SubmitCollector).value = "Submit"
+        node = node.next() as ContinueNode
+        assertEquals("Success", node.name)
+    }
+
+    // Submitting with a non-empty extension sends the value in the request body.
+    @Test
+    fun phoneNumberSubmissionWithExtensionTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val phone = node.collectors[PHONE_NUMBER_INDEX] as PhoneNumberCollector
+        phone.countryCode = "GB"
+        phone.phoneNumber = "(555)555-1234"
+        phone.extension = "4321"
+
+        fillRequiredFields(node)
+
+        (node.collectors[SUBMIT_BUTTON_INDEX] as SubmitCollector).value = "Submit"
+        node = node.next() as ContinueNode
+        assertEquals("Success", node.name)
+    }
+
+    // Leaving phoneNumber + countryCode empty → payload() returns null → field absent from
+    // the POST body → server treats the field as missing and returns a validation error.
+    @Test
+    fun phoneNumberSubmissionWithEmptyPhoneOmitsFieldTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val phone = node.collectors[PHONE_NUMBER_INDEX] as PhoneNumberCollector
+        phone.countryCode = ""
+        phone.phoneNumber = ""
+
+        fillRequiredFields(node)
+
+        (node.collectors[SUBMIT_BUTTON_INDEX] as SubmitCollector).value = "Submit"
+        // payload() returns null → the phone key is absent from formData → server rejects
+        val errors = phone.validate()
+        assertTrue(errors.isNotEmpty(), "Expected Required error when phone is empty")
+        assertEquals("Required", errors[0].toString())
+        // Confirm null payload — field would not be included in the POST body
+        assertNull(phone.payload())
+    }
+
+    // Fills the non-phone required fields in the Form Fields form so that a submission test
+    // targeting the phone field does not fail due to other missing required fields.
+    private fun fillRequiredFields(node: ContinueNode) {
+        (node.collectors[TEXT_INPUT_INDEX] as? TextCollector)?.value = "test"
+        (node.collectors[CHECKBOX_INDEX] as? MultiSelectCollector)?.value = mutableListOf("option1 value")
+        (node.collectors[DROPDOWN_INDEX] as? SingleSelectCollector)?.value = "dropdown-option1-value"
+        (node.collectors[RADIO_INDEX] as? SingleSelectCollector)?.value = "option1 value"
+        (node.collectors[COMBOBOX_INDEX] as? MultiSelectCollector)?.value = mutableListOf("option1 value")
+        (node.collectors[SINGLE_CHECKBOX_INDEX] as? BooleanCollector)?.value = true
+    }
+
     @TestRailCase(26033)
     @Test
     fun flowLinkCollectorTest() = runTest {
@@ -480,7 +647,6 @@ class FormFieldsTest {
         (node.collectors[0] as? SubmitCollector)?.value = "click"
         node = node.next() as ContinueNode
 
-        // 12th collector in the form is a FlowLink (index 11)
         assertTrue(node.collectors[FLOW_LINK_INDEX] is FlowCollector)
         val flowLink = (node.collectors[FLOW_LINK_INDEX] as FlowCollector)
 

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -125,15 +125,15 @@ class FormFieldsTest {
         // No replacement tokens on this label
         assertTrue(richContent2.replacements.isEmpty())
 
-        // labelCollector3: translatable link — richText contains {{token}} placeholders and replacements map contains corresponding entries
         val richContent3 = labelCollector3.richContent
         assertNotNull(richContent3)
-        assertEquals("A translatable rich text to take the user to {{link1}}", richContent3.content)
+        assertEquals("A translatable rich text to take the user to {{link1}} and {{link2}}", richContent3.content)
         assertTrue(richContent3.replacements.containsKey("link1"))
-        val replacement = richContent3.replacements["link1"]
-        assertNotNull(replacement)
-        assertEquals("google.com", replacement.value)
-        assertEquals("https://www.google.com", replacement.href)
+        assertTrue(richContent3.replacements.containsKey("link2"))
+        assertEquals("google.com", richContent3.replacements["link1"]!!.value)
+        assertEquals("https://www.google.com", richContent3.replacements["link1"]!!.href)
+        assertEquals("apple.com", richContent3.replacements["link2"]!!.value)
+        assertEquals("https://www.apple.com", richContent3.replacements["link2"]!!.href)
     }
 
     @Test
@@ -164,6 +164,54 @@ class FormFieldsTest {
             }
         }
         // If no such label is present in the current form, the test is a no-op (no assertion failure)
+    }
+
+    // Verify that a LABEL with two links exposes both replacements with correct values/hrefs.
+    @Test
+    fun labelCollectorMultipleLinksTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val label = node.collectors[LABEL_RICH_TEXT_INDEX] as LabelCollector
+        val richContent = label.richContent
+        assertNotNull(richContent)
+
+        assertEquals(
+            "A translatable rich text to take the user to {{link1}} and {{link2}}",
+            richContent.content
+        )
+        assertEquals(2, richContent.replacements.size)
+
+        val link1 = richContent.replacements["link1"]
+        assertNotNull(link1)
+        assertEquals("google.com", link1.value)
+        assertEquals("https://www.google.com", link1.href)
+        assertEquals("link", link1.type)
+        assertEquals("_self", link1.target)
+
+        val link2 = richContent.replacements["link2"]
+        assertNotNull(link2)
+        assertEquals("apple.com", link2.value)
+        assertEquals("https://www.apple.com", link2.href)
+        assertEquals("link", link2.type)
+        assertEquals("_blank", link2.target)
+    }
+
+    // Verify mixed open-in-new-tab targets — link1 stays in the same context (_self),
+    // link2 requests a new tab (_blank). Both targets must be independently correct.
+    @Test
+    fun labelCollectorLinkTargetsTest() = runTest {
+        var node = daVinci.start() as ContinueNode
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        val label = node.collectors[LABEL_RICH_TEXT_INDEX] as LabelCollector
+        val replacements = label.richContent?.replacements
+        assertNotNull(replacements)
+
+        assertEquals("_self",  replacements["link1"]?.target)
+        assertEquals("_blank", replacements["link2"]?.target)
     }
 
     @TestRailCase(26032, 26031)

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -13,6 +13,7 @@ import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PhoneNumberCollector
 import com.pingidentity.davinci.collector.BooleanCollector
+import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -55,6 +56,9 @@ class FormFieldsTest {
         const val FLOW_BUTTON_INDEX = 10
         const val FLOW_LINK_INDEX = 11
         const val SUBMIT_BUTTON_INDEX = 12
+
+        // Agreement Test form (separate flow branch)
+        const val AGREEMENT_TEST_BUTTON_INDEX = 2  // "Agreement Test" flow button on the menu form
     }
 
     private var daVinci = DaVinci {
@@ -588,6 +592,60 @@ class FormFieldsTest {
         singleCheckbox.value = true
         val validationResult = singleCheckbox.validate() // Should return empty list since it's valid
         assertTrue(validationResult.isEmpty())
+    }
+
+    @Test
+    fun agreementCollectorTest() = runTest {
+        // Navigate to the "Agreement Test" form via the menu
+        var node = daVinci.start() as ContinueNode
+        val agreementButton = node.collectors[AGREEMENT_TEST_BUTTON_INDEX] as FlowCollector
+        agreementButton.value = "click"
+        node = node.next() as ContinueNode
+
+        // Form: "Automation - Agreement Tests"
+        assertEquals("Automation - Agreement Tests", node.name)
+
+        val agreement = node.collectors.filterIsInstance<ReadOnlyTextCollector>().first()
+        val checkbox  = node.collectors.filterIsInstance<BooleanCollector>().first()
+        val submit    = node.collectors.filterIsInstance<SubmitCollector>().first()
+
+        // ReadOnlyTextCollector properties
+        assertEquals("agreement", agreement.key)
+        assertEquals("AGREEMENT", agreement.type)
+        assertEquals("Terms of Service Agreement", agreement.title)
+        assertEquals(true, agreement.titleEnabled)
+        assertEquals(true, agreement.enabled)
+        assertEquals(false, agreement.useDynamicAgreement)
+        assertTrue(agreement.content.isNotEmpty())
+
+        // BooleanCollector properties
+        assertEquals("agreement-checkbox", checkbox.key)
+        assertEquals("I have read and agree to terms", checkbox.label)
+        assertEquals(true, checkbox.required)
+        assertEquals("You must agree to the terms to continue.", checkbox.errorMessage)
+
+        // richContent link inside the checkbox label
+        val richContent = checkbox.richContent
+        assertNotNull(richContent)
+        assertEquals("I have read and agree to {{link1}}", richContent.content)
+        val link1 = richContent.replacements["link1"]
+        assertNotNull(link1)
+        assertEquals("terms", link1.value)
+        assertEquals("https://www.pingidentity.com/en/legal/product-terms.html", link1.href)
+        assertEquals("_self", link1.target)
+
+        // Unchecked → validate() must return an error; submission is blocked
+        assertEquals(false, checkbox.value)
+        assertTrue(checkbox.validate().isNotEmpty())
+
+        // Checking the box clears the error
+        checkbox.value = true
+        assertTrue(checkbox.validate().isEmpty())
+
+        // Submit with checkbox checked → flow advances
+        submit.value = "Accept"
+        node = node.next() as ContinueNode
+        assertEquals("Select Test Form", node.name)
     }
 
     @TestRailCase(26033)

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/Polling-Collector-Tests-Flows.json
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/Polling-Collector-Tests-Flows.json
@@ -10,15 +10,15 @@
     "functionsConnector",
     "httpConnector"
   ],
-  "createdDate": 1779379639501,
-  "currentVersion": 32,
+  "createdDate": 1779484501987,
+  "currentVersion": 45,
   "customerId": "b046b8357f81a6b68a9a60227d631009",
-  "deployedDate": 1779389055294,
+  "deployedDate": 1779484505141,
   "description": "Imported on Wed May 20 2026 15:21:11 GMT+0000 (Coordinated Universal Time)",
   "flowStatus": "enabled",
   "isOutputSchemaSaved": false,
   "name": "Automation - Polling Tests",
-  "publishedVersion": 32,
+  "publishedVersion": 45,
   "settings": {
     "csp": "worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';",
     "intermediateLoadingScreenCSS": "",
@@ -35,9 +35,9 @@
   "trigger": {
     "type": "AUTHENTICATION"
   },
-  "updatedDate": 1779389055311,
+  "updatedDate": 1779484505158,
   "flowId": "03209dede7fdab087a75b012e973916e",
-  "versionId": 32,
+  "versionId": 45,
   "graphData": {
     "elements": {
       "nodes": [
@@ -61,13 +61,16 @@
               },
               "challengeExpiry": {
                 "value": 300
+              },
+              "generateQr": {
+                "value": false
               }
             },
             "isDisabled": false
           },
           "position": {
             "x": 1140,
-            "y": 716
+            "y": 720
           },
           "group": "nodes",
           "removed": false,
@@ -136,8 +139,8 @@
             "capabilityClass": "render"
           },
           "position": {
-            "x": 1484,
-            "y": 802
+            "x": 1470,
+            "y": 810
           },
           "group": "nodes",
           "removed": false,
@@ -155,7 +158,7 @@
           },
           "position": {
             "x": 1290,
-            "y": 776
+            "y": 780
           },
           "group": "nodes",
           "removed": false,
@@ -173,7 +176,7 @@
           },
           "position": {
             "x": 1920,
-            "y": 746
+            "y": 750
           },
           "group": "nodes",
           "removed": false,
@@ -219,7 +222,7 @@
           },
           "position": {
             "x": 2100,
-            "y": 776
+            "y": 780
           },
           "group": "nodes",
           "removed": false,
@@ -250,8 +253,8 @@
             "capabilityClass": "backend"
           },
           "position": {
-            "x": 1754,
-            "y": 802
+            "x": 1740,
+            "y": 810
           },
           "group": "nodes",
           "removed": false,
@@ -269,7 +272,7 @@
           },
           "position": {
             "x": 1620,
-            "y": 776
+            "y": 780
           },
           "group": "nodes",
           "removed": false,
@@ -576,7 +579,7 @@
           },
           "position": {
             "x": 1650,
-            "y": 596
+            "y": 600
           },
           "group": "nodes",
           "removed": false,
@@ -707,7 +710,7 @@
             "type": "trigger",
             "properties": {
               "customHTML": {
-                "value": "<div\n    class=\"bg-light d-flex flex-column justify-content-center align-items-center position-absolute top-0 start-0 bottom-0 end-0 overflow-auto\">\n    <div style=\"max-width: 400px; min-width: 400px; width: 100%\">\n        <div class=\"card shadow mb-5\">\n                <h1 class=\"text-center mb-4\">S</h1>\n                <p class=\"text-muted text-center\">Select Test Form</p>\n                <p class=\"text-danger mdi mdi-alert-circle\" data-id=\"feedback\" data-skcomponent=\"skerror\"></p>\n                <form id=\"success\" data-id=\"success\">\n                    <div class=\"d-flex flex-column\">\n                        <button data-id=\"button\" type=\"submit\" class=\"btn btn-primary mb-3\" data-skcomponent=\"skbutton\"\n                            data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnContinuePolling\"\n                            data-skbuttonvalue=\"Continue Polling\">\n                            Continue Polling\n                        </button>\n                        <div class=\"d-flex flex-column\">\n                            <button data-id=\"button\" class=\"btn btn-link\" data-skcomponent=\"skbutton\"\n                                data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnChallengePolling\"\n                                data-skbuttonvalue=\"Challenge Polling\">\n                                Challenge Polling\n                            </button>\n                        </div>\n                </form>\n            </div>\n        </div>\n    </div>\n</div>"
+                "value": "<div\n    class=\"bg-light d-flex flex-column justify-content-center align-items-center position-absolute top-0 start-0 bottom-0 end-0 overflow-auto\">\n    <div style=\"max-width: 400px; min-width: 400px; width: 100%\">\n        <div class=\"card shadow mb-5\">\n                <h1 class=\"text-center mb-4\">S</h1>\n                <p class=\"text-muted text-center\">Select Test Form</p>\n                <p class=\"text-danger mdi mdi-alert-circle\" data-id=\"feedback\" data-skcomponent=\"skerror\"></p>\n                <form id=\"success\" data-id=\"success\">\n                    <div class=\"d-flex flex-column\">\n                        <button data-id=\"button\" type=\"submit\" class=\"btn btn-primary mb-3\" data-skcomponent=\"skbutton\"\n                            data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnContinuePolling\"\n                            data-skbuttonvalue=\"Continue Polling\">\n                            Continue Polling\n                        </button>\n                        <div class=\"d-flex flex-column\">\n                            <button data-id=\"button\" class=\"btn btn-link\" data-skcomponent=\"skbutton\"\n                                data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnChallengePolling\"\n                                data-skbuttonvalue=\"Challenge Polling\">\n                                Challenge Polling\n                            </button>\n                        </div>\n                         <div class=\"d-flex flex-column\">\n                            <button data-id=\"button\" class=\"btn btn-link\" data-skcomponent=\"skbutton\"\n                                data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnChallengePollingQRCode\"\n                                data-skbuttonvalue=\"Challenge Polling QRCode\">\n                                Challenge Polling QRCode\n                            </button>\n                        </div>\n                </form>\n            </div>\n        </div>\n    </div>\n</div>"
               },
               "formFieldsList": {
                 "value": [
@@ -789,6 +792,10 @@
                   {
                     "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"Challenge Polling\"\n      }\n    ]\n  }\n]",
                     "id": "js0k5824y5"
+                  },
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Challenge Polling QRCode\"\n      }\n    ]\n  }\n]",
+                    "id": "c87ygb1l2b"
                   }
                 ]
               }
@@ -960,7 +967,7 @@
           },
           "position": {
             "x": 1140,
-            "y": 926
+            "y": 930
           },
           "group": "nodes",
           "removed": false,
@@ -995,7 +1002,7 @@
           },
           "position": {
             "x": 1470,
-            "y": 926
+            "y": 930
           },
           "group": "nodes",
           "removed": false,
@@ -1014,7 +1021,7 @@
           },
           "position": {
             "x": 1620,
-            "y": 896
+            "y": 900
           },
           "group": "nodes",
           "removed": false,
@@ -1045,7 +1052,7 @@
           },
           "position": {
             "x": 1770,
-            "y": 926
+            "y": 930
           },
           "group": "nodes",
           "removed": false,
@@ -1063,7 +1070,7 @@
           },
           "position": {
             "x": 1260,
-            "y": 896
+            "y": 900
           },
           "group": "nodes",
           "removed": false,
@@ -1080,8 +1087,405 @@
             "nodeType": "EVAL"
           },
           "position": {
-            "x": 945,
-            "y": 926
+            "x": 960,
+            "y": 930
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "fnh55etehh",
+            "nodeType": "CONNECTION",
+            "connectionId": "2581eb287bb1d9bd29ae9886d675f89f",
+            "connectorId": "flowConnector",
+            "name": "Flow Connector",
+            "label": "Flow [2023-01-24]",
+            "status": "configured",
+            "capabilityName": "oobStart",
+            "type": "trigger",
+            "properties": {
+              "useCustomLink": {
+                "value": false
+              },
+              "customLink": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"pingid://auth.pingone.com/\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"auth.svg\",\n        \"url\": \"companyId\",\n        \"data\": \"{{global.companyId}}\",\n        \"tooltip\": \"{{global.companyId}}\",\n        \"children\": [\n          {\n            \"text\": \"companyId\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"/davinci/connections/\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"2fb0ca54c9286625c1f5d6989808ead1\"\n      },\n      {\n        \"text\": \"/callback/oobContinue?challenge=\"\n      }\n    ]\n  }\n]"
+              },
+              "challengeExpiry": {
+                "value": 300
+              },
+              "generateQr": {
+                "value": true
+              }
+            },
+            "isDisabled": false
+          },
+          "position": {
+            "x": 1020,
+            "y": 1140
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xzhxneu3vg",
+            "nodeType": "CONNECTION",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "status": "configured",
+            "capabilityName": "customForm",
+            "type": "action",
+            "properties": {
+              "formData": {
+                "value": []
+              },
+              "dynamicText": {
+                "value": []
+              },
+              "form": {
+                "value": "eddaf29b-84ba-4946-976f-3301986aecb0"
+              },
+              "enablePolling": {
+                "value": true
+              },
+              "pollRetries": {
+                "value": 3
+              },
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.fnh55etehh.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.fnh55etehh.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "QRCode"
+              },
+              "qrCodeContents": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"continueQr\",\n        \"data\": \"{{local.fnh55etehh.payload.output.continueQr}}\",\n        \"tooltip\": \"{{local.fnh55etehh.payload.output.continueQr}}\",\n        \"children\": [\n          {\n            \"text\": \"continueQr\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "enableRisk": {
+                "value": true
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 1230,
+            "y": 1290
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "sbtlmd892l",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1230,
+            "y": 1170
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "0f6wy2gll8",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1680,
+            "y": 1230
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "o84vpl35go",
+            "nodeType": "CONNECTION",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "status": "configured",
+            "capabilityName": "customForm",
+            "type": "action",
+            "properties": {
+              "formData": {
+                "value": []
+              },
+              "dynamicText": {
+                "value": [
+                  {
+                    "key": "message",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"challenge.svg\",\n        \"url\": \"challengeStatus\",\n        \"data\": \"{{local.xbm789475f.payload.output.challengeStatus}}\",\n        \"tooltip\": \"{{local.xbm789475f.payload.output.challengeStatus}}\",\n        \"children\": [\n          {\n            \"text\": \"challengeStatus\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+                  }
+                ]
+              },
+              "message": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Pool Completed \"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"challenge.svg\",\n        \"url\": \"challengeStatus\",\n        \"data\": \"{{local.xbm789475f.payload.output.challengeStatus}}\",\n        \"tooltip\": \"{{local.xbm789475f.payload.output.challengeStatus}}\",\n        \"children\": [\n          {\n            \"text\": \"challengeStatus\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "form": {
+                "value": "854c055c-cc80-4c17-9c15-7804c7214132"
+              },
+              "nodeTitle": {
+                "value": "Automation - Polling Message"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 1890,
+            "y": 1260
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xbm789475f",
+            "nodeType": "CONNECTION",
+            "connectionId": "94cb18cc8ee6ddaf28e881b16637aec6",
+            "connectorId": "challengeConnector",
+            "name": "Challenge",
+            "label": "Challenge",
+            "status": "configured",
+            "capabilityName": "getChallenge",
+            "type": "action",
+            "properties": {
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.fnh55etehh.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.fnh55etehh.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1530,
+            "y": 1290
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "8e5vvkn8qs",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1380,
+            "y": 1260
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "4a1i3k98dx",
+            "nodeType": "CONNECTION",
+            "connectionId": "2581eb287bb1d9bd29ae9886d675f89f",
+            "connectorId": "flowConnector",
+            "name": "Flow Connector",
+            "label": "Flow [2023-01-24]",
+            "status": "configured",
+            "capabilityName": "oobContinue",
+            "type": "action",
+            "properties": {},
+            "isDisabled": false
+          },
+          "position": {
+            "x": 900,
+            "y": 1410
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "i5cx97efqa",
+            "nodeType": "CONNECTION",
+            "connectionId": "94cb18cc8ee6ddaf28e881b16637aec6",
+            "connectorId": "challengeConnector",
+            "name": "Challenge",
+            "label": "Challenge",
+            "status": "configured",
+            "capabilityName": "updateChallenge",
+            "type": "action",
+            "properties": {
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.4a1i3k98dx.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.4a1i3k98dx.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "challengeStatus": {
+                "value": "approved"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1230,
+            "y": 1410
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "rvvlbgm39b",
+            "nodeType": "EVAL",
+            "label": "Evaluator"
+          },
+          "position": {
+            "x": 1380,
+            "y": 1380
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zhh7h3vfhx",
+            "nodeType": "CONNECTION",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
+            "connectorId": "httpConnector",
+            "name": "Http",
+            "label": "Http",
+            "status": "configured",
+            "capabilityName": "customHtmlMessage",
+            "type": "trigger",
+            "properties": {
+              "message": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Close me\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false
+          },
+          "position": {
+            "x": 1530,
+            "y": 1410
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "i5a89u3oc4",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1020,
+            "y": 1380
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "qvyr5ax007",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 870,
+            "y": 1140
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "wpv71omwl1",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 825,
+            "y": 1410
           },
           "group": "nodes",
           "removed": false,
@@ -1236,7 +1640,7 @@
           },
           "position": {
             "x": 64,
-            "y": 132
+            "y": 172
           },
           "group": "edges",
           "removed": false,
@@ -1732,8 +2136,8 @@
             "multiValueSourceId": "js0k5824y5"
           },
           "position": {
-            "x": 77.5,
-            "y": 113
+            "x": 64,
+            "y": 92
           },
           "group": "edges",
           "removed": false,
@@ -1749,6 +2153,274 @@
             "id": "zdut9flea7",
             "source": "vy2ry2fgs0",
             "target": "28qxx87n1l"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "5tk1dyfhue",
+            "source": "i5a89u3oc4",
+            "target": "i5cx97efqa"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "1bdzjma81e",
+            "source": "xbm789475f",
+            "target": "0f6wy2gll8"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "2lm5svaehe",
+            "source": "xzhxneu3vg",
+            "target": "8e5vvkn8qs"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "n7oqvbfdne",
+            "source": "0f6wy2gll8",
+            "target": "o84vpl35go"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "eafikeugb6",
+            "source": "8e5vvkn8qs",
+            "target": "xbm789475f"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "da2128pc3y",
+            "source": "fnh55etehh",
+            "target": "sbtlmd892l"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xqnub884ud",
+            "source": "sbtlmd892l",
+            "target": "xzhxneu3vg"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "hfp6in9sbq",
+            "source": "i5cx97efqa",
+            "target": "rvvlbgm39b"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "x2g18eocmy",
+            "source": "rvvlbgm39b",
+            "target": "zhh7h3vfhx"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ds3klo90p4",
+            "source": "4a1i3k98dx",
+            "target": "i5a89u3oc4"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "wq4336sn1e",
+            "source": "87uin0o14z",
+            "target": "qvyr5ax007",
+            "multiValueSourceId": "c87ygb1l2b"
+          },
+          "position": {
+            "x": 77.5,
+            "y": 153
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "g9i8i881gu",
+            "source": "qvyr5ax007",
+            "target": "fnh55etehh"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "h5dn1s4dju",
+            "source": "87uin0o14z",
+            "target": "wpv71omwl1",
+            "multiValueSourceId": "c87ygb1l2b"
+          },
+          "position": {
+            "x": 77.5,
+            "y": 153
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ouqetzikgs",
+            "source": "wpv71omwl1",
+            "target": "4a1i3k98dx"
           },
           "position": {
             "x": 0,
@@ -1783,7 +2455,7 @@
     }
   },
   "flowColor": "#E3F0FF",
-  "savedDate": 1779379639429,
+  "savedDate": 1779484501750,
   "variables": [],
   "forms": {
     "658b150f-da19-461e-afcb-79ea7bb52076": {
@@ -1900,6 +2572,102 @@
       "translationMethod": "TRANSLATE",
       "created": "2026-05-20T15:21:10.841Z",
       "modified": "2026-05-21T16:09:32.625Z",
+      "readOnly": false
+    },
+    "eddaf29b-84ba-4946-976f-3301986aecb0": {
+      "id": "eddaf29b-84ba-4946-976f-3301986aecb0",
+      "environment": {
+        "id": "300c4f2a-39d4-4ba9-a18a-f6de246006f4"
+      },
+      "name": "Automation - Polling with QR Code",
+      "category": "CUSTOM",
+      "components": {
+        "fields": [
+          {
+            "type": "SLATE_TEXTBLOB",
+            "position": {
+              "row": 0,
+              "col": 0
+            },
+            "content": "[{\"type\":\"align-center\",\"children\":[{\"children\":[{\"text\":\"Authenticator App\"}],\"type\":\"heading-1\"}]}]",
+            "key": "title-text",
+            "icon": {
+              "type": "MOBILE_PHONE",
+              "size": "MEDIUM"
+            }
+          },
+          {
+            "type": "SLATE_TEXTBLOB",
+            "position": {
+              "row": 1,
+              "col": 0
+            },
+            "content": "[{\"type\":\"align-center\",\"children\":[{\"children\":[{\"text\":\"\"}]},{\"children\":[{\"text\":\"Scan the QR code below to approve the challenge polling request.\"}]},{\"children\":[{\"text\":\"\"}]}]}]",
+            "key": "help-text",
+            "icon": {
+              "type": "NONE",
+              "size": "MEDIUM"
+            }
+          },
+          {
+            "type": "ERROR_DISPLAY",
+            "position": {
+              "row": 2,
+              "col": 0
+            }
+          },
+          {
+            "type": "QR_CODE",
+            "position": {
+              "row": 3,
+              "col": 0
+            },
+            "key": "qr-code-field",
+            "alignment": "CENTER",
+            "size": "MEDIUM",
+            "fallbackText": "[{\"type\":\"align-center\",\"children\":[{\"type\":\"paragraph\",\"children\":[{\"color\":\"#7d8389\",\"fontSize\":\"12px\",\"text\":\"\"}]}]}]"
+          },
+          {
+            "pollingAppearance": "SPINNER",
+            "size": "MEDIUM",
+            "type": "POLLING",
+            "position": {
+              "row": 4,
+              "col": 0
+            },
+            "key": "polling-field"
+          },
+          {
+            "type": "FLOW_LINK",
+            "position": {
+              "row": 5,
+              "col": 0
+            },
+            "key": "cancel-link-field",
+            "label": "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Cancel\"}]}]",
+            "styles": {
+              "alignment": "CENTER",
+              "textColor": "#4462ED",
+              "padding": {
+                "top": 0,
+                "right": 0,
+                "bottom": 0,
+                "left": 0
+              },
+              "displayDefaultThemeLinkColor": true,
+              "enabled": true
+            }
+          }
+        ]
+      },
+      "cols": 4,
+      "markOptional": true,
+      "markRequired": false,
+      "textAutoCompleteEnabled": false,
+      "passwordAutoCompleteEnabled": false,
+      "translationMethod": "TRANSLATE",
+      "created": "2026-05-22T20:45:07.758Z",
+      "modified": "2026-05-22T21:31:23.794Z",
       "readOnly": false
     }
   },

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/Polling-Collector-Tests-Flows.json
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/Polling-Collector-Tests-Flows.json
@@ -1,0 +1,1907 @@
+{
+  "companyId": "300c4f2a-39d4-4ba9-a18a-f6de246006f4",
+  "authTokenExpireIds": [],
+  "connectorIds": [
+    "flowConnector",
+    "pingOneFormsConnector",
+    "challengeConnector",
+    "errorConnector",
+    "variablesConnector",
+    "functionsConnector",
+    "httpConnector"
+  ],
+  "createdDate": 1779379639501,
+  "currentVersion": 32,
+  "customerId": "b046b8357f81a6b68a9a60227d631009",
+  "deployedDate": 1779389055294,
+  "description": "Imported on Wed May 20 2026 15:21:11 GMT+0000 (Coordinated Universal Time)",
+  "flowStatus": "enabled",
+  "isOutputSchemaSaved": false,
+  "name": "Automation - Polling Tests",
+  "publishedVersion": 32,
+  "settings": {
+    "csp": "worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';",
+    "intermediateLoadingScreenCSS": "",
+    "intermediateLoadingScreenHTML": "",
+    "customTimeoutErrorScreenMessage": "",
+    "customTimeoutErrorScreenHTML": "",
+    "customTimeoutErrorScreenCSS": "",
+    "logLevel": 4,
+    "flowTimeoutInSeconds": 300,
+    "useV2FlowEngine": true,
+    "pingOneFlow": true
+  },
+  "timeouts": "null",
+  "trigger": {
+    "type": "AUTHENTICATION"
+  },
+  "updatedDate": 1779389055311,
+  "flowId": "03209dede7fdab087a75b012e973916e",
+  "versionId": 32,
+  "graphData": {
+    "elements": {
+      "nodes": [
+        {
+          "data": {
+            "id": "fm42gtef24",
+            "nodeType": "CONNECTION",
+            "connectionId": "2581eb287bb1d9bd29ae9886d675f89f",
+            "connectorId": "flowConnector",
+            "name": "Flow Connector",
+            "label": "Flow [2023-01-24]",
+            "status": "configured",
+            "capabilityName": "oobStart",
+            "type": "trigger",
+            "properties": {
+              "useCustomLink": {
+                "value": false
+              },
+              "customLink": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"pingid://auth.pingone.com/\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"auth.svg\",\n        \"url\": \"companyId\",\n        \"data\": \"{{global.companyId}}\",\n        \"tooltip\": \"{{global.companyId}}\",\n        \"children\": [\n          {\n            \"text\": \"companyId\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"/davinci/connections/\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"2fb0ca54c9286625c1f5d6989808ead1\"\n      },\n      {\n        \"text\": \"/callback/oobContinue?challenge=\"\n      }\n    ]\n  }\n]"
+              },
+              "challengeExpiry": {
+                "value": 300
+              }
+            },
+            "isDisabled": false
+          },
+          "position": {
+            "x": 1140,
+            "y": 716
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "vo9sum8789",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 937,
+            "y": 566
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "1zibef6q58",
+            "nodeType": "CONNECTION",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "status": "configured",
+            "capabilityName": "customForm",
+            "type": "action",
+            "properties": {
+              "formData": {
+                "value": []
+              },
+              "dynamicText": {
+                "value": [
+                  {
+                    "key": "challenge",
+                    "value": "[{\"children\":[{\"text\":\"\"},{\"text\":\"\"},{\"type\":\"link\",\"src\":\"flow-connector.svg\",\"url\":\"continueLink\",\"data\":\"{{local.fm42gtef24.payload.output.continueLink}}\",\"tooltip\":\"{{local.fm42gtef24.payload.output.continueLink}}\",\"children\":[{\"text\":\"continueLink\"}]},{\"text\":\"\"}]}]"
+                  }
+                ]
+              },
+              "form": {
+                "value": "658b150f-da19-461e-afcb-79ea7bb52076"
+              },
+              "enablePolling": {
+                "value": true
+              },
+              "pollRetries": {
+                "value": 3
+              },
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.fm42gtef24.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.fm42gtef24.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 1484,
+            "y": 802
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "1xfyysl518",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1290,
+            "y": 776
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "3cjoqszp9p",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1920,
+            "y": 746
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "dfff42c9rl",
+            "nodeType": "CONNECTION",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "status": "configured",
+            "capabilityName": "customForm",
+            "type": "action",
+            "properties": {
+              "formData": {
+                "value": []
+              },
+              "dynamicText": {
+                "value": [
+                  {
+                    "key": "message",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"challenge.svg\",\n        \"url\": \"challengeStatus\",\n        \"data\": \"{{local.d9ef9698ci.payload.output.challengeStatus}}\",\n        \"tooltip\": \"{{local.d9ef9698ci.payload.output.challengeStatus}}\",\n        \"children\": [\n          {\n            \"text\": \"challengeStatus\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+                  }
+                ]
+              },
+              "message": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Pool Completed \"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"challenge.svg\",\n        \"url\": \"challengeStatus\",\n        \"data\": \"{{local.d9ef9698ci.payload.output.challengeStatus}}\",\n        \"tooltip\": \"{{local.d9ef9698ci.payload.output.challengeStatus}}\",\n        \"children\": [\n          {\n            \"text\": \"challengeStatus\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "form": {
+                "value": "854c055c-cc80-4c17-9c15-7804c7214132"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 2100,
+            "y": 776
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "d9ef9698ci",
+            "nodeType": "CONNECTION",
+            "connectionId": "94cb18cc8ee6ddaf28e881b16637aec6",
+            "connectorId": "challengeConnector",
+            "name": "Challenge",
+            "label": "Challenge",
+            "status": "configured",
+            "capabilityName": "getChallenge",
+            "type": "action",
+            "properties": {
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.fm42gtef24.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.fm42gtef24.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1754,
+            "y": 802
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ay4vat2279",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1620,
+            "y": 776
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ymknltt5uq",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 720,
+            "y": 746
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "yiwhv9njku",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected error has occurred\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Received an unexpected value"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Could not determine which button was selected\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Unexpected value received\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected value was received for button selection\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Received an unexpected value for the button selected to submit the form"
+              }
+            },
+            "idUnique": "rge707gdc2",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 720,
+            "y": 896
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xkjp36pjc9",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1830,
+            "y": 536
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "3an9yvhvhn",
+            "nodeType": "CONNECTION",
+            "connectionId": "06922a684039827499bdbdd97f49827b",
+            "connectorId": "variablesConnector",
+            "name": "Variables",
+            "label": "Variables",
+            "status": "configured",
+            "capabilityName": "saveValue",
+            "type": "trigger",
+            "properties": {
+              "saveVariables": {
+                "value": [
+                  {
+                    "name": "numberCounter",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"0\"\n      }\n    ]\n  }\n]",
+                    "key": 0.7740247529585037,
+                    "label": "numberCounter (number - flowInstance)",
+                    "type": "number"
+                  }
+                ]
+              }
+            },
+            "isDisabled": false,
+            "idUnique": "2qamj6w5nr",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 277,
+            "y": 446
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "czys1qteu6",
+            "nodeType": "CONNECTION",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "status": "configured",
+            "capabilityName": "customForm",
+            "type": "action",
+            "properties": {
+              "formData": {
+                "value": []
+              },
+              "dynamicText": {
+                "value": [
+                  {
+                    "key": "challenge"
+                  }
+                ]
+              },
+              "form": {
+                "value": "658b150f-da19-461e-afcb-79ea7bb52076"
+              },
+              "enablePolling": {
+                "value": true
+              },
+              "pollRetries": {
+                "value": 3
+              },
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.s06s8f59cs.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.s06s8f59cs.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "pollChallengeStatus": {
+                "value": false
+              },
+              "nodeTitle": {
+                "value": "Automation - Polling"
+              },
+              "pollInterval": {
+                "value": 2000
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 1147,
+            "y": 386
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "5csh5flsjb",
+            "nodeType": "CONNECTION",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
+            "connectorId": "functionsConnector",
+            "name": "Functions",
+            "label": "Functions",
+            "status": "configured",
+            "capabilityName": "ALessThanB",
+            "type": "trigger",
+            "properties": {
+              "leftValueA": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"variable.svg\",\n        \"url\": \"numberCounter\",\n        \"data\": \"{{global.variables.numberCounter}}\",\n        \"tooltip\": \"{{global.variables.numberCounter}}\",\n        \"children\": [\n          {\n            \"text\": \"numberCounter\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "rightValueB": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"3\"\n      }\n    ]\n  }\n]"
+              },
+              "type": {
+                "value": "number"
+              }
+            },
+            "isDisabled": false,
+            "idUnique": "0xx3ajrf7q",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 2010,
+            "y": 386
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "a3a58jrrsk",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 397,
+            "y": 476
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "fxopi4maps",
+            "nodeType": "CONNECTION",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
+            "connectorId": "httpConnector",
+            "name": "Http",
+            "label": "Http",
+            "status": "configured",
+            "capabilityName": "continuePolling",
+            "type": "trigger",
+            "properties": {
+              "connectionInstanceId": {}
+            },
+            "isDisabled": false,
+            "idUnique": "zlkvg41nn2"
+          },
+          "position": {
+            "x": 2430,
+            "y": 386
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "vn99anhmq3",
+            "nodeType": "CONNECTION",
+            "connectionId": "06922a684039827499bdbdd97f49827b",
+            "connectorId": "variablesConnector",
+            "name": "Variables",
+            "label": "Variables",
+            "status": "configured",
+            "capabilityName": "incrementByN",
+            "type": "action",
+            "properties": {
+              "variable": {
+                "value": "numberCounter"
+              },
+              "incrementCounter": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"1\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false,
+            "idUnique": "5rbqtn10e9",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1650,
+            "y": 596
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "mo61fr3wwb",
+            "nodeType": "EVAL",
+            "properties": {
+              "mbax39f3ce": {
+                "value": "allTriggersFalse"
+              },
+              "3an9yvhvhn": {
+                "value": "allTriggersFalse"
+              },
+              "i1rmuzlx6t": {
+                "value": "allTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 2160,
+            "y": 446
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "i1rmuzlx6t",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "nodeType": "CONNECTION",
+            "status": "configured",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "type": "action",
+            "capabilityName": "customForm",
+            "properties": {
+              "message": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Done\"\n      }\n    ]\n  }\n]"
+              },
+              "formData": {
+                "value": []
+              },
+              "dynamicText": {
+                "value": [
+                  {
+                    "key": "message",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Done\"\n      }\n    ]\n  }\n]"
+                  }
+                ]
+              },
+              "form": {
+                "value": "854c055c-cc80-4c17-9c15-7804c7214132"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 2430,
+            "y": 536
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ba0sbapwnk",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "nodeType": "CONNECTION",
+            "status": "configured",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Message",
+            "type": "action",
+            "capabilityName": "customErrorMessage",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingone-forms.svg\",\n        \"url\": \"message\",\n        \"data\": \"{{local.czys1qteu6.payload.error.message}}\",\n        \"tooltip\": \"{{local.czys1qteu6.payload.error.message}}\",\n        \"children\": [\n          {\n            \"text\": \"message\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1650,
+            "y": 236
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "uc4fp6815q",
+            "nodeType": "CONNECTION",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
+            "connectorId": "httpConnector",
+            "name": "Http",
+            "label": "Http",
+            "status": "configured",
+            "capabilityName": "customHTMLTemplate",
+            "type": "trigger",
+            "properties": {
+              "customHTML": {
+                "value": "<div\n    class=\"bg-light d-flex flex-column justify-content-center align-items-center position-absolute top-0 start-0 bottom-0 end-0 overflow-auto\">\n    <div style=\"max-width: 400px; min-width: 400px; width: 100%\">\n        <div class=\"card shadow mb-5\">\n                <h1 class=\"text-center mb-4\">S</h1>\n                <p class=\"text-muted text-center\">Select Test Form</p>\n                <p class=\"text-danger mdi mdi-alert-circle\" data-id=\"feedback\" data-skcomponent=\"skerror\"></p>\n                <form id=\"success\" data-id=\"success\">\n                    <div class=\"d-flex flex-column\">\n                        <button data-id=\"button\" type=\"submit\" class=\"btn btn-primary mb-3\" data-skcomponent=\"skbutton\"\n                            data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnContinuePolling\"\n                            data-skbuttonvalue=\"Continue Polling\">\n                            Continue Polling\n                        </button>\n                        <div class=\"d-flex flex-column\">\n                            <button data-id=\"button\" class=\"btn btn-link\" data-skcomponent=\"skbutton\"\n                                data-skbuttontype=\"form-submit\" data-skform=\"success\" id=\"btnChallengePolling\"\n                                data-skbuttonvalue=\"Challenge Polling\">\n                                Challenge Polling\n                            </button>\n                        </div>\n                </form>\n            </div>\n        </div>\n    </div>\n</div>"
+              },
+              "formFieldsList": {
+                "value": [
+                  {
+                    "preferredControlType": "textField",
+                    "preferredDataType": "string",
+                    "propertyName": "buttonValue"
+                  }
+                ]
+              },
+              "nodeTitle": {
+                "value": "Select Test Form"
+              },
+              "customCSS": {},
+              "nodeDescription": {
+                "value": "Select form for testing"
+              }
+            },
+            "idUnique": "6hy3rb1jbf"
+          },
+          "position": {
+            "x": 517,
+            "y": 446
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "nilwin5fab",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 637,
+            "y": 476
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "87uin0o14z",
+            "nodeType": "CONNECTION",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
+            "connectorId": "functionsConnector",
+            "name": "Functions",
+            "label": "Functions",
+            "status": "configured",
+            "capabilityName": "AEqualsMultipleB",
+            "type": "trigger",
+            "properties": {
+              "leftValueA": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"http.svg\",\n        \"url\": \"buttonValue\",\n        \"data\": \"{{local.uc4fp6815q.payload.output.buttonValue}}\",\n        \"tooltip\": \"{{local.uc4fp6815q.payload.output.buttonValue}}\",\n        \"children\": [\n          {\n            \"text\": \"buttonValue\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "rightValueB": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"submit\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Test Selection Button Pressed"
+              },
+              "rightValueMultiple": {
+                "value": [
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"Continue Polling\"\n      }\n    ]\n  }\n]",
+                    "id": "vgii63uk2p"
+                  },
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"Challenge Polling\"\n      }\n    ]\n  }\n]",
+                    "id": "js0k5824y5"
+                  }
+                ]
+              }
+            },
+            "isDisabled": false,
+            "idUnique": "dwdsvkhd4r",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 750,
+            "y": 416
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "i7szmrdpi9",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 937,
+            "y": 416
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "cbgzopn46e",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
+            "nodeType": "CONNECTION",
+            "status": "configured",
+            "connectorId": "functionsConnector",
+            "name": "Functions",
+            "label": "Functions",
+            "type": "trigger",
+            "capabilityName": "AEqualsB",
+            "properties": {
+              "leftValueA": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingone-forms.svg\",\n        \"url\": \"type\",\n        \"data\": \"{{local.czys1qteu6.payload.output.event.type}}\",\n        \"tooltip\": \"{{local.czys1qteu6.payload.output.event.type}}\",\n        \"children\": [\n          {\n            \"text\": \"type\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "rightValueB": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"action\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1470,
+            "y": 416
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "txook6po45",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1260,
+            "y": 446
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "kexobbj140",
+            "nodeType": "EVAL",
+            "properties": {
+              "ba0sbapwnk": {
+                "value": "allTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 1290,
+            "y": 296
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "y53sjwib7t",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1927,
+            "y": 504
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "dgchywwzd9",
+            "nodeType": "EVAL",
+            "properties": {
+              "vn99anhmq3": {
+                "value": "allTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 1650,
+            "y": 476
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "28qxx87n1l",
+            "nodeType": "CONNECTION",
+            "connectionId": "2581eb287bb1d9bd29ae9886d675f89f",
+            "connectorId": "flowConnector",
+            "name": "Flow Connector",
+            "label": "Flow [2023-01-24]",
+            "status": "configured",
+            "capabilityName": "oobContinue",
+            "type": "action",
+            "properties": {},
+            "isDisabled": false
+          },
+          "position": {
+            "x": 1140,
+            "y": 926
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "nzf6fi2kg7",
+            "nodeType": "CONNECTION",
+            "connectionId": "94cb18cc8ee6ddaf28e881b16637aec6",
+            "connectorId": "challengeConnector",
+            "name": "Challenge",
+            "label": "Challenge",
+            "status": "configured",
+            "capabilityName": "updateChallenge",
+            "type": "action",
+            "properties": {
+              "challenge": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"flow-connector.svg\",\n        \"url\": \"challenge\",\n        \"data\": \"{{local.28qxx87n1l.payload.output.challenge}}\",\n        \"tooltip\": \"{{local.28qxx87n1l.payload.output.challenge}}\",\n        \"children\": [\n          {\n            \"text\": \"challenge\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "challengeStatus": {
+                "value": "approved"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1470,
+            "y": 926
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "9eye8r09js",
+            "nodeType": "EVAL",
+            "label": "Evaluator"
+          },
+          "position": {
+            "x": 1620,
+            "y": 896
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "r81rfpcgfm",
+            "nodeType": "CONNECTION",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
+            "connectorId": "httpConnector",
+            "name": "Http",
+            "label": "Http",
+            "status": "configured",
+            "capabilityName": "customHtmlMessage",
+            "type": "trigger",
+            "properties": {
+              "message": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Close me\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "isDisabled": false
+          },
+          "position": {
+            "x": 1770,
+            "y": 926
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "6ifmikdao2",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1260,
+            "y": 896
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "vy2ry2fgs0",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 945,
+            "y": 926
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        }
+      ],
+      "edges": [
+        {
+          "data": {
+            "id": "qc8yc2w93g",
+            "source": "6ifmikdao2",
+            "target": "nzf6fi2kg7"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "k9s5o4zgjl",
+            "source": "mo61fr3wwb",
+            "target": "i1rmuzlx6t"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "803xnfq2nd",
+            "source": "d9ef9698ci",
+            "target": "3cjoqszp9p"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "s8dqimqhra",
+            "source": "3an9yvhvhn",
+            "target": "a3a58jrrsk"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "6bw0cgyi3j",
+            "source": "a3a58jrrsk",
+            "target": "uc4fp6815q"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "yk0dn0kel0",
+            "source": "vn99anhmq3",
+            "target": "xkjp36pjc9"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ocuqypko8d",
+            "source": "xkjp36pjc9",
+            "target": "5csh5flsjb"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "81df6odjsl",
+            "source": "87uin0o14z",
+            "target": "ymknltt5uq",
+            "multiValueSourceId": "-1"
+          },
+          "position": {
+            "x": 64,
+            "y": 132
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "084v07dord",
+            "source": "1zibef6q58",
+            "target": "ay4vat2279"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "5kp620pqk4",
+            "source": "5csh5flsjb",
+            "target": "mo61fr3wwb"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "9y5um9zi6y",
+            "source": "3cjoqszp9p",
+            "target": "dfff42c9rl"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "m4yp83whcc",
+            "source": "87uin0o14z",
+            "target": "i7szmrdpi9",
+            "multiValueSourceId": "vgii63uk2p"
+          },
+          "position": {
+            "x": 64,
+            "y": 52
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "03ycftmag6",
+            "source": "ay4vat2279",
+            "target": "d9ef9698ci"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "oppp7ex01q",
+            "source": "ymknltt5uq",
+            "target": "yiwhv9njku"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "6r4ve57zk4",
+            "source": "uc4fp6815q",
+            "target": "nilwin5fab"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "csrt68yu07",
+            "source": "i7szmrdpi9",
+            "target": "czys1qteu6"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zwrcz4xee7",
+            "source": "fm42gtef24",
+            "target": "1xfyysl518"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "p0fyjf1o4w",
+            "source": "87uin0o14z",
+            "target": "vo9sum8789",
+            "multiValueSourceId": "js0k5824y5"
+          },
+          "position": {
+            "x": 64,
+            "y": 92
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "8naeb9la4o",
+            "source": "vo9sum8789",
+            "target": "fm42gtef24"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ghjuzzfhz6",
+            "source": "mo61fr3wwb",
+            "target": "fxopi4maps"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "7wq3y6itzu",
+            "source": "1xfyysl518",
+            "target": "1zibef6q58"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ans1j0idlh",
+            "source": "nilwin5fab",
+            "target": "87uin0o14z"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "35qa5pqbrg",
+            "source": "czys1qteu6",
+            "target": "txook6po45"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "3fuesooiw9",
+            "source": "txook6po45",
+            "target": "cbgzopn46e"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "yewbeftu8t",
+            "source": "czys1qteu6",
+            "target": "kexobbj140"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "z2ta0m5xxm",
+            "source": "kexobbj140",
+            "target": "ba0sbapwnk"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ksxwz039d1",
+            "source": "cbgzopn46e",
+            "target": "y53sjwib7t"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zf8uzqegq2",
+            "source": "y53sjwib7t",
+            "target": "i1rmuzlx6t"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "jija0liogt",
+            "source": "cbgzopn46e",
+            "target": "dgchywwzd9"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "w8mknp9372",
+            "source": "dgchywwzd9",
+            "target": "vn99anhmq3"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "4j0a8s9jzj",
+            "source": "nzf6fi2kg7",
+            "target": "9eye8r09js"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "85kvidyhu2",
+            "source": "9eye8r09js",
+            "target": "r81rfpcgfm"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ohlq8nx5hx",
+            "source": "28qxx87n1l",
+            "target": "6ifmikdao2"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "psn6s6qwwu",
+            "source": "87uin0o14z",
+            "target": "vy2ry2fgs0",
+            "multiValueSourceId": "js0k5824y5"
+          },
+          "position": {
+            "x": 77.5,
+            "y": 113
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zdut9flea7",
+            "source": "vy2ry2fgs0",
+            "target": "28qxx87n1l"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        }
+      ]
+    },
+    "data": {},
+    "zoomingEnabled": true,
+    "userZoomingEnabled": true,
+    "zoom": 1,
+    "minZoom": 1e-50,
+    "maxZoom": 1e+50,
+    "panningEnabled": true,
+    "userPanningEnabled": true,
+    "pan": {
+      "x": 0,
+      "y": 0
+    },
+    "boxSelectionEnabled": true,
+    "renderer": {
+      "name": "null"
+    }
+  },
+  "flowColor": "#E3F0FF",
+  "savedDate": 1779379639429,
+  "variables": [],
+  "forms": {
+    "658b150f-da19-461e-afcb-79ea7bb52076": {
+      "id": "658b150f-da19-461e-afcb-79ea7bb52076",
+      "environment": {
+        "id": "300c4f2a-39d4-4ba9-a18a-f6de246006f4"
+      },
+      "name": "Automation - Polling",
+      "description": "Used by E2E Automation Tests",
+      "category": "CUSTOM",
+      "components": {
+        "fields": [
+          {
+            "type": "SLATE_TEXTBLOB",
+            "position": {
+              "row": 0,
+              "col": 0
+            },
+            "content": "[{\"type\":\"align-center\",\"children\":[{\"children\":[{\"text\":\"Authenticator App\"}],\"type\":\"heading-1\"}]}]",
+            "key": "title-text",
+            "icon": {
+              "type": "MOBILE_PHONE",
+              "size": "MEDIUM"
+            }
+          },
+          {
+            "type": "ERROR_DISPLAY",
+            "position": {
+              "row": 1,
+              "col": 0
+            }
+          },
+          {
+            "pollingAppearance": "SPINNER",
+            "size": "MEDIUM",
+            "type": "POLLING",
+            "position": {
+              "row": 2,
+              "col": 0
+            },
+            "key": "polling-field"
+          },
+          {
+            "type": "SLATE_TEXTBLOB",
+            "position": {
+              "row": 3,
+              "col": 0
+            },
+            "content": "[{\"children\":[{\"text\":\"Number Challenge {{challenge}}\"}]}]",
+            "key": "rich-text",
+            "icon": {
+              "type": "NONE",
+              "size": "MEDIUM"
+            }
+          },
+          {
+            "type": "FLOW_BUTTON",
+            "position": {
+              "row": 4,
+              "col": 0
+            },
+            "key": "Finish",
+            "label": "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Finish\"}]}]"
+          }
+        ]
+      },
+      "cols": 4,
+      "markOptional": true,
+      "markRequired": false,
+      "textAutoCompleteEnabled": false,
+      "passwordAutoCompleteEnabled": false,
+      "translationMethod": "TRANSLATE",
+      "created": "2026-05-20T15:21:10.831Z",
+      "modified": "2026-05-21T16:09:12.339Z",
+      "readOnly": false
+    },
+    "854c055c-cc80-4c17-9c15-7804c7214132": {
+      "id": "854c055c-cc80-4c17-9c15-7804c7214132",
+      "environment": {
+        "id": "300c4f2a-39d4-4ba9-a18a-f6de246006f4"
+      },
+      "name": "Automation - Polling Message",
+      "description": "Used by E2E Automation Tests",
+      "category": "CUSTOM",
+      "components": {
+        "fields": [
+          {
+            "type": "ERROR_DISPLAY",
+            "position": {
+              "row": 0,
+              "col": 0
+            }
+          },
+          {
+            "type": "SLATE_TEXTBLOB",
+            "position": {
+              "row": 1,
+              "col": 0
+            },
+            "content": "[{\"children\":[{\"text\":\"Message: {{message}}\"}]}]",
+            "key": "rich-text",
+            "icon": {
+              "type": "NONE",
+              "size": "MEDIUM"
+            }
+          }
+        ]
+      },
+      "cols": 4,
+      "markOptional": true,
+      "markRequired": false,
+      "textAutoCompleteEnabled": false,
+      "passwordAutoCompleteEnabled": false,
+      "translationMethod": "TRANSLATE",
+      "created": "2026-05-20T15:21:10.841Z",
+      "modified": "2026-05-21T16:09:32.625Z",
+      "readOnly": false
+    }
+  },
+  "connections": []
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import androidx.test.filters.SmallTest
+import com.pingidentity.davinci.collector.FlowCollector
+import com.pingidentity.davinci.collector.LabelCollector
+import com.pingidentity.davinci.collector.PollingCollector
+import com.pingidentity.davinci.collector.PollingStatus
+import com.pingidentity.davinci.collector.SubmitCollector
+import com.pingidentity.davinci.module.Oidc
+import com.pingidentity.davinci.module.name
+import com.pingidentity.davinci.plugin.collectors
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.ErrorNode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * E2E tests for PollingCollector covering two DaVinci policies:
+ *   - Simple polling (pollChallengeStatus=false, 3 retries, 2s interval)
+ *   - Challenge-status polling (pollChallengeStatus=true, 2s interval)
+ */
+@SmallTest
+class PollingCollectorE2ETests {
+    private var daVinci = DaVinci {
+        logger = Logger.STANDARD
+
+        module(Oidc) {
+            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+            discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
+            redirectUri = "org.forgerock.demo://oauth2redirect"
+            acrValues = "fae6bc3d08a5c4f5b8ff95175b117278"
+        }
+    }
+
+    @BeforeTest
+    fun setUp() = runTest {
+        daVinci.user()?.logout()
+    }
+
+    // =========================================================================
+    // Simple (Continue) Polling
+    // =========================================================================
+
+    /**
+     * All 3 retries exhaust without completion. Each cycle posts "continue" and the server
+     * rewinds to the same form; on the third cycle TimedOut is emitted and the final submit
+     * returns a 400 ErrorNode with message "timedOut".
+     */
+    @Test
+    fun continuePollingTimeout() = runTest {
+        var node = daVinci.start() as ContinueNode
+        assertEquals("Select Test Form", node.name)
+        assertEquals("Continue Polling", (node.collectors[0] as SubmitCollector).label)
+        assertEquals("Challenge Polling", (node.collectors[1] as FlowCollector).label)
+
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        assertEquals("Automation - Polling", node.name)
+        val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
+        assertFalse(pollingCollector.pollChallengeStatus)
+        assertEquals("2000", pollingCollector.pollInterval)
+        assertEquals("3", pollingCollector.pollRetries)
+        assertEquals(3, pollingCollector.retriesAllowed)
+
+        // Cycle 1 — retriesAllowed 3→2, emits Complete("continue"); server rewinds to same form
+        var statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value)
+        assertEquals(2, pollingCollector.retriesAllowed)
+        node = node.next() as ContinueNode
+        assertEquals("Automation - Polling", node.name)
+
+        // Cycle 2 — retriesAllowed 2→1, emits Complete("continue"); server rewinds to same form
+        statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value)
+        assertEquals(1, pollingCollector.retriesAllowed)
+        node = node.next() as ContinueNode
+        assertEquals("Automation - Polling", node.name)
+
+        // Cycle 3 — retriesAllowed 1→0, emits TimedOut; submit "timedOut" → 400 ErrorNode
+        statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.TimedOut)
+        assertEquals("timedOut", pollingCollector.value)
+        assertEquals(0, pollingCollector.retriesAllowed)
+
+        val result = node.next()
+        assertTrue(result is ErrorNode)
+        assertEquals("timedOut", (result as ErrorNode).message.trim())
+    }
+
+    /**
+     * User clicks "Finish" after one poll cycle, bypassing remaining retries.
+     * The server skips the rewind and returns the "Done" message form directly.
+     */
+    @Test
+    fun continuePollingFinish() = runTest {
+        var node = daVinci.start() as ContinueNode
+        assertEquals("Select Test Form", node.name)
+
+        (node.collectors[0] as? SubmitCollector)?.value = "click"
+        node = node.next() as ContinueNode
+
+        assertEquals("Automation - Polling", node.name)
+        val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
+        assertFalse(pollingCollector.pollChallengeStatus)
+
+        // One poll cycle → Complete("continue"); server rewinds to the same polling form
+        val statuses = pollingCollector.pollStatus().toList()
+        assertEquals(1, statuses.size)
+        assertTrue(statuses[0] is PollingStatus.Complete)
+        assertEquals("continue", (statuses[0] as PollingStatus.Complete).status)
+        assertEquals("continue", pollingCollector.value)
+        node = node.next() as ContinueNode
+        assertEquals("Automation - Polling", node.name)
+
+        // Click "Finish" → server returns the "Done" message form directly
+        val finishButton = node.collectors.filterIsInstance<FlowCollector>()
+            .first { it.label == "Finish" }
+        finishButton.value = finishButton.label
+        node = node.next() as ContinueNode
+
+        assertEquals("Automation - Polling Message", node.name)
+        val doneLabel = node.collectors.filterIsInstance<LabelCollector>()
+            .first { it.content == "Message: Done" }
+        assertEquals("Message: Done", doneLabel.content)
+    }
+
+    // =========================================================================
+    // Challenge-Status Polling
+    // =========================================================================
+
+    /**
+     * No approval is given; all 3 poll cycles return status="started" (isChallengeComplete=false),
+     * so pollStatus() emits Continue(1,3) → Continue(2,3) → Continue(3,3) → TimedOut.
+     * The final submit returns a 400 ErrorNode with message "timedOut".
+     */
+    @Test
+    fun challengePollingTimeout() = runBlocking {
+        var node = withContext(Dispatchers.IO) { daVinci.start() } as ContinueNode
+        assertEquals("Select Test Form", node.name)
+        assertTrue(node.collectors[1] is FlowCollector)
+        assertEquals("Challenge Polling", (node.collectors[1] as FlowCollector).label)
+
+        (node.collectors[1] as FlowCollector).value = "click"
+        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+
+        assertEquals("Automation - Polling", node.name)
+        val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
+        assertTrue(pollingCollector.pollChallengeStatus)
+        assertEquals("2000", pollingCollector.pollInterval)
+        assertEquals("3", pollingCollector.pollRetries)
+        assertTrue(pollingCollector.challenge.isNotEmpty())
+
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertEquals(4, statuses.size)
+
+        assertTrue(statuses[0] is PollingStatus.Continue)
+        assertEquals(1, (statuses[0] as PollingStatus.Continue).retryCount)
+        assertEquals(3, (statuses[0] as PollingStatus.Continue).maxRetries)
+
+        assertTrue(statuses[1] is PollingStatus.Continue)
+        assertEquals(2, (statuses[1] as PollingStatus.Continue).retryCount)
+        assertEquals(3, (statuses[1] as PollingStatus.Continue).maxRetries)
+
+        assertTrue(statuses[2] is PollingStatus.Continue)
+        assertEquals(3, (statuses[2] as PollingStatus.Continue).retryCount)
+        assertEquals(3, (statuses[2] as PollingStatus.Continue).maxRetries)
+
+        assertTrue(statuses[3] is PollingStatus.TimedOut)
+        assertEquals("timedOut", pollingCollector.value)
+
+        val result = withContext(Dispatchers.IO) { node.next() }
+        assertTrue(result is ErrorNode)
+        assertEquals("timedOut", (result as ErrorNode).message.trim())
+    }
+
+    /**
+     * OOB approval is simulated by GETting the magic link (from the LabelCollector) on a
+     * background thread while pollStatus() polls concurrently. The approval is sent after a
+     * 3 s delay to land between poll cycles. The last emitted status must be Complete("approved")
+     * and the flow must advance to the "Automation - Polling Message" form.
+     */
+    @Test
+    fun challengePollingApproval() = runBlocking {
+        var node = withContext(Dispatchers.IO) { daVinci.start() } as ContinueNode
+        assertEquals("Select Test Form", node.name)
+        assertTrue(node.collectors[1] is FlowCollector)
+        assertEquals("Challenge Polling", (node.collectors[1] as FlowCollector).label)
+
+        (node.collectors[1] as FlowCollector).value = "click"
+        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+
+        assertEquals("Automation - Polling", node.name)
+        val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
+        assertTrue(pollingCollector.pollChallengeStatus)
+        assertTrue(pollingCollector.pollInterval.toInt() > 0)
+        assertTrue(pollingCollector.pollRetries.toInt() > 0)
+        assertTrue(pollingCollector.challenge.isNotEmpty())
+
+        // The OOB URL is embedded in the label as "Number Challenge <url>"
+        val magicLink = node.collectors.filterIsInstance<LabelCollector>()
+            .first { it.content.startsWith("Number Challenge ") }
+            .content.substringAfter("Number Challenge ").trim()
+        assertTrue(magicLink.startsWith("https://"), "Expected a magic link URL, got: $magicLink")
+
+        // Start polling, then visit the magic link after 3 s so it lands between poll cycles
+        val pollJob = async(Dispatchers.IO) { pollingCollector.pollStatus().toList() }
+        val approvalJob = async(Dispatchers.IO) {
+            delay(3000L)
+            java.net.URL(magicLink).openStream().close()
+        }
+
+        approvalJob.await()
+        val statuses = pollJob.await()
+
+        assertTrue(statuses.isNotEmpty())
+        val lastStatus = statuses.last()
+        assertTrue(lastStatus is PollingStatus.Complete)
+        assertEquals("approved", (lastStatus as PollingStatus.Complete).status)
+        assertEquals("approved", pollingCollector.value)
+
+        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+        assertEquals("Automation - Polling Message", node.name)
+        val approvedLabel = node.collectors.filterIsInstance<LabelCollector>()
+            .first { it.content == "Message: approved" }
+        assertEquals("Message: approved", approvedLabel.content)
+    }
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -82,8 +83,8 @@ class PollingCollectorE2ETests {
         assertEquals("Automation - Polling", node.name)
         val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
         assertFalse(pollingCollector.pollChallengeStatus)
-        assertEquals("2000", pollingCollector.pollInterval)
-        assertEquals("3", pollingCollector.pollRetries)
+        assertEquals(2000, pollingCollector.pollInterval.toInt())
+        assertEquals(3, pollingCollector.pollRetries.toInt())
         assertEquals(3, pollingCollector.retriesAllowed)
 
         // Cycle 1 — retriesAllowed 3→2, emits Complete("continue"); server rewinds to same form
@@ -165,20 +166,20 @@ class PollingCollectorE2ETests {
      * The final submit returns a 400 ErrorNode with message "timedOut".
      */
     @Test
-    fun challengePollingTimeout() = runBlocking {
-        var node = withContext(Dispatchers.IO) { daVinci.start() } as ContinueNode
+    fun challengePollingTimeout() = runTest {
+        var node = daVinci.start() as ContinueNode
         assertEquals("Select Test Form", node.name)
         assertTrue(node.collectors[1] is FlowCollector)
         assertEquals("Challenge Polling", (node.collectors[1] as FlowCollector).label)
 
         (node.collectors[1] as FlowCollector).value = "click"
-        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+        node = node.next() as ContinueNode
 
         assertEquals("Automation - Polling", node.name)
         val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
         assertTrue(pollingCollector.pollChallengeStatus)
-        assertEquals("2000", pollingCollector.pollInterval)
-        assertEquals("3", pollingCollector.pollRetries)
+        assertEquals(2000, pollingCollector.pollInterval.toInt())
+        assertEquals(3, pollingCollector.pollRetries.toInt())
         assertTrue(pollingCollector.challenge.isNotEmpty())
 
         val statuses = pollingCollector.pollStatus().toList()
@@ -200,7 +201,7 @@ class PollingCollectorE2ETests {
         assertTrue(statuses[3] is PollingStatus.TimedOut)
         assertEquals("timedOut", pollingCollector.value)
 
-        val result = withContext(Dispatchers.IO) { node.next() }
+        val result = node.next()
         assertTrue(result is ErrorNode)
         assertEquals("timedOut", (result as ErrorNode).message.trim())
     }
@@ -211,6 +212,11 @@ class PollingCollectorE2ETests {
      * first Continue status is received, guaranteeing the challenge is registered before the
      * approval request is sent. The last emitted status must be Complete("approved") and the
      * flow must advance to the "Automation - Polling Message" form.
+     *
+     * runBlocking is intentional: the test launches two concurrent real-IO coroutines (poll
+     * loop + OOB approval) that must interleave against a live server. runTest's virtual-time
+     * scheduler would auto-advance delays inside pollStatus(), causing the approval request to
+     * race ahead of the challenge registration and producing non-deterministic failures.
      */
     @Test
     fun challengePollingApproval() = runBlocking {
@@ -244,7 +250,7 @@ class PollingCollectorE2ETests {
                 .toList()
         }
         val approvalJob = async(Dispatchers.IO) {
-            firstContinueSeen.await()
+            withTimeoutOrNull(30_000) { firstContinueSeen.await() } ?: return@async
             (java.net.URL(magicLink).openConnection() as java.net.HttpURLConnection).apply {
                 connectTimeout = 10_000
                 readTimeout = 10_000
@@ -290,14 +296,14 @@ class PollingCollectorE2ETests {
      * The test verifies QRCodeCollector properties before polling begins.
      */
     @Test
-    fun qrCodeChallengePollingTimeout() = runBlocking {
-        var node = withContext(Dispatchers.IO) { daVinci.start() } as ContinueNode
+    fun qrCodeChallengePollingTimeout() = runTest {
+        var node = daVinci.start() as ContinueNode
         assertEquals("Select Test Form", node.name)
         assertTrue(node.collectors[2] is FlowCollector)
         assertEquals("Challenge Polling QRCode", (node.collectors[2] as FlowCollector).label)
 
         (node.collectors[2] as FlowCollector).value = "click"
-        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+        node = node.next() as ContinueNode
 
         assertEquals("Automation - Polling with QR Code", node.name)
 
@@ -310,7 +316,7 @@ class PollingCollectorE2ETests {
         // Verify PollingCollector is present and configured for challenge-status polling
         val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
         assertTrue(pollingCollector.pollChallengeStatus)
-        assertEquals("2000", pollingCollector.pollInterval)
+        assertEquals(2000, pollingCollector.pollInterval.toInt())
         assertTrue(pollingCollector.challenge.isNotEmpty())
 
         // Poll until all retries are exhausted — no OOB approval, so TimedOut is emitted last
@@ -320,7 +326,7 @@ class PollingCollectorE2ETests {
         assertTrue(statuses.last() is PollingStatus.TimedOut)
         assertEquals("timedOut", pollingCollector.value)
 
-        val result = withContext(Dispatchers.IO) { node.next() }
+        val result = node.next()
         assertTrue(result is ErrorNode)
         assertEquals("timedOut", (result as ErrorNode).message.trim())
     }
@@ -330,6 +336,11 @@ class PollingCollectorE2ETests {
      * GETting it on a background thread while pollStatus() polls concurrently. The approval
      * is sent once the first Continue status is received; the last status must be
      * Complete("approved") and the flow must advance to "Automation - Polling Message".
+     *
+     * runBlocking is intentional: the test launches two concurrent real-IO coroutines (poll
+     * loop + OOB approval) that must interleave against a live server. runTest's virtual-time
+     * scheduler would auto-advance delays inside pollStatus(), causing the approval request to
+     * race ahead of the challenge registration and producing non-deterministic failures.
      */
     @Test
     fun qrCodeChallengePollingApproval() = runBlocking {
@@ -363,7 +374,7 @@ class PollingCollectorE2ETests {
                 .toList()
         }
         val approvalJob = async(Dispatchers.IO) {
-            firstContinueSeen.await()
+            withTimeoutOrNull(30_000) { firstContinueSeen.await() } ?: return@async
             (java.net.URL(approvalUrl).openConnection() as java.net.HttpURLConnection).apply {
                 connectTimeout = 10_000
                 readTimeout = 10_000

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -12,6 +12,7 @@ import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.PollingStatus
+import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.module.Oidc
 import com.pingidentity.davinci.module.name
@@ -31,6 +32,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 /**
@@ -236,6 +238,114 @@ class PollingCollectorE2ETests {
         val approvalJob = async(Dispatchers.IO) {
             delay(3000L)
             java.net.URL(magicLink).openStream().close()
+        }
+
+        approvalJob.await()
+        val statuses = pollJob.await()
+
+        assertTrue(statuses.isNotEmpty())
+        val lastStatus = statuses.last()
+        assertTrue(lastStatus is PollingStatus.Complete)
+        assertEquals("approved", (lastStatus as PollingStatus.Complete).status)
+        assertEquals("approved", pollingCollector.value)
+
+        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+        assertEquals("Automation - Polling Message", node.name)
+        val approvedLabel = node.collectors.filterIsInstance<LabelCollector>()
+            .first { it.content == "Message: approved" }
+        assertEquals("Message: approved", approvedLabel.content)
+    }
+
+    // =========================================================================
+    // QR Code + Challenge-Status Polling
+    // =========================================================================
+
+    /**
+     * Decodes the URL encoded in a QR code Bitmap using ZXing.
+     */
+    private fun decodeQrBitmap(bitmap: android.graphics.Bitmap): String {
+        val pixels = IntArray(bitmap.width * bitmap.height)
+        bitmap.getPixels(pixels, 0, bitmap.width, 0, 0, bitmap.width, bitmap.height)
+        val source = com.google.zxing.RGBLuminanceSource(bitmap.width, bitmap.height, pixels)
+        val binaryBitmap = com.google.zxing.BinaryBitmap(com.google.zxing.common.HybridBinarizer(source))
+        return com.google.zxing.MultiFormatReader().decode(binaryBitmap).text
+    }
+
+    /**
+     * The "Challenge Polling QRCode" flow shows a QR_CODE field alongside a POLLING field.
+     * No approval is given; all retries exhaust → TimedOut → 400 ErrorNode.
+     * The test verifies QRCodeCollector properties before polling begins.
+     */
+    @Test
+    fun qrCodeChallengePollingTimeout() = runBlocking {
+        var node = withContext(Dispatchers.IO) { daVinci.start() } as ContinueNode
+        assertEquals("Select Test Form", node.name)
+        assertTrue(node.collectors[2] is FlowCollector)
+        assertEquals("Challenge Polling QRCode", (node.collectors[2] as FlowCollector).label)
+
+        (node.collectors[2] as FlowCollector).value = "click"
+        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+
+        assertEquals("QRCode", node.name)
+
+        // Verify QRCodeCollector is present and well-formed
+        val qrCodeCollector = node.collectors.filterIsInstance<QRCodeCollector>().first()
+        assertTrue(qrCodeCollector.content.startsWith("data:image/"), "Expected a data URI, got: ${qrCodeCollector.content}")
+        assertTrue(qrCodeCollector.content.contains("base64,"), "Expected base64 encoding in data URI")
+        assertNotNull(qrCodeCollector.bitmap(), "bitmap() must decode successfully from a valid base64 data URI")
+
+        // Verify PollingCollector is present and configured for challenge-status polling
+        val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
+        assertTrue(pollingCollector.pollChallengeStatus)
+        assertEquals("2000", pollingCollector.pollInterval)
+        assertTrue(pollingCollector.challenge.isNotEmpty())
+
+        // Poll until all retries are exhausted — no OOB approval, so TimedOut is emitted last
+        val statuses = pollingCollector.pollStatus().toList()
+
+        assertTrue(statuses.isNotEmpty())
+        assertTrue(statuses.last() is PollingStatus.TimedOut)
+        assertEquals("timedOut", pollingCollector.value)
+
+        val result = withContext(Dispatchers.IO) { node.next() }
+        assertTrue(result is ErrorNode)
+        assertEquals("timedOut", (result as ErrorNode).message.trim())
+    }
+
+    /**
+     * Simulates scanning the QR code by decoding the URL from the QR bitmap (ZXing) and
+     * GETting it on a background thread while pollStatus() polls concurrently.
+     * The approval lands after a 3 s delay; the last status must be Complete("approved")
+     * and the flow must advance to "Automation - Polling Message".
+     */
+    @Test
+    fun qrCodeChallengePollingApproval() = runBlocking {
+        var node = withContext(Dispatchers.IO) { daVinci.start() } as ContinueNode
+        assertEquals("Select Test Form", node.name)
+        assertTrue(node.collectors[2] is FlowCollector)
+        assertEquals("Challenge Polling QRCode", (node.collectors[2] as FlowCollector).label)
+
+        (node.collectors[2] as FlowCollector).value = "click"
+        node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
+
+        assertEquals("QRCode", node.name)
+
+        // Decode the approval URL from the QR code bitmap
+        val qrCodeCollector = node.collectors.filterIsInstance<QRCodeCollector>().first()
+        val bitmap = qrCodeCollector.bitmap()
+        assertNotNull(bitmap, "bitmap() must decode successfully")
+        val approvalUrl = decodeQrBitmap(bitmap!!)
+        assertTrue(approvalUrl.startsWith("https://"), "Expected an HTTPS URL in QR code, got: $approvalUrl")
+
+        val pollingCollector = node.collectors.filterIsInstance<PollingCollector>().first()
+        assertTrue(pollingCollector.pollChallengeStatus)
+        assertTrue(pollingCollector.challenge.isNotEmpty())
+
+        // Start polling concurrently; visit the approval URL after 3 s to land between poll cycles
+        val pollJob = async(Dispatchers.IO) { pollingCollector.pollStatus().toList() }
+        val approvalJob = async(Dispatchers.IO) {
+            delay(3000L)
+            java.net.URL(approvalUrl).openStream().close()
         }
 
         approvalJob.await()

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -7,7 +7,7 @@
 
 package com.pingidentity.davinci
 
-import androidx.test.filters.SmallTest
+import androidx.test.filters.LargeTest
 import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.davinci.collector.LabelCollector
 import com.pingidentity.davinci.collector.PollingCollector
@@ -21,9 +21,10 @@ import com.pingidentity.logger.Logger
 import com.pingidentity.logger.STANDARD
 import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.orchestrate.ErrorNode
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -40,7 +41,7 @@ import kotlin.test.assertTrue
  *   - Simple polling (pollChallengeStatus=false, 3 retries, 2s interval)
  *   - Challenge-status polling (pollChallengeStatus=true, 2s interval)
  */
-@SmallTest
+@LargeTest
 class PollingCollectorE2ETests {
     private var daVinci = DaVinci {
         logger = Logger.STANDARD
@@ -206,9 +207,10 @@ class PollingCollectorE2ETests {
 
     /**
      * OOB approval is simulated by GETting the magic link (from the LabelCollector) on a
-     * background thread while pollStatus() polls concurrently. The approval is sent after a
-     * 3 s delay to land between poll cycles. The last emitted status must be Complete("approved")
-     * and the flow must advance to the "Automation - Polling Message" form.
+     * background thread while pollStatus() polls concurrently. The approval is sent once the
+     * first Continue status is received, guaranteeing the challenge is registered before the
+     * approval request is sent. The last emitted status must be Complete("approved") and the
+     * flow must advance to the "Automation - Polling Message" form.
      */
     @Test
     fun challengePollingApproval() = runBlocking {
@@ -233,11 +235,22 @@ class PollingCollectorE2ETests {
             .content.substringAfter("Number Challenge ").trim()
         assertTrue(magicLink.startsWith("https://"), "Expected a magic link URL, got: $magicLink")
 
-        // Start polling, then visit the magic link after 3 s so it lands between poll cycles
-        val pollJob = async(Dispatchers.IO) { pollingCollector.pollStatus().toList() }
+        // Fire approval only after the first Continue status is received, guaranteeing the
+        // challenge is registered server-side before the approval request is sent.
+        val firstContinueSeen = CompletableDeferred<Unit>()
+        val pollJob = async(Dispatchers.IO) {
+            pollingCollector.pollStatus()
+                .onEach { if (it is PollingStatus.Continue && !firstContinueSeen.isCompleted) firstContinueSeen.complete(Unit) }
+                .toList()
+        }
         val approvalJob = async(Dispatchers.IO) {
-            delay(3000L)
-            java.net.URL(magicLink).openStream().close()
+            firstContinueSeen.await()
+            (java.net.URL(magicLink).openConnection() as java.net.HttpURLConnection).apply {
+                connectTimeout = 10_000
+                readTimeout = 10_000
+                connect()
+                disconnect()
+            }
         }
 
         approvalJob.await()
@@ -314,9 +327,9 @@ class PollingCollectorE2ETests {
 
     /**
      * Simulates scanning the QR code by decoding the URL from the QR bitmap (ZXing) and
-     * GETting it on a background thread while pollStatus() polls concurrently.
-     * The approval lands after a 3 s delay; the last status must be Complete("approved")
-     * and the flow must advance to "Automation - Polling Message".
+     * GETting it on a background thread while pollStatus() polls concurrently. The approval
+     * is sent once the first Continue status is received; the last status must be
+     * Complete("approved") and the flow must advance to "Automation - Polling Message".
      */
     @Test
     fun qrCodeChallengePollingApproval() = runBlocking {
@@ -341,11 +354,22 @@ class PollingCollectorE2ETests {
         assertTrue(pollingCollector.pollChallengeStatus)
         assertTrue(pollingCollector.challenge.isNotEmpty())
 
-        // Start polling concurrently; visit the approval URL after 3 s to land between poll cycles
-        val pollJob = async(Dispatchers.IO) { pollingCollector.pollStatus().toList() }
+        // Fire approval only after the first Continue status is received, guaranteeing the
+        // challenge is registered server-side before the approval request is sent.
+        val firstContinueSeen = CompletableDeferred<Unit>()
+        val pollJob = async(Dispatchers.IO) {
+            pollingCollector.pollStatus()
+                .onEach { if (it is PollingStatus.Continue && !firstContinueSeen.isCompleted) firstContinueSeen.complete(Unit) }
+                .toList()
+        }
         val approvalJob = async(Dispatchers.IO) {
-            delay(3000L)
-            java.net.URL(approvalUrl).openStream().close()
+            firstContinueSeen.await()
+            (java.net.URL(approvalUrl).openConnection() as java.net.HttpURLConnection).apply {
+                connectTimeout = 10_000
+                readTimeout = 10_000
+                connect()
+                disconnect()
+            }
         }
 
         approvalJob.await()

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -248,7 +248,7 @@ class PollingCollectorE2ETests {
             (java.net.URL(magicLink).openConnection() as java.net.HttpURLConnection).apply {
                 connectTimeout = 10_000
                 readTimeout = 10_000
-                connect()
+                runCatching { responseCode }
                 disconnect()
             }
         }
@@ -299,7 +299,7 @@ class PollingCollectorE2ETests {
         (node.collectors[2] as FlowCollector).value = "click"
         node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
 
-        assertEquals("QRCode", node.name)
+        assertEquals("Automation - Polling with QR Code", node.name)
 
         // Verify QRCodeCollector is present and well-formed
         val qrCodeCollector = node.collectors.filterIsInstance<QRCodeCollector>().first()
@@ -341,7 +341,7 @@ class PollingCollectorE2ETests {
         (node.collectors[2] as FlowCollector).value = "click"
         node = withContext(Dispatchers.IO) { node.next() } as ContinueNode
 
-        assertEquals("QRCode", node.name)
+        assertEquals("Automation - Polling with QR Code", node.name)
 
         // Decode the approval URL from the QR code bitmap
         val qrCodeCollector = node.collectors.filterIsInstance<QRCodeCollector>().first()
@@ -367,7 +367,7 @@ class PollingCollectorE2ETests {
             (java.net.URL(approvalUrl).openConnection() as java.net.HttpURLConnection).apply {
                 connectTimeout = 10_000
                 readTimeout = 10_000
-                connect()
+                runCatching { responseCode }
                 disconnect()
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,3 @@ android.nonTransitiveRClass=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
-
-# bcprov-jdk18on 1.84 contains META-INF/versions/25 multi-release class files (Java 25,
-# class file major version 69). AGP's bundled JaCoCo 0.8.12 cannot instrument them.
-# This overrides AGP's JacocoTransform to use 0.8.13, which adds Java 25 support.
-android.jacoco.version=0.8.13

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,8 @@ android.nonTransitiveRClass=true
 
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+
+# bcprov-jdk18on 1.84 contains META-INF/versions/25 multi-release class files (Java 25,
+# class file major version 69). AGP's bundled JaCoCo 0.8.12 cannot instrument them.
+# This overrides AGP's JacocoTransform to use 0.8.13, which adds Java 25 support.
+android.jacoco.version=0.8.13

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ security-crypto = "1.1.0"
 
 play-services-location = "21.3.0"
 google-android-recaptcha = "18.6.1" # This version is compatible with API Level 29 and does not require desugaring.
+zxing = "3.5.3"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -159,6 +160,8 @@ nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimb
 
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "play-services-location" }
 google-android-recaptcha = { module = "com.google.android.recaptcha:recaptcha", version.ref = "google-android-recaptcha" }
+
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4249](https://pingidentity.atlassian.net/browse/SDKS-4249) [QA] Support for new DaVinci collectors

# Description

New tests added in FormFieldsTest.kt, FormFieldValidationTest.kt, and PollingCollectorE2ETests.kt covering the following collectors/features:
  - ReadOnlyTextCollector (agreement text)
  - BooleanCollector (required "I agree" checkbox)
  - PhoneNumberCollector (object payload format, extension field, end-to-end submission)
  - LabelCollector (multiple rich text links, target field for open-in-new-tab)
  - PollingCollector (timeout, completion, challenge approval, QR code challenge)
  - Password policy validation (max repeat, max length, field-level policy source)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polling collector supports OOB and QR-code approval workflows with timeout handling
  * Rich-text labels support multiple links with configurable targets
  * Phone-number collector accepts object format (country code, number, optional extension)
  * Agreement collector for checkbox-based consent flows
  * Enhanced password validation (max repeated characters, max length) and policy metadata surfaced

* **Tests**
  * Expanded E2E and instrumentation coverage for polling (including QR approval), password policies, phone formats, agreement flows, and rich-text link behavior
  * Added a comprehensive polling test flow configuration used by tests

* **Chores**
  * Added QR-code decoding support for tests and pinned JaCoCo test coverage version

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ForgeRock/ping-android-sdk/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->