### PR TITLE
SDKS-5065 Standardized JSON configuration

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/DaVinci.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/DaVinci.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -12,12 +12,16 @@ import com.pingidentity.davinci.module.ContinueNode
 import com.pingidentity.davinci.module.NodeTransform
 import com.pingidentity.davinci.module.Oidc
 import com.pingidentity.davinci.plugin.DaVinci
+import com.pingidentity.oidc.JsonConfigKey
+import com.pingidentity.oidc.JsonConfigParser
+import com.pingidentity.oidc.update
 import com.pingidentity.orchestrate.WorkflowConfig
 import com.pingidentity.orchestrate.module.Cookie
 import com.pingidentity.orchestrate.module.CustomHeader
 import com.pingidentity.orchestrate.module.CustomParameter
 import com.pingidentity.orchestrate.module.CustomParameterConfig.Companion.START
 import com.pingidentity.utils.toAcceptLanguage
+import kotlinx.serialization.json.JsonObject
 
 // typealias DaVinciConfig = WorkflowConfig
 private const val ACCEPT_LANGUAGE = "Accept-Language"
@@ -66,4 +70,60 @@ fun DaVinci(block: DaVinciConfig.() -> Unit = {}): DaVinci {
     config.apply(block)
 
     return DaVinci(config)
+}
+
+/**
+ * Creates a [DaVinci] instance from a JSON configuration.
+ *
+ * Required OIDC fields are nested under the `oidc` key. Example:
+ * ```json
+ * {
+ *   "timeout": 30000,
+ *   "log": "STANDARD",
+ *   "oidc": {
+ *     "clientId": "my-client-id",
+ *     "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+ *     "scopes": ["openid", "profile"],
+ *     "redirectUri": "myapp://oauth2redirect",
+ *     "signOutRedirectUri": "myapp://logout",
+ *     "refreshThreshold": 60,
+ *     "loginHint": "user@example.com",
+ *     "state": "custom-state",
+ *     "nonce": "custom-nonce",
+ *     "display": "page",
+ *     "prompt": "login",
+ *     "uiLocales": "en-US",
+ *     "acrValues": "Level3",
+ *     "par": true,
+ *     "additionalParameters": { "max_age": "3600" },
+ *     "openId": {
+ *       "authorizationEndpoint": "https://auth.example.com/authorize",
+ *       "tokenEndpoint": "https://auth.example.com/token",
+ *       "userinfoEndpoint": "https://auth.example.com/userinfo",
+ *       "endSessionEndpoint": "https://auth.example.com/logout",
+ *       "revocationEndpoint": "https://auth.example.com/revoke"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param json The JSON configuration object.
+ * @return A [Result] containing the [DaVinci] instance or an exception if the configuration is invalid.
+ */
+fun DaVinci(json: JsonObject): Result<DaVinci> {
+    return runCatching {
+        val jsonConfigParser = JsonConfigParser(json)
+        DaVinci {
+            logger = jsonConfigParser.logLevel()
+            timeout = jsonConfigParser.timeoutMillis()
+            module(Oidc) { //Add this here Just to preserve the order
+                val oidcJsonConfig = JsonConfigParser(jsonConfigParser.required<JsonObject>(JsonConfigKey.OIDC))
+                clientId = oidcJsonConfig.required<String>(JsonConfigKey.CLIENT_ID)
+                discoveryEndpoint = oidcJsonConfig.required<String>(JsonConfigKey.DISCOVERY_ENDPOINT)
+                scopes = oidcJsonConfig.scopeSet(JsonConfigKey.SCOPES)
+                redirectUri = oidcJsonConfig.required<String>(JsonConfigKey.REDIRECT_URI)
+                update(oidcJsonConfig)
+            }
+        }
+    }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
@@ -26,6 +26,7 @@ import com.pingidentity.davinci.plugin.collectors
 import com.pingidentity.logger.Logger
 import com.pingidentity.logger.STANDARD
 import com.pingidentity.network.ktor.KtorHttpClient
+import com.pingidentity.oidc.JsonConfigKey
 import com.pingidentity.oidc.Token
 import com.pingidentity.oidc.module.VERIFICATION_URI_COMPLETE
 import com.pingidentity.oidc.module.user
@@ -50,8 +51,12 @@ import io.ktor.http.content.TextContent
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.junit.Rule
 import org.junit.rules.TestWatcher
 import org.junit.runner.RunWith
@@ -745,6 +750,105 @@ class DaVinciTest {
         assertTrue(paths.contains("/token"), "normal flow must call /token")
         assertTrue(paths.none { it.contains("deviceFlow") }, "deviceFlow must not be called in normal flow")
         assertNotNull(tokenStorage.get())
+    }
+
+    // -------------------------------------------------------------------------
+    // createDaVinci JSON config
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createDaVinci succeeds with valid JSON config`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid"); add("profile") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(DaVinci(json).isSuccess)
+    }
+
+    @Test
+    fun `createDaVinci fails when oidc block is missing from JSON`() {
+        assertTrue(DaVinci(buildJsonObject {}).isFailure)
+    }
+
+    @Test
+    fun `createDaVinci fails when clientId is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(DaVinci(json).isFailure)
+    }
+
+    @Test
+    fun `createDaVinci fails when redirectUri is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+            })
+        }
+        assertTrue(DaVinci(json).isFailure)
+    }
+
+    @Test
+    fun `createDaVinci succeeds with optional acrValues in JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+                put(JsonConfigKey.ACR_VALUES, "urn:acr:silver")
+            })
+        }
+        assertTrue(DaVinci(json).isSuccess)
+    }
+
+    @Test
+    fun `createDaVinci succeeds with scopes as comma-separated string`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid,profile")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(DaVinci(json).isSuccess)
+    }
+
+    @Test
+    fun `createDaVinci succeeds with all optional OIDC fields`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+                put(JsonConfigKey.PAR, true)
+                put(JsonConfigKey.LOGIN_HINT, "user@example.com")
+                put(JsonConfigKey.STATE, "custom-state")
+                put(JsonConfigKey.NONCE, "custom-nonce")
+                put(JsonConfigKey.DISPLAY, "page")
+                put(JsonConfigKey.PROMPT, "login")
+                put(JsonConfigKey.UI_LOCALES, "en-US")
+                put(JsonConfigKey.ACR_VALUES, "Level3")
+                put(JsonConfigKey.SIGN_OUT_REDIRECT_URI, "myapp://logout")
+                put(JsonConfigKey.REFRESH_THRESHOLD, 60L)
+                put(JsonConfigKey.ADDITIONAL_PARAMETERS, buildJsonObject {
+                    put("custom_param", "custom_value")
+                })
+            })
+        }
+        assertTrue(DaVinci(json).isSuccess)
     }
 
     private fun parResponse(): String =

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/JsonConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/JsonConfig.kt
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.oidc
+
+import com.pingidentity.logger.CONSOLE
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.NONE
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.logger.WARN
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+object JsonConfigKey {
+    // Top level keys - Required
+    const val JOURNEY = "journey"
+    const val OIDC = "oidc"
+    const val LOG = "log"
+    const val TIMEOUT = "timeout"
+    const val SERVER_URL = "serverUrl"
+    const val REALM = "realm"
+    const val COOKIE_NAME = "cookieName"
+    const val WEB = "web"
+    const val WEB_CUSTOM_TAB_COLOR_SCHEME = "webCustomTabs"
+    const val WEB_AUTH_TAB_COLOR_SCHEME = "authCustomTabs"
+
+    // OIDC keys - Required
+    const val CLIENT_ID = "clientId"
+    const val DISCOVERY_ENDPOINT = "discoveryEndpoint"
+    const val REDIRECT_URI = "redirectUri"
+    const val SCOPES = "scopes"
+
+    // OIDC keys - Optional
+    const val PAR = "par"
+    const val SIGN_OUT_REDIRECT_URI = "signOutRedirectUri"
+    const val REFRESH_THRESHOLD = "refreshThreshold"
+    const val LOGIN_HINT = "loginHint"
+    const val NONCE = "nonce"
+    const val STATE = "state"
+    const val DISPLAY = "display"
+    const val PROMPT = "prompt"
+    const val UI_LOCALES = "uiLocales"
+    const val ACR_VALUES = "acrValues"
+    const val ADDITIONAL_PARAMETERS = "additionalParameters"
+    const val STORAGE_FILENAME = "storageFilename"
+
+    // OPEN ID
+    const val OPEN_ID = "openId"
+    const val DEVICE_AUTHORIZATION_ENDPOINT = "deviceAuthorizationEndpoint"
+    const val AUTHORIZATION_ENDPOINT = "authorizationEndpoint"
+    const val TOKEN_ENDPOINT = "tokenEndpoint"
+    const val USER_INFO_ENDPOINT = "userInfoEndpoint"
+    const val END_SESSION_ENDPOINT = "endSessionEndpoint"
+    const val REVOCATION_ENDPOINT = "revocationEndpoint"
+}
+
+/**
+ * Exception class for JSON configuration errors.
+ *
+ * @param message The error message describing the configuration issue.
+ */
+open class JsonConfigError(message: String) : Exception(message) {
+    class MissingRequiredField(val field: String) :
+        JsonConfigError("Missing required configuration field: '$field'")
+
+    class InvalidType(val field: String, val expected: String) :
+        JsonConfigError("Invalid type for configuration field '$field': expected $expected")
+}
+
+/**
+ * A helper class for parsing JSON configuration with error handling.
+ *
+ * @param json The JSON object containing the configuration.
+ */
+class JsonConfigParser(@PublishedApi internal val json: JsonObject) {
+
+    /**
+     * Returns the value for [key] decoded as type [T].
+     *
+     * @param key The JSON key to look up.
+     * @throws JsonConfigError.MissingRequiredField if the key is absent.
+     * @throws JsonConfigError.InvalidType if the value cannot be decoded as [T].
+     */
+    inline fun <reified T> required(key: String): T {
+        val element = json[key] ?: throw JsonConfigError.MissingRequiredField(key)
+        return runCatching { Json.decodeFromJsonElement<T>(element) }.getOrElse {
+            throw JsonConfigError.InvalidType(field = key, expected = T::class.simpleName ?: "unknown")
+        }
+    }
+
+    /**
+     * Returns the value for [key] decoded as type [T], or [default] if the key is absent.
+     *
+     * @param key The JSON key to look up.
+     * @param default The value to return when the key is not present.
+     * @throws JsonConfigError.InvalidType if the key is present but the value cannot be decoded as [T].
+     */
+    inline fun <reified T> optional(key: String, default: T): T {
+        val element = json[key] ?: return default
+        return runCatching { Json.decodeFromJsonElement<T>(element) }.getOrElse {
+            throw JsonConfigError.InvalidType(field = key, expected = T::class.simpleName ?: "unknown")
+        }
+    }
+
+    /**
+     * Parses an optional `Map<String, String>` field from the JSON object.
+     *
+     * Each value in the object must be a JSON string; if any value is a non-string type an
+     * [JsonConfigError.InvalidType] is thrown naming the offending nested key
+     * (e.g. `"additionalParameters.badKey"`), matching iOS behaviour.
+     *
+     * @param key The JSON key for the map field.
+     * @return The parsed map, or `null` if the key is absent.
+     */
+    fun additionalParameters(key: String): Map<String, String>? {
+        val element = json[key] ?: return null
+        val obj = runCatching { element.jsonObject }.getOrElse {
+            throw JsonConfigError.InvalidType(field = key, expected = "JsonObject")
+        }
+        return obj.entries.associate { (entryKey, entryValue) ->
+            if (entryValue !is JsonPrimitive || !entryValue.isString) {
+                throw JsonConfigError.InvalidType(
+                    field = "$key.$entryKey",
+                    expected = "string"
+                )
+            }
+            entryKey to entryValue.content
+        }
+    }
+
+    /**
+     * Parses a scope set from the JSON object, accepting either a comma-separated string or an array of strings.
+     * If the field is a string, it is split on commas to create the set. If the field is an array, each element must be a string.
+     * If the field is missing, a [JsonConfigError.MissingRequiredField] is thrown. If the field is present but not a string or array of strings, a [JsonConfigError.InvalidType] is thrown.
+     * @param key The JSON key for the scopes field.
+     * @return A mutable set of scopes.
+     */
+    fun scopeSet(key: String): MutableSet<String> {
+        val element = json[key] ?: throw JsonConfigError.MissingRequiredField(key)
+        return when (element) {
+            is JsonArray -> runCatching {
+                Json.decodeFromJsonElement<List<String>>(element)
+            }.getOrElse {
+                throw JsonConfigError.InvalidType(field = key, expected = "JsonArray of String")
+            }.toMutableSet()
+            else -> runCatching {
+                Json.decodeFromJsonElement<String>(element)
+            }.getOrElse {
+                throw JsonConfigError.InvalidType(field = key, expected = "String or JsonArray")
+            }.toScopeSet()
+        }
+    }
+
+    /**
+     * Parses a timeout value in milliseconds from the JSON object. If the field is missing, returns the provided default value.
+      * If the field is present but not a long integer, a [JsonConfigError.InvalidType] is thrown.
+      * @param default The default timeout value to return if the field is missing (default is 15,000 milliseconds).
+      * @return The parsed timeout value in milliseconds, or the default if the field is missing.
+     */
+    fun timeoutMillis(default: Long = 15_000L): Long {
+        val element = json[JsonConfigKey.TIMEOUT] ?: return default
+        return runCatching { element.jsonPrimitive.long }.getOrElse {
+            throw JsonConfigError.InvalidType(field = JsonConfigKey.TIMEOUT, expected = "Long")
+        }
+    }
+
+    /**
+     * Parses a log level from the JSON `log` field.
+     *
+     * Accepted values (case-insensitive): `"STANDARD"`, `"DEBUG"`, `"WARN"`, `"CONSOLE"`, `"NONE"`.
+     *
+     * @param default The log level to use when the field is absent. Defaults to `NONE`.
+     * @throws JsonConfigError.InvalidType if the field is present but does not match a valid level.
+     */
+    fun logLevel(default: Logger = Logger.NONE): Logger {
+        val levelStr = json[JsonConfigKey.LOG]?.jsonPrimitive?.content ?: return default
+        return runCatching {
+            when (levelStr.uppercase()) {
+                "DEBUG", "STANDARD" -> Logger.STANDARD
+                "WARN" -> Logger.WARN
+                "CONSOLE" -> Logger.CONSOLE
+                "NONE" -> Logger.NONE
+                else -> throw IllegalArgumentException("Unknown log level: $levelStr")
+            }
+        }.getOrElse {
+            throw JsonConfigError.InvalidType(field = JsonConfigKey.LOG, expected = "STANDARD, WARN, CONSOLE, or NONE")
+        }
+    }
+}
+
+/**
+ * Splits a comma-separated scope string into a mutable set of trimmed, non-blank scope values.
+ *
+ * Example: `"openid, profile, email"` → `mutableSetOf("openid", "profile", "email")`
+ */
+fun String.toScopeSet(): MutableSet<String> =
+    split(",").map { it.trim() }.filter { it.isNotEmpty() }.toMutableSet()
+
+/**
+ * Converts a comma-separated scope string into a [kotlinx.serialization.json.JsonArray] of strings.
+ *
+ * Used when building a JSON config object where `scopes` must be a JSON array rather than a
+ * comma-separated string (e.g. before passing config to a factory function).
+ *
+ * Example: `"openid, profile"` → `["openid", "profile"]`
+ */
+fun String.toScopesJsonArray() = buildJsonArray {
+    split(",").map { it.trim() }.filter { it.isNotEmpty() }.forEach { add(it) }
+}

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/JsonConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/JsonConfig.kt
@@ -31,10 +31,6 @@ object JsonConfigKey {
     const val SERVER_URL = "serverUrl"
     const val REALM = "realm"
     const val COOKIE_NAME = "cookieName"
-    const val WEB = "web"
-    const val WEB_CUSTOM_TAB_COLOR_SCHEME = "webCustomTabs"
-    const val WEB_AUTH_TAB_COLOR_SCHEME = "authCustomTabs"
-
     // OIDC keys - Required
     const val CLIENT_ID = "clientId"
     const val DISCOVERY_ENDPOINT = "discoveryEndpoint"
@@ -53,7 +49,6 @@ object JsonConfigKey {
     const val UI_LOCALES = "uiLocales"
     const val ACR_VALUES = "acrValues"
     const val ADDITIONAL_PARAMETERS = "additionalParameters"
-    const val STORAGE_FILENAME = "storageFilename"
 
     // OPEN ID
     const val OPEN_ID = "openId"

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/JsonConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/JsonConfig.kt
@@ -187,8 +187,8 @@ class JsonConfigParser(@PublishedApi internal val json: JsonObject) {
         val levelStr = json[JsonConfigKey.LOG]?.jsonPrimitive?.content ?: return default
         return runCatching {
             when (levelStr.uppercase()) {
-                "DEBUG", "STANDARD" -> Logger.STANDARD
-                "WARN" -> Logger.WARN
+                "INFO", "DEBUG", "STANDARD" -> Logger.STANDARD
+                "ERROR", "WARN" -> Logger.WARN
                 "CONSOLE" -> Logger.CONSOLE
                 "NONE" -> Logger.NONE
                 else -> throw IllegalArgumentException("Unknown log level: $levelStr")

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -38,6 +38,104 @@ import kotlin.coroutines.coroutineContext
 inline fun OidcClient(block: OidcClientConfig.() -> Unit = {}): OidcClient {
     val oidcClientConfig = OidcClientConfig().apply(block)
     return OidcClient(oidcClientConfig)
+}
+
+/**
+ * Factory function to create an instance of [OidcClient] from a JSON configuration.
+ *
+ * Required fields are nested under the `oidc` key. Example:
+ * ```json
+ * {
+ *   "log": "STANDARD",
+ *   "oidc": {
+ *     "clientId": "my-client-id",
+ *     "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+ *     "scopes": ["openid", "profile"],
+ *     "redirectUri": "myapp://oauth2redirect",
+ *     "signOutRedirectUri": "myapp://logout",
+ *     "refreshThreshold": 60,
+ *     "loginHint": "user@example.com",
+ *     "state": "custom-state",
+ *     "nonce": "custom-nonce",
+ *     "display": "page",
+ *     "prompt": "login",
+ *     "uiLocales": "en-US",
+ *     "acrValues": "Level3",
+ *     "par": true,
+ *     "additionalParameters": { "max_age": "3600" },
+ *     "openId": {
+ *       "authorizationEndpoint": "https://auth.example.com/authorize",
+ *       "tokenEndpoint": "https://auth.example.com/token",
+ *       "userinfoEndpoint": "https://auth.example.com/userinfo",
+ *       "endSessionEndpoint": "https://auth.example.com/logout",
+ *       "revocationEndpoint": "https://auth.example.com/revoke"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param json The JSON configuration object.
+ * @return A [Result] containing the [OidcClient] instance or an error if the configuration is invalid.
+ */
+fun OidcClient(json: JsonObject): kotlin.Result<OidcClient> {
+    return runCatching {
+        val jsonConfigParser = JsonConfigParser(json)
+        val oidcJsonConfig = JsonConfigParser(jsonConfigParser.required<JsonObject>(JsonConfigKey.OIDC))
+        OidcClient {
+            logger = jsonConfigParser.logLevel()
+            clientId = oidcJsonConfig.required<String>(JsonConfigKey.CLIENT_ID)
+            discoveryEndpoint = oidcJsonConfig.required<String>(JsonConfigKey.DISCOVERY_ENDPOINT)
+            scopes = oidcJsonConfig.scopeSet(JsonConfigKey.SCOPES)
+            redirectUri = oidcJsonConfig.required<String>(JsonConfigKey.REDIRECT_URI)
+            update(oidcJsonConfig)
+        }
+    }
+}
+
+/**
+ * Applies all optional OIDC fields from [oidcJsonConfig] to this [OidcClientConfig].
+ *
+ * Mandatory fields (`clientId`, `discoveryEndpoint`, `scopes`, `redirectUri`) are set by each
+ * JSON factory independently. This function handles every optional field:
+ * `display`, `par`, `loginHint`, `state`, `nonce`, `prompt`, `uiLocales`, `acrValues`,
+ * `signOutRedirectUri`, `refreshThreshold`, `additionalParameters`, `storageFilename`,
+ * and the `openId` endpoint-override sub-object.
+ *
+ * @param oidcJsonConfig Parser wrapping the `oidc` sub-object of the top-level JSON config.
+ */
+fun OidcClientConfig.update(oidcJsonConfig: JsonConfigParser) {
+    display = oidcJsonConfig.optional<String?>(JsonConfigKey.DISPLAY, null)
+    par = oidcJsonConfig.optional<Boolean>(JsonConfigKey.PAR, false)
+    loginHint = oidcJsonConfig.optional<String?>(JsonConfigKey.LOGIN_HINT, null)
+    state = oidcJsonConfig.optional<String?>(JsonConfigKey.STATE, null)
+    nonce = oidcJsonConfig.optional<String?>(JsonConfigKey.NONCE, null)
+    prompt = oidcJsonConfig.optional<String?>(JsonConfigKey.PROMPT, null)
+    uiLocales = oidcJsonConfig.optional<String?>(JsonConfigKey.UI_LOCALES, null)
+    acrValues = oidcJsonConfig.optional<String?>(JsonConfigKey.ACR_VALUES, null)
+    signOutRedirectUri = oidcJsonConfig.optional<String?>(JsonConfigKey.SIGN_OUT_REDIRECT_URI, null)
+    refreshThreshold = oidcJsonConfig.optional<Long>(JsonConfigKey.REFRESH_THRESHOLD, 0L)
+    val additionalParams = oidcJsonConfig.additionalParameters(JsonConfigKey.ADDITIONAL_PARAMETERS)
+    if (additionalParams != null) {
+        additionalParameters = additionalParams
+    }
+    val storageFilename = oidcJsonConfig.optional<String>(JsonConfigKey.STORAGE_FILENAME, "")
+    if (storageFilename.isNotEmpty()) {
+        storage {
+            fileName = storageFilename
+        }
+    }
+    val openIdJson = oidcJsonConfig.optional<JsonObject?>(JsonConfigKey.OPEN_ID, null)
+    if (openIdJson != null) {
+        val openIdParser = JsonConfigParser(openIdJson)
+        openIdOverride = {
+            openIdParser.optional<String?>(JsonConfigKey.AUTHORIZATION_ENDPOINT, null)?.let { authorizationEndpoint = it }
+            openIdParser.optional<String?>(JsonConfigKey.TOKEN_ENDPOINT, null)?.let { tokenEndpoint = it }
+            openIdParser.optional<String?>(JsonConfigKey.USER_INFO_ENDPOINT, null)?.let { userinfoEndpoint = it }
+            openIdParser.optional<String?>(JsonConfigKey.END_SESSION_ENDPOINT, null)?.let { endSessionEndpoint = it }
+            openIdParser.optional<String?>(JsonConfigKey.REVOCATION_ENDPOINT, null)?.let { revocationEndpoint = it }
+            openIdParser.optional<String?>(JsonConfigKey.DEVICE_AUTHORIZATION_ENDPOINT, null)?.let { deviceAuthorizationEndpoint = it }
+        }
+    }
 }
 
 internal typealias IdToken = String

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClient.kt
@@ -98,7 +98,7 @@ fun OidcClient(json: JsonObject): kotlin.Result<OidcClient> {
  * Mandatory fields (`clientId`, `discoveryEndpoint`, `scopes`, `redirectUri`) are set by each
  * JSON factory independently. This function handles every optional field:
  * `display`, `par`, `loginHint`, `state`, `nonce`, `prompt`, `uiLocales`, `acrValues`,
- * `signOutRedirectUri`, `refreshThreshold`, `additionalParameters`, `storageFilename`,
+ * `signOutRedirectUri`, `refreshThreshold`, `additionalParameters`,
  * and the `openId` endpoint-override sub-object.
  *
  * @param oidcJsonConfig Parser wrapping the `oidc` sub-object of the top-level JSON config.
@@ -117,12 +117,6 @@ fun OidcClientConfig.update(oidcJsonConfig: JsonConfigParser) {
     val additionalParams = oidcJsonConfig.additionalParameters(JsonConfigKey.ADDITIONAL_PARAMETERS)
     if (additionalParams != null) {
         additionalParameters = additionalParams
-    }
-    val storageFilename = oidcJsonConfig.optional<String>(JsonConfigKey.STORAGE_FILENAME, "")
-    if (storageFilename.isNotEmpty()) {
-        storage {
-            fileName = storageFilename
-        }
     }
     val openIdJson = oidcJsonConfig.optional<JsonObject?>(JsonConfigKey.OPEN_ID, null)
     if (openIdJson != null) {

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcDeviceClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcDeviceClient.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.serialization.json.JsonObject
 import java.net.URL
 
 // Error codes defined by RFC 8628 §3.5
@@ -55,6 +56,53 @@ private const val SLOW_DOWN_INCREMENT_SECONDS = 5
 fun OidcDeviceClient(block: OidcClientConfig.() -> Unit = {}): OidcDeviceClient {
     val config = OidcClientConfig().apply(block)
     return OidcDeviceClient(config)
+}
+
+/**
+ * Factory function to create an [OidcDeviceClient] from a JSON configuration object.
+ *
+ * Required OIDC fields are nested under the `oidc` key. The `deviceAuthorizationEndpoint`
+ * can be overridden via the `openId` sub-object inside `oidc`. Example:
+ * ```json
+ * {
+ *   "log": "STANDARD",
+ *   "oidc": {
+ *     "clientId": "my-client-id",
+ *     "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+ *     "scopes": ["openid", "profile"],
+ *     "redirectUri": "myapp://oauth2redirect",
+ *     "acrValues": "urn:mace:incommon:iap:silver",
+ *     "par": true,
+ *     "additionalParameters": { "max_age": "3600" },
+ *     "storageFilename": "oidc_device_storage",
+ *     "openId": {
+ *       "deviceAuthorizationEndpoint": "https://auth.example.com/device/code",
+ *       "authorizationEndpoint": "https://auth.example.com/authorize",
+ *       "tokenEndpoint": "https://auth.example.com/token",
+ *       "userinfoEndpoint": "https://auth.example.com/userinfo",
+ *       "endSessionEndpoint": "https://auth.example.com/logout",
+ *       "revocationEndpoint": "https://auth.example.com/revoke"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param json The JSON configuration object.
+ * @return A [Result] containing the configured [OidcDeviceClient] or an exception if the configuration is invalid.
+ */
+fun OidcDeviceClient(json: JsonObject): Result<OidcDeviceClient> {
+    return runCatching {
+        val configParser = JsonConfigParser(json)
+        val oidcConfigParser = JsonConfigParser(configParser.required<JsonObject>(JsonConfigKey.OIDC))
+        OidcDeviceClient {
+            logger = configParser.logLevel()
+            discoveryEndpoint = oidcConfigParser.required<String>(JsonConfigKey.DISCOVERY_ENDPOINT)
+            clientId = oidcConfigParser.required<String>(JsonConfigKey.CLIENT_ID)
+            scopes = oidcConfigParser.scopeSet(JsonConfigKey.SCOPES)
+            redirectUri = oidcConfigParser.optional<String>(JsonConfigKey.REDIRECT_URI, "")
+            update(oidcConfigParser)
+        }
+    }
 }
 
 /**

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcDeviceClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcDeviceClient.kt
@@ -74,7 +74,6 @@ fun OidcDeviceClient(block: OidcClientConfig.() -> Unit = {}): OidcDeviceClient 
  *     "acrValues": "urn:mace:incommon:iap:silver",
  *     "par": true,
  *     "additionalParameters": { "max_age": "3600" },
- *     "storageFilename": "oidc_device_storage",
  *     "openId": {
  *       "deviceAuthorizationEndpoint": "https://auth.example.com/device/code",
  *       "authorizationEndpoint": "https://auth.example.com/authorize",

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWebClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWebClient.kt
@@ -7,6 +7,9 @@
 
 package com.pingidentity.oidc
 
+import com.pingidentity.browser.BrowserLauncher.authTabCustomizer
+import com.pingidentity.browser.BrowserLauncher.customTabsCustomizer
+import com.pingidentity.oidc.module.Oidc
 import com.pingidentity.oidc.module.OidcFlow
 import com.pingidentity.oidc.module.PARAMETERS
 import com.pingidentity.oidc.module.Web
@@ -17,6 +20,7 @@ import com.pingidentity.oidc.module.user
 import com.pingidentity.orchestrate.FailureNode
 import com.pingidentity.orchestrate.SuccessNode
 import com.pingidentity.orchestrate.WorkflowConfig
+import kotlinx.serialization.json.JsonObject
 
 /**
  * OIDC Web configuration class.
@@ -63,21 +67,96 @@ class OidcWebClient(val config: OidcWebClientConfig) {
             prepareUser(OidcUser(oidcClientConfig()))
         }
     }
+}
 
-    companion object {
-        /**
-         * Creates an instance of [OidcWebClient] with the provided configuration block.
-         *
-         * @param block The configuration block to apply to the OIDC web configuration.
-         * @return An instance of [OidcWebClient].
-         */
-        operator fun invoke(block: OidcWebClientConfig.() -> Unit = {}): OidcWebClient {
-            val config = OidcWebClientConfig()
-            config.apply {
-                config.module(Web) // register the web module
+/**
+ * Creates an instance of [OidcWebClient] with the provided configuration block.
+ *
+ * @param block The configuration block to apply to the OIDC web configuration.
+ * @return An instance of [OidcWebClient].
+ */
+fun OidcWebClient(block: OidcWebClientConfig.() -> Unit = {}): OidcWebClient {
+    val config = OidcWebClientConfig()
+    config.apply {
+        config.module(Web) // register the web module
+    }
+    config.apply(block) // apply the configuration block
+    return OidcWebClient(config)
+}
+
+/**
+ * Creates an instance of [OidcWebClient] from a JSON configuration.
+ *
+ * Required OIDC fields are nested under `oidc`; web UI settings under `web`. Example:
+ * ```json
+ * {
+ *   "timeout": 30000,
+ *   "log": "STANDARD",
+ *   "oidc": {
+ *     "clientId": "my-client-id",
+ *     "discoveryEndpoint": "https://auth.example.com/.well-known/openid-configuration",
+ *     "scopes": ["openid", "profile"],
+ *     "redirectUri": "myapp://oauth2redirect",
+ *     "signOutRedirectUri": "myapp://logout",
+ *     "refreshThreshold": 60,
+ *     "loginHint": "user@example.com",
+ *     "state": "custom-state",
+ *     "nonce": "custom-nonce",
+ *     "display": "page",
+ *     "prompt": "login",
+ *     "uiLocales": "en-US",
+ *     "acrValues": "Level3",
+ *     "par": true,
+ *     "additionalParameters": { "max_age": "3600" },
+ *     "openId": {
+ *       "authorizationEndpoint": "https://auth.example.com/authorize",
+ *       "tokenEndpoint": "https://auth.example.com/token",
+ *       "userinfoEndpoint": "https://auth.example.com/userinfo",
+ *       "endSessionEndpoint": "https://auth.example.com/logout",
+ *       "revocationEndpoint": "https://auth.example.com/revoke"
+ *     }
+ *   },
+ *   "web": {
+ *     "webCustomTabs": 0,
+ *     "authCustomTabs": 0
+ *   }
+ * }
+ * ```
+ *
+ * @param json The JSON configuration object.
+ * @return A [Result] containing the [OidcWebClient] or an exception if the configuration is invalid.
+ */
+fun OidcWebClient(json: JsonObject): Result<OidcWebClient> {
+    return runCatching {
+        OidcWebClient {
+            val configParser = JsonConfigParser(json)
+            logger = configParser.logLevel()
+            timeout = configParser.timeoutMillis()
+
+            val oidcConfigParser = JsonConfigParser(configParser.required<JsonObject>(JsonConfigKey.OIDC))
+            module(Oidc) {
+                discoveryEndpoint = oidcConfigParser.required<String>(JsonConfigKey.DISCOVERY_ENDPOINT)
+                clientId = oidcConfigParser.required<String>(JsonConfigKey.CLIENT_ID)
+                scopes = oidcConfigParser.scopeSet(JsonConfigKey.SCOPES)
+                redirectUri = oidcConfigParser.required<String>(JsonConfigKey.REDIRECT_URI)
+                update(oidcConfigParser)
             }
-            config.apply(block) // apply the configuration block
-            return OidcWebClient(config)
+            val webConfig =
+                configParser.optional<JsonObject?>(JsonConfigKey.WEB, null) ?: return@OidcWebClient
+            // No web configuration, skip UI settings
+            val webJsonConfig = JsonConfigParser(webConfig)
+            if (JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME in webConfig) {
+                val customTabColorScheme = webJsonConfig.required<Int>(JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME)
+                customTabsCustomizer = {
+                    setColorScheme(customTabColorScheme)
+                }
+            }
+            if (JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME in webConfig) {
+                val authTabColorScheme = webJsonConfig.required<Int>(JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME)
+                authTabCustomizer = {
+                    setColorScheme(authTabColorScheme)
+                }
+            }
         }
     }
 }

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWebClient.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcWebClient.kt
@@ -116,10 +116,6 @@ fun OidcWebClient(block: OidcWebClientConfig.() -> Unit = {}): OidcWebClient {
  *       "revocationEndpoint": "https://auth.example.com/revoke"
  *     }
  *   },
- *   "web": {
- *     "webCustomTabs": 0,
- *     "authCustomTabs": 0
- *   }
  * }
  * ```
  *
@@ -140,22 +136,6 @@ fun OidcWebClient(json: JsonObject): Result<OidcWebClient> {
                 scopes = oidcConfigParser.scopeSet(JsonConfigKey.SCOPES)
                 redirectUri = oidcConfigParser.required<String>(JsonConfigKey.REDIRECT_URI)
                 update(oidcConfigParser)
-            }
-            val webConfig =
-                configParser.optional<JsonObject?>(JsonConfigKey.WEB, null) ?: return@OidcWebClient
-            // No web configuration, skip UI settings
-            val webJsonConfig = JsonConfigParser(webConfig)
-            if (JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME in webConfig) {
-                val customTabColorScheme = webJsonConfig.required<Int>(JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME)
-                customTabsCustomizer = {
-                    setColorScheme(customTabColorScheme)
-                }
-            }
-            if (JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME in webConfig) {
-                val authTabColorScheme = webJsonConfig.required<Int>(JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME)
-                authTabCustomizer = {
-                    setColorScheme(authTabColorScheme)
-                }
             }
         }
     }

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/JsonConfigTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/JsonConfigTest.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.oidc
+
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.NONE
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.logger.WARN
+import com.pingidentity.logger.CONSOLE
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class JsonConfigTest {
+
+    // -------------------------------------------------------------------------
+    // JsonConfigParser.required
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `required returns value when key is present and type matches`() {
+        val parser = JsonConfigParser(buildJsonObject { put("clientId", "my-client") })
+        assertEquals("my-client", parser.required<String>("clientId"))
+    }
+
+    @Test
+    fun `required throws MissingRequiredField when key is absent`() {
+        val parser = JsonConfigParser(buildJsonObject {})
+        val ex = assertFailsWith<JsonConfigError.MissingRequiredField> {
+            parser.required<String>("clientId")
+        }
+        assertEquals("clientId", ex.field)
+    }
+
+    @Test
+    fun `required throws InvalidType when value has wrong type`() {
+        val parser = JsonConfigParser(buildJsonObject { put("timeout", 5000) })
+        val ex = assertFailsWith<JsonConfigError.InvalidType> {
+            parser.required<String>("timeout")
+        }
+        assertEquals("timeout", ex.field)
+    }
+
+    // -------------------------------------------------------------------------
+    // JsonConfigParser.optional
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `optional returns value when key is present and type matches`() {
+        val parser = JsonConfigParser(buildJsonObject { put("realm", "alpha") })
+        assertEquals("alpha", parser.optional("realm", "root"))
+    }
+
+    @Test
+    fun `optional returns default when key is absent`() {
+        val parser = JsonConfigParser(buildJsonObject {})
+        assertEquals("root", parser.optional("realm", "root"))
+    }
+
+    @Test
+    fun `optional throws InvalidType when value has wrong type`() {
+        val parser = JsonConfigParser(buildJsonObject { put("realm", 42) })
+        val ex = assertFailsWith<JsonConfigError.InvalidType> {
+            parser.optional("realm", "root")
+        }
+        assertEquals("realm", ex.field)
+    }
+
+    // -------------------------------------------------------------------------
+    // JsonConfigParser.timeoutMillis
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `timeoutMillis returns parsed value in millis`() {
+        val parser = JsonConfigParser(buildJsonObject { put("timeout", 30000) })
+        assertEquals(30_000L, parser.timeoutMillis())
+    }
+
+    @Test
+    fun `timeoutMillis returns default when key is absent`() {
+        val parser = JsonConfigParser(buildJsonObject {})
+        assertEquals(15_000L, parser.timeoutMillis())
+    }
+
+    @Test
+    fun `timeoutMillis returns custom default when key is absent`() {
+        val parser = JsonConfigParser(buildJsonObject {})
+        assertEquals(60_000L, parser.timeoutMillis(default = 60_000L))
+    }
+
+    @Test
+    fun `timeoutMillis throws InvalidType when value is not a number`() {
+        val parser = JsonConfigParser(buildJsonObject { put("timeout", "fast") })
+        assertFailsWith<JsonConfigError.InvalidType> {
+            parser.timeoutMillis()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JsonConfigParser.logLevel
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `logLevel returns STANDARD for standard string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "STANDARD") })
+        assertEquals(Logger.STANDARD, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel returns STANDARD for debug string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "DEBUG") })
+        assertEquals(Logger.STANDARD, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel returns WARN for warn string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "WARN") })
+        assertEquals(Logger.WARN, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel returns CONSOLE for console string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "CONSOLE") })
+        assertEquals(Logger.CONSOLE, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel returns NONE for none string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "NONE") })
+        assertEquals(Logger.NONE, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel is case insensitive`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "standard") })
+        assertEquals(Logger.STANDARD, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel returns default when key is absent`() {
+        val parser = JsonConfigParser(buildJsonObject {})
+        assertEquals(Logger.NONE, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel throws InvalidType for unknown level string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "verbose") })
+        assertFailsWith<JsonConfigError.InvalidType> {
+            parser.logLevel()
+        }
+    }
+
+    @Test
+    fun `logLevel throws InvalidType when value is not a string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", 1) })
+        assertFailsWith<JsonConfigError.InvalidType> {
+            parser.logLevel()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // String.toScopeSet
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `toScopeSet splits comma-separated scopes`() {
+        assertEquals(setOf("openid", "email", "profile"), "openid,email,profile".toScopeSet())
+    }
+
+    @Test
+    fun `toScopeSet trims whitespace around each scope`() {
+        assertEquals(setOf("openid", "email"), " openid , email ".toScopeSet())
+    }
+
+    @Test
+    fun `toScopeSet filters out blank entries`() {
+        assertEquals(setOf("openid"), "openid,,".toScopeSet())
+    }
+
+    @Test
+    fun `toScopeSet returns empty set for blank string`() {
+        assertEquals(emptySet(), "".toScopeSet())
+    }
+
+    // -------------------------------------------------------------------------
+    // JsonConfigParser.additionalParameters
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `additionalParameters returns null when key is absent`() {
+        val parser = JsonConfigParser(buildJsonObject {})
+        assertNull(parser.additionalParameters("additionalParameters"))
+    }
+
+    @Test
+    fun `additionalParameters parses string values correctly`() {
+        val parser = JsonConfigParser(buildJsonObject {
+            put("additionalParameters", buildJsonObject {
+                put("max_age", "3600")
+                put("custom_param", "custom_value")
+            })
+        })
+        val result = parser.additionalParameters("additionalParameters")
+        assertEquals(mapOf("max_age" to "3600", "custom_param" to "custom_value"), result)
+    }
+
+    @Test
+    fun `additionalParameters throws InvalidType when a value is not a string`() {
+        val parser = JsonConfigParser(buildJsonObject {
+            put("additionalParameters", buildJsonObject {
+                put("max_age", 3600)
+            })
+        })
+        val ex = assertFailsWith<JsonConfigError.InvalidType> {
+            parser.additionalParameters("additionalParameters")
+        }
+        assertEquals("additionalParameters.max_age", ex.field)
+        assertEquals("string", ex.expected)
+    }
+
+    @Test
+    fun `additionalParameters throws InvalidType when field is not a JsonObject`() {
+        val parser = JsonConfigParser(buildJsonObject {
+            put("additionalParameters", "not-an-object")
+        })
+        assertFailsWith<JsonConfigError.InvalidType> {
+            parser.additionalParameters("additionalParameters")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JsonConfigError messages
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `MissingRequiredField message contains field name`() {
+        val ex = JsonConfigError.MissingRequiredField("clientId")
+        assertEquals("Missing required configuration field: 'clientId'", ex.message)
+    }
+
+    @Test
+    fun `InvalidType message contains field and expected type`() {
+        val ex = JsonConfigError.InvalidType(field = "timeout", expected = "Int")
+        assertEquals("Invalid type for configuration field 'timeout': expected Int", ex.message)
+    }
+}

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/JsonConfigTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/JsonConfigTest.kt
@@ -120,8 +120,20 @@ class JsonConfigTest {
     }
 
     @Test
+    fun `logLevel returns STANDARD for info string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "INFO") })
+        assertEquals(Logger.STANDARD, parser.logLevel())
+    }
+
+    @Test
     fun `logLevel returns WARN for warn string`() {
         val parser = JsonConfigParser(buildJsonObject { put("log", "WARN") })
+        assertEquals(Logger.WARN, parser.logLevel())
+    }
+
+    @Test
+    fun `logLevel returns WARN for error string`() {
+        val parser = JsonConfigParser(buildJsonObject { put("log", "ERROR") })
         assertEquals(Logger.WARN, parser.logLevel())
     }
 

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcClientTest.kt
@@ -29,7 +29,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.junit.Rule
 import org.junit.rules.TestWatcher
 import org.junit.runner.RunWith
@@ -691,6 +695,124 @@ class OidcClientTest {
             // Verify token was obtained successfully
             assertEquals("Dummy AccessToken", result.value.accessToken)
         }
+
+    // -------------------------------------------------------------------------
+    // createOidcClient JSON config
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createOidcClient succeeds with valid JSON config`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid,profile")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcClient fails when oidc block is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.CLIENT_ID, "my-client")
+            put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+            put(JsonConfigKey.SCOPES, "openid")
+            put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+        }
+        assertTrue(OidcClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcClient fails when clientId is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcClient fails when discoveryEndpoint is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcClient fails when redirectUri is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid")
+            })
+        }
+        assertTrue(OidcClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcClient fails when scopes is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcClient succeeds with scopes as JsonArray`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray {
+                    add("openid")
+                    add("profile")
+                })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcClient succeeds with all optional OIDC fields`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.pingone.ca/env-id/as/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+                put(JsonConfigKey.PAR, true)
+                put(JsonConfigKey.LOGIN_HINT, "user@example.com")
+                put(JsonConfigKey.STATE, "custom-state")
+                put(JsonConfigKey.NONCE, "custom-nonce")
+                put(JsonConfigKey.DISPLAY, "page")
+                put(JsonConfigKey.PROMPT, "login")
+                put(JsonConfigKey.UI_LOCALES, "en-US")
+                put(JsonConfigKey.ACR_VALUES, "Level3")
+                put(JsonConfigKey.SIGN_OUT_REDIRECT_URI, "myapp://logout")
+                put(JsonConfigKey.REFRESH_THRESHOLD, 60L)
+                put(JsonConfigKey.ADDITIONAL_PARAMETERS, buildJsonObject {
+                    put("custom_param", "custom_value")
+                })
+            })
+        }
+        assertTrue(OidcClient(json).isSuccess)
+    }
 
     @Test
     fun `token with PAR enabled fails when PAR endpoint returns an error`() =

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcDeviceClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcDeviceClientTest.kt
@@ -17,6 +17,10 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.AfterTest
@@ -94,7 +98,7 @@ class OidcDeviceClientTest {
     }
 
     // ------------------------------------------------------------------
-    // Factory function compilation test
+    // Factory function (block)
     // ------------------------------------------------------------------
 
     @Test
@@ -107,6 +111,102 @@ class OidcDeviceClientTest {
             storage = { MemoryStorage() }
         }
         assertNotNull(client)
+    }
+
+    // ------------------------------------------------------------------
+    // JSON factory
+    // ------------------------------------------------------------------
+
+    @Test
+    fun `OidcDeviceClient JSON factory succeeds with valid config`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcDeviceClient(json).isSuccess)
+    }
+
+    @Test
+    fun `OidcDeviceClient JSON factory succeeds with scopes as JsonArray`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray {
+                    add("openid")
+                    add("profile")
+                })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcDeviceClient(json).isSuccess)
+    }
+
+    @Test
+    fun `OidcDeviceClient JSON factory fails when oidc block is missing`() {
+        assertTrue(OidcDeviceClient(buildJsonObject {}).isFailure)
+    }
+
+    @Test
+    fun `OidcDeviceClient JSON factory fails when clientId is missing`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcDeviceClient(json).isFailure)
+    }
+
+    @Test
+    fun `OidcDeviceClient JSON factory fails when discoveryEndpoint is missing`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcDeviceClient(json).isFailure)
+    }
+
+    @Test
+    fun `OidcDeviceClient JSON factory succeeds with all optional OIDC fields`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+                put(JsonConfigKey.PAR, true)
+                put(JsonConfigKey.LOGIN_HINT, "user@example.com")
+                put(JsonConfigKey.STATE, "custom-state")
+                put(JsonConfigKey.NONCE, "custom-nonce")
+                put(JsonConfigKey.DISPLAY, "page")
+                put(JsonConfigKey.PROMPT, "login")
+                put(JsonConfigKey.UI_LOCALES, "en-US")
+                put(JsonConfigKey.ACR_VALUES, "Level3")
+                put(JsonConfigKey.SIGN_OUT_REDIRECT_URI, "myapp://logout")
+                put(JsonConfigKey.REFRESH_THRESHOLD, 60L)
+                put(JsonConfigKey.ADDITIONAL_PARAMETERS, buildJsonObject {
+                    put("custom_param", "custom_value")
+                })
+                put(JsonConfigKey.OPEN_ID, buildJsonObject {
+                    put(JsonConfigKey.DEVICE_AUTHORIZATION_ENDPOINT, "https://auth.example.com/device/code")
+                    put(JsonConfigKey.AUTHORIZATION_ENDPOINT, "https://auth.example.com/authorize")
+                    put(JsonConfigKey.TOKEN_ENDPOINT, "https://auth.example.com/token")
+                    put(JsonConfigKey.USER_INFO_ENDPOINT, "https://auth.example.com/userinfo")
+                    put(JsonConfigKey.END_SESSION_ENDPOINT, "https://auth.example.com/logout")
+                    put(JsonConfigKey.REVOCATION_ENDPOINT, "https://auth.example.com/revoke")
+                })
+            })
+        }
+        assertTrue(OidcDeviceClient(json).isSuccess)
     }
 
     // ------------------------------------------------------------------

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
@@ -404,37 +404,6 @@ class OidcWebClientTest {
     }
 
     @Test
-    fun `createOidcWebClient succeeds with web block and color scheme keys`() {
-        val json = buildJsonObject {
-            put(JsonConfigKey.OIDC, buildJsonObject {
-                put(JsonConfigKey.CLIENT_ID, "my-client")
-                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
-                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
-                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
-            })
-            put(JsonConfigKey.WEB, buildJsonObject {
-                put(JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME, 0)
-                put(JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME, 1)
-            })
-        }
-        assertTrue(OidcWebClient(json).isSuccess)
-    }
-
-    @Test
-    fun `createOidcWebClient succeeds with empty web block - no forced dark mode`() {
-        val json = buildJsonObject {
-            put(JsonConfigKey.OIDC, buildJsonObject {
-                put(JsonConfigKey.CLIENT_ID, "my-client")
-                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
-                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
-                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
-            })
-            put(JsonConfigKey.WEB, buildJsonObject {})
-        }
-        assertTrue(OidcWebClient(json).isSuccess)
-    }
-
-    @Test
     fun `createOidcWebClient succeeds with all optional OIDC fields`() {
         val json = buildJsonObject {
             put(JsonConfigKey.OIDC, buildJsonObject {

--- a/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
+++ b/foundation/oidc/src/test/kotlin/com/pingidentity/oidc/OidcWebClientTest.kt
@@ -34,6 +34,10 @@ import io.mockk.slot
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.net.URL
@@ -42,6 +46,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
@@ -312,6 +317,168 @@ class OidcWebClientTest {
         assertTrue(!urlQuery.contains("code_challenge="))
 
         parMockEngine.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // OidcWebClient JSON factory
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createOidcWebClient succeeds with valid JSON config`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid"); add("profile") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcWebClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcWebClient succeeds with scopes as comma-separated string`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid,profile")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcWebClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcWebClient fails when oidc block is missing`() {
+        assertTrue(OidcWebClient(buildJsonObject {}).isFailure)
+    }
+
+    @Test
+    fun `createOidcWebClient fails when clientId is missing`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcWebClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcWebClient fails when discoveryEndpoint is missing`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcWebClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcWebClient fails when scopes is missing`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcWebClient(json).isFailure)
+    }
+
+    @Test
+    fun `createOidcWebClient succeeds without web block`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(OidcWebClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcWebClient succeeds with web block and color scheme keys`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+            put(JsonConfigKey.WEB, buildJsonObject {
+                put(JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME, 0)
+                put(JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME, 1)
+            })
+        }
+        assertTrue(OidcWebClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcWebClient succeeds with empty web block - no forced dark mode`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+            put(JsonConfigKey.WEB, buildJsonObject {})
+        }
+        assertTrue(OidcWebClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcWebClient succeeds with all optional OIDC fields`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+                put(JsonConfigKey.SIGN_OUT_REDIRECT_URI, "myapp://logout")
+                put(JsonConfigKey.REFRESH_THRESHOLD, 60L)
+                put(JsonConfigKey.LOGIN_HINT, "user@example.com")
+                put(JsonConfigKey.STATE, "custom-state")
+                put(JsonConfigKey.NONCE, "custom-nonce")
+                put(JsonConfigKey.DISPLAY, "page")
+                put(JsonConfigKey.PROMPT, "login")
+                put(JsonConfigKey.UI_LOCALES, "en-US")
+                put(JsonConfigKey.ACR_VALUES, "Level3")
+                put(JsonConfigKey.PAR, true)
+                put(JsonConfigKey.ADDITIONAL_PARAMETERS, buildJsonObject {
+                    put("custom_param", "custom_value")
+                })
+                put(JsonConfigKey.OPEN_ID, buildJsonObject {
+                    put(JsonConfigKey.AUTHORIZATION_ENDPOINT, "https://auth.example.com/authorize")
+                    put(JsonConfigKey.TOKEN_ENDPOINT, "https://auth.example.com/token")
+                    put(JsonConfigKey.USER_INFO_ENDPOINT, "https://auth.example.com/userinfo")
+                    put(JsonConfigKey.END_SESSION_ENDPOINT, "https://auth.example.com/logout")
+                    put(JsonConfigKey.REVOCATION_ENDPOINT, "https://auth.example.com/revoke")
+                })
+            })
+        }
+        assertTrue(OidcWebClient(json).isSuccess)
+    }
+
+    @Test
+    fun `createOidcWebClient returns failure with typed error when required field is missing`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://auth.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        val result = OidcWebClient(json)
+        assertTrue(result.isFailure)
+        assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
     }
 
 }

--- a/journey/src/main/kotlin/com/pingidentity/journey/Journey.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/Journey.kt
@@ -22,8 +22,12 @@ import com.pingidentity.journey.Constants.SERVICE
 import com.pingidentity.journey.Constants.START_REQUEST
 import com.pingidentity.journey.Constants.SUSPENDED_ID
 import com.pingidentity.journey.module.NodeTransform
+import com.pingidentity.journey.module.Oidc
 import com.pingidentity.journey.module.RequestUrl
 import com.pingidentity.journey.module.Session
+import com.pingidentity.oidc.JsonConfigKey
+import com.pingidentity.oidc.JsonConfigParser
+import com.pingidentity.oidc.update
 import com.pingidentity.orchestrate.Node
 import com.pingidentity.orchestrate.Setup
 import com.pingidentity.orchestrate.SharedContext
@@ -31,6 +35,7 @@ import com.pingidentity.orchestrate.Workflow
 import com.pingidentity.orchestrate.WorkflowConfig
 import com.pingidentity.orchestrate.module.CustomHeader
 import com.pingidentity.utils.toAcceptLanguage
+import kotlinx.serialization.json.JsonObject
 import com.pingidentity.network.HttpRequest as Request
 
 typealias Journey = Workflow
@@ -138,6 +143,73 @@ fun Journey(block: JourneyConfig.() -> Unit = {}): Journey {
      */
 
     return Journey(config)
+}
+
+/**
+ * Creates a [Journey] instance from a JSON configuration.
+ *
+ * Journey-specific fields are nested under `journey`; OIDC fields under `oidc`. Example:
+ * ```json
+ * {
+ *   "timeout": 30000,
+ *   "log": "STANDARD",
+ *   "journey": {
+ *     "serverUrl": "https://openam.example.com/am",
+ *     "realm": "alpha",
+ *     "cookieName": "iPlanetDirectoryPro"
+ *   },
+ *   "oidc": {
+ *     "clientId": "my-client-id",
+ *     "discoveryEndpoint": "https://openam.example.com/am/oauth2/alpha/.well-known/openid-configuration",
+ *     "scopes": ["openid", "profile"],
+ *     "redirectUri": "myapp://oauth2redirect",
+ *     "signOutRedirectUri": "myapp://logout",
+ *     "refreshThreshold": 60,
+ *     "loginHint": "user@example.com",
+ *     "state": "custom-state",
+ *     "nonce": "custom-nonce",
+ *     "display": "page",
+ *     "prompt": "login",
+ *     "uiLocales": "en-US",
+ *     "acrValues": "Level3",
+ *     "par": true,
+ *     "additionalParameters": { "max_age": "3600" },
+ *     "openId": {
+ *       "authorizationEndpoint": "https://openam.example.com/authorize",
+ *       "tokenEndpoint": "https://openam.example.com/token",
+ *       "userinfoEndpoint": "https://openam.example.com/userinfo",
+ *       "endSessionEndpoint": "https://openam.example.com/logout",
+ *       "revocationEndpoint": "https://openam.example.com/revoke"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param json The JSON configuration object.
+ * @return A [Result] containing the [Journey] instance or an exception if the configuration is invalid.
+ */
+fun Journey(json: JsonObject): Result<Journey> {
+    return runCatching {
+        val jsonConfigParser = JsonConfigParser(json)
+        val journeyJsonConfig = JsonConfigParser(jsonConfigParser.required<JsonObject>(JsonConfigKey.JOURNEY))
+        val oidcJsonConfig = JsonConfigParser(jsonConfigParser.required<JsonObject>(JsonConfigKey.OIDC))
+        Journey {
+            logger = jsonConfigParser.logLevel()
+            timeout = jsonConfigParser.timeoutMillis()
+
+            serverUrl = journeyJsonConfig.required<String>(JsonConfigKey.SERVER_URL)
+            realm = journeyJsonConfig.optional<String>(JsonConfigKey.REALM, REALM)
+            cookie = journeyJsonConfig.optional<String>(JsonConfigKey.COOKIE_NAME, COOKIE)
+
+            module(Oidc) {
+                clientId = oidcJsonConfig.required<String>(JsonConfigKey.CLIENT_ID)
+                discoveryEndpoint = oidcJsonConfig.required<String>(JsonConfigKey.DISCOVERY_ENDPOINT)
+                redirectUri = oidcJsonConfig.required<String>(JsonConfigKey.REDIRECT_URI)
+                scopes = oidcJsonConfig.scopeSet(JsonConfigKey.SCOPES)
+                update(oidcJsonConfig)
+            }
+        }
+    }
 }
 
 /**

--- a/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
+++ b/journey/src/test/kotlin/com/pingidentity/journey/JourneyTest.kt
@@ -23,6 +23,7 @@ import com.pingidentity.logger.CONSOLE
 import com.pingidentity.logger.Logger
 import com.pingidentity.logger.STANDARD
 import com.pingidentity.network.ktor.KtorHttpClient
+import com.pingidentity.oidc.JsonConfigKey
 import com.pingidentity.oidc.Token
 import com.pingidentity.oidc.module.VERIFICATION_URI_COMPLETE
 import com.pingidentity.orchestrate.ContinueNode
@@ -47,9 +48,13 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import org.junit.Rule
 import org.junit.rules.TestWatcher
 import org.junit.runner.RunWith
@@ -913,7 +918,7 @@ class JourneyTest {
 
         var node = journey.start("myLogin") // Return first Node
         assertTrue(node is ContinueNode)
-        assertTrue { (node as ContinueNode).callbacks.size == 2 }
+        assertTrue { node.callbacks.size == 2 }
 
         (node.callbacks[0] as? NameCallback)?.name = "My First Name"
         (node.callbacks[1] as? PasswordCallback)?.password = "My Password"
@@ -1148,6 +1153,146 @@ class JourneyTest {
         assertTrue(paths.contains("/access_token"))
         // No device flow request
         assertTrue(paths.none { it.contains("deviceFlow") })
+    }
+
+    // -------------------------------------------------------------------------
+    // createJourney JSON config
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `createJourney succeeds with valid JSON config`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.SERVER_URL, "https://openam.example.com/am")
+                put(JsonConfigKey.REALM, "alpha")
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid"); add("profile") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        val result = Journey(json)
+        assertTrue(result.isSuccess)
+        val journey = result.getOrThrow()
+        assertEquals("https://openam.example.com/am", journey.options.serverUrl)
+        assertEquals("alpha", journey.options.realm)
+    }
+
+    @Test
+    fun `createJourney uses default realm when absent from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.SERVER_URL, "https://openam.example.com/am")
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        val result = Journey(json)
+        assertTrue(result.isSuccess)
+        assertEquals(Constants.REALM, (result.getOrThrow().config as JourneyConfig).realm)
+    }
+
+    @Test
+    fun `createJourney fails when journey block is missing from JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(Journey(json).isFailure)
+    }
+
+    @Test
+    fun `createJourney fails when serverUrl is missing from journey block`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.REALM, "alpha")
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(Journey(json).isFailure)
+    }
+
+    @Test
+    fun `createJourney fails when oidc block is missing from JSON`() {
+        assertTrue(Journey(buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject { put(JsonConfigKey.SERVER_URL, "https://openam.example.com/am") })
+        }).isFailure)
+    }
+
+    @Test
+    fun `createJourney fails when clientId is missing from oidc JSON`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.SERVER_URL, "https://openam.example.com/am")
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(Journey(json).isFailure)
+    }
+
+    @Test
+    fun `createJourney succeeds with scopes as comma-separated string`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.SERVER_URL, "https://openam.example.com/am")
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, "openid,profile")
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+            })
+        }
+        assertTrue(Journey(json).isSuccess)
+    }
+
+    @Test
+    fun `createJourney succeeds with all optional OIDC fields`() {
+        val json = buildJsonObject {
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.SERVER_URL, "https://openam.example.com/am")
+                put(JsonConfigKey.REALM, "alpha")
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, "my-client")
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, "https://openam.example.com/.well-known/openid-configuration")
+                put(JsonConfigKey.SCOPES, buildJsonArray { add("openid") })
+                put(JsonConfigKey.REDIRECT_URI, "myapp://oauth2redirect")
+                put(JsonConfigKey.PAR, true)
+                put(JsonConfigKey.LOGIN_HINT, "user@example.com")
+                put(JsonConfigKey.STATE, "custom-state")
+                put(JsonConfigKey.NONCE, "custom-nonce")
+                put(JsonConfigKey.DISPLAY, "page")
+                put(JsonConfigKey.PROMPT, "login")
+                put(JsonConfigKey.UI_LOCALES, "en-US")
+                put(JsonConfigKey.ACR_VALUES, "Level3")
+                put(JsonConfigKey.SIGN_OUT_REDIRECT_URI, "myapp://logout")
+                put(JsonConfigKey.REFRESH_THRESHOLD, 60L)
+                put(JsonConfigKey.ADDITIONAL_PARAMETERS, buildJsonObject {
+                    put("custom_param", "custom_value")
+                })
+            })
+        }
+        assertTrue(Journey(json).isSuccess)
     }
 
     private fun parResponse(): String =

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -154,7 +154,6 @@ internal fun buildJourney(config: JourneyConfigState) {
                 put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
                 put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
                 put(JsonConfigKey.DISPLAY, config.display)
-                put(JsonConfigKey.STORAGE_FILENAME, "journey")
             })
         }
     ).onSuccess { journey = it }
@@ -191,7 +190,6 @@ internal fun buildDaVinci(config: OidcConfigState) {
                 put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
                 put(JsonConfigKey.DISPLAY, config.display)
                 if (config.arcValue.isNotBlank()) put(JsonConfigKey.ACR_VALUES, config.arcValue)
-                put(JsonConfigKey.STORAGE_FILENAME, "daVinci")
             })
         }
     ).onSuccess { daVinci = it }
@@ -211,10 +209,6 @@ internal fun buildWeb(config: OidcConfigState) {
                 put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
                 put(JsonConfigKey.DISPLAY, config.display)
             })
-            put(JsonConfigKey.WEB, buildJsonObject {
-                put(JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME, CustomTabsIntent.COLOR_SCHEME_DARK)
-                put(JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME, CustomTabsIntent.COLOR_SCHEME_DARK)
-            })
         }
     ).onSuccess { web = it }
         .onFailure {
@@ -231,7 +225,6 @@ internal fun buildDeviceAuthClient(config: DeviceAuthConfigState) {
                 put(JsonConfigKey.DISCOVERY_ENDPOINT, config.discoveryEndpoint)
                 put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
                 put(JsonConfigKey.DISPLAY, config.display)
-                put(JsonConfigKey.STORAGE_FILENAME, "device_flow")
                 if (config.acrValues.isNotBlank()) put(JsonConfigKey.ACR_VALUES, config.acrValues)
                 put(JsonConfigKey.OPEN_ID, buildJsonObject {
                     if (config.authorizationEndpoint.isNotBlank()) put(

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 - 2026 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -23,33 +23,34 @@ import com.pingidentity.davinci.plugin.DaVinci
 import com.pingidentity.journey.Journey
 import com.pingidentity.logger.Logger
 import com.pingidentity.logger.STANDARD
+import com.pingidentity.oidc.JsonConfigKey
 import com.pingidentity.oidc.OidcClient
 import com.pingidentity.oidc.OidcWebClient
-import com.pingidentity.oidc.module.Web
 import com.pingidentity.oidc.OidcDeviceClient
+import com.pingidentity.oidc.toScopesJsonArray
 import com.pingidentity.samples.pingsampleapp.settingDataStore
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.json.JSONArray
 import org.json.JSONObject
-import com.pingidentity.davinci.module.Oidc as DaVinciOidc
-import com.pingidentity.journey.module.Oidc as JourneyOidc
 
 // ---------------------------------------------------------------------------
 // Config state data classes
 // ---------------------------------------------------------------------------
 
 data class JourneyConfigState(
-    val serverUrl: String = "https://www.example.com/am",
-    val realm: String = "alpha",
+    val serverUrl: String = "",
+    val realm: String = "",
     val cookie: String = "",
-    val clientId: String = "dummy",
-    val discoveryEndpoint: String = "https://www.example.com/am/oauth2/alpha/.well-known/openid-configuration",
-    val scopes: String = "openid,email,address,profile,phone",
-    val redirectUri: String = "org.forgerock.demo:/oauth2redirect",
-    val display: String = "Journey Test Config",
+    val clientId: String = "",
+    val discoveryEndpoint: String = "",
+    val scopes: String = "",
+    val redirectUri: String = "",
+    val display: String = "",
 )
 
 data class OidcConfigState(
@@ -79,7 +80,16 @@ data class DeviceAuthConfigState(
 // Default preset configs (used as fallbacks when no saved config exists)
 // ---------------------------------------------------------------------------
 
-internal val defaultJourneyConfig = JourneyConfigState()
+internal val defaultJourneyConfig = JourneyConfigState(
+    serverUrl = "https://www.example.com/am",
+    realm = "alpha",
+    cookie = "",
+    clientId = "dummy",
+    discoveryEndpoint = "https://www.example.com/am/oauth2/alpha/.well-known/openid-configuration",
+    scopes = "openid,email,address,profile,phone",
+    redirectUri = "org.forgerock.demo:/oauth2redirect",
+    display = "Journey Test Config",
+)
 
 internal val defaultDaVinciConfig = OidcConfigState(
     clientId = "dummy",
@@ -115,7 +125,7 @@ internal val defaultWebConfig = OidcConfigState(
 // Global SDK instance holders (consumed by other ViewModels)
 // ---------------------------------------------------------------------------
 
-var journey: Journey = createJourney(defaultJourneyConfig)
+var journey: Journey? = null
 var oidcClient: OidcClient? = null
 var daVinci: DaVinci? = null
 var web: OidcWebClient? = null
@@ -129,84 +139,133 @@ lateinit var daVinciRedirectUri: Uri
 // Package-level SDK builders (called both at app startup and from ViewModel)
 // ---------------------------------------------------------------------------
 
-private fun createJourney(config: JourneyConfigState): Journey = Journey {
-    logger = Logger.STANDARD
-    serverUrl = config.serverUrl
-    realm = config.realm
-    if (config.cookie.isNotBlank()) cookie = config.cookie
-    module(JourneyOidc) {
-        clientId = config.clientId
-        discoveryEndpoint = config.discoveryEndpoint
-        scopes = config.scopes.toScopeSet()
-        redirectUri = config.redirectUri
-        display = config.display
-        storage { fileName = "journey" }
-    }
-}
-
 internal fun buildJourney(config: JourneyConfigState) {
-    journey = createJourney(config)
-    oidcClient = OidcClient {
-        clientId = config.clientId
-        discoveryEndpoint = config.discoveryEndpoint
-        scopes = config.scopes.toScopeSet()
-        redirectUri = config.redirectUri
-        display = config.display
-    }
+    Journey(
+        buildJsonObject {
+            put(JsonConfigKey.LOG, "STANDARD")
+            put(JsonConfigKey.JOURNEY, buildJsonObject {
+                put(JsonConfigKey.SERVER_URL, config.serverUrl)
+                put(JsonConfigKey.REALM, config.realm)
+                if (config.cookie.isNotBlank()) put(JsonConfigKey.COOKIE_NAME, config.cookie)
+            })
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, config.clientId)
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, config.discoveryEndpoint)
+                put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
+                put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
+                put(JsonConfigKey.DISPLAY, config.display)
+                put(JsonConfigKey.STORAGE_FILENAME, "journey")
+            })
+        }
+    ).onSuccess { journey = it }
+        .onFailure {
+            Logger.STANDARD.d("Failed to create Journey instance: ${it.message}")
+            journey = null
+        }
+    OidcClient(
+        buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, config.clientId)
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, config.discoveryEndpoint)
+                put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
+                put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
+                put(JsonConfigKey.DISPLAY, config.display)
+            })
+        }
+    ).onSuccess { oidcClient = it }
+        .onFailure {
+            Logger.STANDARD.d("Failed to create OIDC client instance: ${it.message}")
+            oidcClient = null
+        }
     redirectUri = config.redirectUri.toUri()
 }
 
 internal fun buildDaVinci(config: OidcConfigState) {
-    daVinci = DaVinci {
-        logger = Logger.STANDARD
-        module(DaVinciOidc) {
-            clientId = config.clientId
-            discoveryEndpoint = config.discoveryEndpoint
-            scopes = config.scopes.toScopeSet()
-            redirectUri = config.redirectUri
-            display = config.display
-            if (config.arcValue.isNotBlank()) acrValues = config.arcValue
-            storage { fileName = "daVinci" }
+    DaVinci(
+        buildJsonObject {
+            put(JsonConfigKey.LOG, "STANDARD")
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, config.clientId)
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, config.discoveryEndpoint)
+                put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
+                put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
+                put(JsonConfigKey.DISPLAY, config.display)
+                if (config.arcValue.isNotBlank()) put(JsonConfigKey.ACR_VALUES, config.arcValue)
+                put(JsonConfigKey.STORAGE_FILENAME, "daVinci")
+            })
         }
-    }
+    ).onSuccess { daVinci = it }
+        .onFailure { Logger.STANDARD.d("Failed to create DaVinci instance: ${it.message}") }
     // Store in the DaVinci-specific global so it never overwrites Journey's redirectUri
     daVinciRedirectUri = config.redirectUri.toUri()
 }
 
 internal fun buildWeb(config: OidcConfigState) {
-    web = OidcWebClient {
-        logger = Logger.STANDARD
-        module(com.pingidentity.oidc.module.Oidc) {
-            clientId = config.clientId
-            discoveryEndpoint = config.discoveryEndpoint
-            scopes = config.scopes.toScopeSet()
-            redirectUri = config.redirectUri
-            display = config.display
+    OidcWebClient(
+        buildJsonObject {
+            put(JsonConfigKey.LOG, "STANDARD")
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, config.clientId)
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, config.discoveryEndpoint)
+                put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
+                put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
+                put(JsonConfigKey.DISPLAY, config.display)
+            })
+            put(JsonConfigKey.WEB, buildJsonObject {
+                put(JsonConfigKey.WEB_CUSTOM_TAB_COLOR_SCHEME, CustomTabsIntent.COLOR_SCHEME_DARK)
+                put(JsonConfigKey.WEB_AUTH_TAB_COLOR_SCHEME, CustomTabsIntent.COLOR_SCHEME_DARK)
+            })
         }
-        module(Web) {
-            customTabsCustomizer = { setColorScheme(CustomTabsIntent.COLOR_SCHEME_DARK) }
-            authTabCustomizer = { setColorScheme(CustomTabsIntent.COLOR_SCHEME_DARK) }
+    ).onSuccess { web = it }
+        .onFailure {
+            Logger.STANDARD.d("Failed to create OIDC Web client instance: ${it.message}")
+            web = null
         }
-    }
 }
 
 internal fun buildDeviceAuthClient(config: DeviceAuthConfigState) {
-    oidcDeviceClient = OidcDeviceClient {
-        logger = Logger.STANDARD
-        clientId = config.clientId
-        discoveryEndpoint = config.discoveryEndpoint
-        scopes = config.scopes.toScopeSet()
-        if (config.acrValues.isNotBlank()) acrValues = config.acrValues
-        storage { fileName = "device_flow" }
-        openIdOverride = {
-            if (config.authorizationEndpoint.isNotBlank()) authorizationEndpoint = config.authorizationEndpoint
-            if (config.tokenEndpoint.isNotBlank()) tokenEndpoint = config.tokenEndpoint
-            if (config.userinfoEndpoint.isNotBlank()) userinfoEndpoint = config.userinfoEndpoint
-            if (config.endSessionEndpoint.isNotBlank()) endSessionEndpoint = config.endSessionEndpoint
-            if (config.revocationEndpoint.isNotBlank()) revocationEndpoint = config.revocationEndpoint
-            if (config.deviceAuthorizationEndpoint.isNotBlank()) deviceAuthorizationEndpoint = config.deviceAuthorizationEndpoint
+    OidcDeviceClient(
+        buildJsonObject {
+            put(JsonConfigKey.OIDC, buildJsonObject {
+                put(JsonConfigKey.CLIENT_ID, config.clientId)
+                put(JsonConfigKey.DISCOVERY_ENDPOINT, config.discoveryEndpoint)
+                put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
+                put(JsonConfigKey.DISPLAY, config.display)
+                put(JsonConfigKey.STORAGE_FILENAME, "device_flow")
+                if (config.acrValues.isNotBlank()) put(JsonConfigKey.ACR_VALUES, config.acrValues)
+                put(JsonConfigKey.OPEN_ID, buildJsonObject {
+                    if (config.authorizationEndpoint.isNotBlank()) put(
+                        JsonConfigKey.AUTHORIZATION_ENDPOINT,
+                        config.authorizationEndpoint
+                    )
+                    if (config.tokenEndpoint.isNotBlank()) put(
+                        JsonConfigKey.TOKEN_ENDPOINT,
+                        config.tokenEndpoint
+                    )
+                    if (config.userinfoEndpoint.isNotBlank()) put(
+                        JsonConfigKey.USER_INFO_ENDPOINT,
+                        config.userinfoEndpoint
+                    )
+                    if (config.endSessionEndpoint.isNotBlank()) put(
+                        JsonConfigKey.END_SESSION_ENDPOINT,
+                        config.endSessionEndpoint
+                    )
+                    if (config.revocationEndpoint.isNotBlank()) put(
+                        JsonConfigKey.REVOCATION_ENDPOINT,
+                        config.revocationEndpoint
+                    )
+                    if (config.deviceAuthorizationEndpoint.isNotBlank()) put(
+                        JsonConfigKey.DEVICE_AUTHORIZATION_ENDPOINT,
+                        config.deviceAuthorizationEndpoint
+                    )
+                })
+            })
         }
-    }
+    ).onSuccess { oidcDeviceClient = it }
+        .onFailure {
+            Logger.STANDARD.d("Failed to create OIDC Device client instance: ${it.message}")
+            oidcDeviceClient = null
+        }
 }
 
 // ---------------------------------------------------------------------------
@@ -792,10 +851,3 @@ class EnvViewModel : ViewModel() {
         }
     }.getOrDefault(emptyList())
 }
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-private fun String.toScopeSet(): MutableSet<String> =
-    split(",").map { it.trim() }.filter { it.isNotEmpty() }.toMutableSet()

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/devicemanagement/DeviceManagementViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/devicemanagement/DeviceManagementViewModel.kt
@@ -84,7 +84,11 @@ class DeviceManagementViewModel(
             s.copy(selectedDeviceType = deviceType, isLoading = true)
         }
         viewModelScope.launch {
-            val deviceClient = buildDeviceClient() ?: return@launch
+            val deviceClient = buildDeviceClient()
+            if (deviceClient == null) {
+                state.update { s -> s.copy(deviceList = emptyList(), isLoading = false) }
+                return@launch
+            }
             try {
                 when (deviceType) {
                     DeviceType.OATH -> {
@@ -322,7 +326,7 @@ class DeviceManagementViewModel(
     }
 
     private suspend fun buildDeviceClient(): DeviceClient? {
-        val user = journey.user() ?: return null
+        val user = journey?.user() ?: return null
         return DeviceClient {
             ssoTokenString = user.session().value
             serverUrl = URL("https://openam-sdks.forgeblocks.com/am")

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/journey/JourneyViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/journey/JourneyViewModel.kt
@@ -36,11 +36,11 @@ class JourneyViewModel(
         loading.update { true }
         viewModelScope.launch {
             val next = if (!verificationUri.isNullOrBlank()) {
-                journey.start(journeyName) {
+                journey?.start(journeyName) {
                     VERIFICATION_URI_COMPLETE to verificationUri.toUri()
                 }
             } else {
-                journey.start(journeyName)
+                journey?.start(journeyName)
             }
             state.update { it.copy(node = next) }
             loading.update { false }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/logout/LogoutViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/logout/LogoutViewModel.kt
@@ -31,7 +31,7 @@ class LogoutViewModel: ViewModel() {
         viewModelScope.launch {
             state.value = LogoutState(
                 daVinci = daVinci?.davinciUser() != null,
-                journey = journey.journeyUser() != null,
+                journey = journey?.journeyUser() != null,
                 oidc = web?.user() != null,
                 oidcDeviceClient = oidcDeviceClient?.user() != null,
             )
@@ -40,7 +40,7 @@ class LogoutViewModel: ViewModel() {
 
     fun logoutJourney(onCompleted: () -> Unit) {
         viewModelScope.launch {
-            journey.journeyUser()?.logout()
+            journey?.journeyUser()?.logout()
             onCompleted()
         }
     }
@@ -70,7 +70,7 @@ class LogoutViewModel: ViewModel() {
         viewModelScope.launch {
             // Logout from all active sessions
             try {
-                runCatching { journey.journeyUser()?.logout() }
+                runCatching { journey?.journeyUser()?.logout() }
                 runCatching { daVinci?.davinciUser()?.logout() }
                 runCatching { web?.user()?.logout() }
                 runCatching { oidcDeviceClient?.user()?.logout() }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/TokenViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/TokenViewModel.kt
@@ -108,7 +108,7 @@ class TokenViewModel : ViewModel() {
     // Journey Token Operations
     private fun journeyAccessToken() {
         viewModelScope.launch {
-            journey.journeyUser()?.let {
+            journey?.journeyUser()?.let {
                 when (val result = it.token()) {
                     is Failure -> {
                         state.update { state ->
@@ -131,7 +131,7 @@ class TokenViewModel : ViewModel() {
 
     private fun journeyRevoke() {
         viewModelScope.launch {
-            journey.journeyUser()?.revoke()
+            journey?.journeyUser()?.revoke()
             state.update {
                 it.copy(journeyToken = null, journeyError = null)
             }
@@ -140,7 +140,7 @@ class TokenViewModel : ViewModel() {
 
     private fun journeyRefresh() {
         viewModelScope.launch {
-            journey.journeyUser()?.let {
+            journey?.journeyUser()?.let {
                 when (val result = it.refresh()) {
                     is Failure -> {
                         state.update { state ->

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/userprofile/UserProfileViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/userprofile/UserProfileViewModel.kt
@@ -101,7 +101,7 @@ class UserProfileViewModel : ViewModel() {
     // Journey Operations
     private fun journeyUserInfo() {
         viewModelScope.launch {
-            val user = journey.journeyUser()
+            val user = journey?.journeyUser()
             if (user == null) {
                 state.update { s -> s.copy(journeyUser = null, journeyError = null) }
                 return@launch


### PR DESCRIPTION
# JIRA Ticket
[SDKS-5065](https://pingidentity.atlassian.net/browse/SDKS-5065)

# Description
This PR updates the `DaVinci`, `Journey` and `OidcClient` to handle initialization of configuration via json. This is part of the Unified Configuration standardization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON-driven configuration added for Journey, DaVinci, OIDC Web/Device/Client factories with rich OIDC options, scope parsing, additional parameters, endpoint overrides, timeout and log controls, and web theming.
* **Refactor**
  * Web client construction moved to top-level factory functions; many constructors gain JSON factory overloads.
* **Bug Fixes**
  * Safer nullable handling across sample app viewmodels.
* **Tests**
  * Expanded unit tests for JSON parsing, validation, scopes, timeout/log, and additionalParameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->