### PR TITLE
SDKS-4783 Add E2E tests for OAuth 2.0 Device Authorization Grant

### DIFF
--- a/.github/workflows/browserstack-davinci-run.yaml
+++ b/.github/workflows/browserstack-davinci-run.yaml
@@ -83,10 +83,6 @@ jobs:
             "deviceLogs": ${{ vars.BS_DEVICE_LOGS }},
             "networkLogs": ${{ vars.BS_NETWORK_LOGS }},
             "video": ${{ vars.BS_VIDEO }}, 
-            "shards": {
-              "numberOfShards": ${{ vars.BS_NUMBER_OF_SHARDS }}, 
-              "deviceSelection": "all"
-            },
             "project": "davinci-tests"
           }
           EOF
@@ -102,8 +98,13 @@ jobs:
             -H "Content-Type: application/json" \
             -d @browserstack-run-config.json)
           echo "RUN_RESPONSE: $RUN_RESPONSE"
-          echo "BROWSERSTACK_DAVINCI_BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_ENV
-          echo "browserstack_davinci_build_id=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_OUTPUT
+          BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')
+          if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "Failed to start BrowserStack davinci run. Response: $RUN_RESPONSE"
+            exit 1
+          fi
+          echo "BROWSERSTACK_DAVINCI_BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+          echo "browserstack_davinci_build_id=$BUILD_ID" >> $GITHUB_OUTPUT
 
       # Send slack notification ONLY if any of the steps above fail
       - name: Send slack notification

--- a/.github/workflows/browserstack-journey-run.yaml
+++ b/.github/workflows/browserstack-journey-run.yaml
@@ -83,10 +83,6 @@ jobs:
             "deviceLogs": ${{ vars.BS_DEVICE_LOGS }},
             "networkLogs": ${{ vars.BS_NETWORK_LOGS }},
             "video": ${{ vars.BS_VIDEO }}, 
-            "shards": {
-              "numberOfShards": ${{ vars.BS_NUMBER_OF_SHARDS }}, 
-              "deviceSelection": "all"
-            },
             "project": "journey-tests"
           }
           EOF
@@ -102,8 +98,13 @@ jobs:
             -H "Content-Type: application/json" \
             -d @browserstack-run-config.json)
           echo "RUN_RESPONSE: $RUN_RESPONSE"
-          echo "BROWSERSTACK_JOURNEY_BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_ENV
-          echo "browserstack_journey_build_id=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_OUTPUT
+          BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')
+          if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "Failed to start BrowserStack journey run. Response: $RUN_RESPONSE"
+            exit 1
+          fi
+          echo "BROWSERSTACK_JOURNEY_BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+          echo "browserstack_journey_build_id=$BUILD_ID" >> $GITHUB_OUTPUT
 
       # Send slack notification ONLY if any of the steps above fail
       - name: Send slack notification

--- a/.github/workflows/browserstack-oath-run.yaml
+++ b/.github/workflows/browserstack-oath-run.yaml
@@ -75,11 +75,7 @@ jobs:
             "devices": $DEVICES_JSON,
             "deviceLogs": ${{ vars.BS_DEVICE_LOGS }},
             "networkLogs": ${{ vars.BS_NETWORK_LOGS }},
-            "video": ${{ vars.BS_VIDEO }}, 
-            "shards": {
-              "numberOfShards": ${{ vars.BS_NUMBER_OF_SHARDS }}, 
-              "deviceSelection": "all"
-            },
+            "video": ${{ vars.BS_VIDEO }},
             "project": "oath-tests"
           }
           EOF
@@ -95,8 +91,13 @@ jobs:
             -H "Content-Type: application/json" \
             -d @browserstack-run-config.json)
           echo "RUN_RESPONSE: $RUN_RESPONSE"
-          echo "BROWSERSTACK_OATH_BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_ENV
-          echo "browserstack_oath_build_id=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_OUTPUT
+          BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')
+          if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "Failed to start BrowserStack oath run. Response: $RUN_RESPONSE"
+            exit 1
+          fi
+          echo "BROWSERSTACK_OATH_BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+          echo "browserstack_oath_build_id=$BUILD_ID" >> $GITHUB_OUTPUT
       # Send slack notification ONLY if any of the steps above fail
       - name: Send slack notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/browserstack-prepare-artifacts.yaml
+++ b/.github/workflows/browserstack-prepare-artifacts.yaml
@@ -64,11 +64,11 @@ jobs:
       - name: List build tools versions
         run: ls $ANDROID_HOME/build-tools/
 
-      # Sign app-debug.apk
-      - name: Sign app-debug.apk
+      # Sign pingsampleapp-debug.apk
+      - name: Sign pingsampleapp-debug.apk
         uses: r0adkll/sign-android-release@v1
         with:
-          releaseDirectory: samples/app/build/outputs/apk/debug
+          releaseDirectory: samples/pingsampleapp/build/outputs/apk/debug
           signingKeyBase64: ${{ secrets.SIGNING_KEYSTORE }}
           alias: ${{ secrets.SIGNING_ALIAS }}
           keyStorePassword: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
@@ -125,12 +125,12 @@ jobs:
           BUILD_TOOLS_VERSION: "35.0.0"
 
       # Publish the signed APKs as build artifacts
-      - name: Publish app-debug.apk
+      - name: Publish app-debug-signed.apk
         uses: actions/upload-artifact@v4
         if: success()
         with:
           name: app-debug-signed.apk
-          path: samples/app/build/outputs/apk/debug/app-debug-signed.apk
+          path: samples/pingsampleapp/build/outputs/apk/debug/pingsampleapp-debug-signed.apk
 
       - name: Publish davinci-debug-androidTest.apk
         uses: actions/upload-artifact@v4

--- a/.github/workflows/browserstack-prepare-artifacts.yaml
+++ b/.github/workflows/browserstack-prepare-artifacts.yaml
@@ -76,6 +76,10 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "35.0.0"
 
+      # Rename to the canonical name expected by downstream run workflows
+      - name: Rename pingsampleapp-debug-signed.apk to app-debug-signed.apk
+        run: mv samples/pingsampleapp/build/outputs/apk/debug/pingsampleapp-debug-signed.apk samples/pingsampleapp/build/outputs/apk/debug/app-debug-signed.apk
+
       # Sign davinci-debug-androidTest.apk
       - name: Sign davinci-debug-androidTest.apk
         uses: r0adkll/sign-android-release@v1
@@ -130,7 +134,7 @@ jobs:
         if: success()
         with:
           name: app-debug-signed.apk
-          path: samples/pingsampleapp/build/outputs/apk/debug/pingsampleapp-debug-signed.apk
+          path: samples/pingsampleapp/build/outputs/apk/debug/app-debug-signed.apk
 
       - name: Publish davinci-debug-androidTest.apk
         uses: actions/upload-artifact@v4

--- a/.github/workflows/browserstack-prepare-artifacts.yaml
+++ b/.github/workflows/browserstack-prepare-artifacts.yaml
@@ -27,6 +27,9 @@ on:
       E2E_CONFIG:
         description: 'Variables for the e2e tests'
         required: true
+      DAVINCI_E2E_CONFIG:
+        description: 'Variables for the DaVinci e2e tests'
+        required: true
 jobs:
   prepare-device-farm-artifacts:
     runs-on: ubuntu-latest
@@ -43,6 +46,7 @@ jobs:
       - name: Setup config file for e2e tests
         run: |
           echo "${{ secrets.E2E_CONFIG }}" > journey/src/main/assets/test_config.properties
+          echo "${{ secrets.DAVINCI_E2E_CONFIG }}" > davinci/src/main/assets/davinci_test_config.properties
 
       # Setup JDK and cache and restore dependencies.
       - name: Set up JDK 17

--- a/.github/workflows/browserstack-push-run.yaml
+++ b/.github/workflows/browserstack-push-run.yaml
@@ -75,11 +75,7 @@ jobs:
             "devices": $DEVICES_JSON,
             "deviceLogs": ${{ vars.BS_DEVICE_LOGS }},
             "networkLogs": ${{ vars.BS_NETWORK_LOGS }},
-            "video": ${{ vars.BS_VIDEO }}, 
-            "shards": {
-              "numberOfShards": ${{ vars.BS_NUMBER_OF_SHARDS }}, 
-              "deviceSelection": "all"
-            },
+            "video": ${{ vars.BS_VIDEO }},
             "project": "push-tests"
           }
           EOF
@@ -95,8 +91,13 @@ jobs:
             -H "Content-Type: application/json" \
             -d @browserstack-run-config.json)
           echo "RUN_RESPONSE: $RUN_RESPONSE"
-          echo "BROWSERSTACK_PUSH_BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_ENV
-          echo "browserstack_push_build_id=$(echo $RUN_RESPONSE | jq -r '.build_id')" >> $GITHUB_OUTPUT
+          BUILD_ID=$(echo $RUN_RESPONSE | jq -r '.build_id')
+          if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "Failed to start BrowserStack push run. Response: $RUN_RESPONSE"
+            exit 1
+          fi
+          echo "BROWSERSTACK_PUSH_BUILD_ID=$BUILD_ID" >> $GITHUB_ENV
+          echo "browserstack_push_build_id=$BUILD_ID" >> $GITHUB_OUTPUT
       # Send slack notification ONLY if any of the steps above fail
       - name: Send slack notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,7 @@ jobs:
     needs: create-testrail-run
     secrets:
       E2E_CONFIG: ${{ secrets.E2E_CONFIG }}
+      DAVINCI_E2E_CONFIG: ${{ secrets.DAVINCI_E2E_CONFIG }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       TESTRAIL_USERNAME: ${{ secrets.TESTRAIL_USERNAME }}
@@ -64,13 +65,17 @@ jobs:
     needs: build-and-test
     secrets:
       E2E_CONFIG: ${{ secrets.E2E_CONFIG }}
+      DAVINCI_E2E_CONFIG: ${{ secrets.DAVINCI_E2E_CONFIG }}
       SIGNING_KEYSTORE: ${{ secrets.SIGNING_KEYSTORE }}
       SIGNING_ALIAS: ${{ secrets.SIGNING_ALIAS }}
       SIGNING_KEYSTORE_PASSWORD: ${{ secrets.SIGNING_KEYSTORE_PASSWORD }}
       SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
       SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  # Execute e2e test cases in BrowserStack. The workflow outputs the newly created run id.
+  # Execute e2e test cases in BrowserStack.
+  # Runs in two batches of 2 to stay within the 3-parallel-session limit:
+  #   Batch 1 (parallel): davinci + journey
+  #   Batch 2 (parallel): oath + push  — starts only after both batch 1 jobs finish
   browserstack-davinci-run:
     name: Run tests in BrowserStack
     uses: ./.github/workflows/browserstack-davinci-run.yaml
@@ -92,8 +97,9 @@ jobs:
   browserstack-oath-run:
     name: Run tests in BrowserStack
     uses: ./.github/workflows/browserstack-oath-run.yaml
-    needs: 
-      - browserstack-prepare-artifacts
+    needs:
+      - browserstack-davinci-results
+      - browserstack-journey-results
     secrets:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
@@ -102,8 +108,9 @@ jobs:
   browserstack-push-run:
     name: Run tests in BrowserStack
     uses: ./.github/workflows/browserstack-push-run.yaml
-    needs: 
-      - browserstack-prepare-artifacts
+    needs:
+      - browserstack-davinci-results
+      - browserstack-journey-results
     secrets:
       BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -32,6 +32,9 @@ on:
       E2E_CONFIG:
         description: 'Variables for the e2e tests'
         required: true
+      DAVINCI_E2E_CONFIG:
+        description: 'Variables for the DaVinci e2e tests'
+        required: true
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -53,6 +56,7 @@ jobs:
       - name: Setup config file for e2e tests
         run: |
           echo "${{ secrets.E2E_CONFIG }}" > journey/src/main/assets/test_config.properties
+          echo "${{ secrets.DAVINCI_E2E_CONFIG }}" > davinci/src/main/assets/davinci_test_config.properties
 
       # Setup JDK and cache and restore dependencies.
       - name: Setup JDK 17

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ xcuserdata
 .kotlin
 .polaris/
 .claude/settings.local.json
+.playwright-mcp/

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DaVinciTestConfig.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DaVinciTestConfig.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.android.ContextProvider
+import java.io.IOException
+import java.util.Properties
+
+object DaVinciTestConfig {
+    private const val CONFIG_FILE_NAME = "davinci_test_config.properties"
+    private val properties = Properties()
+
+    // Shared
+    var davinciRedirectUri: String = ""
+        private set
+
+    // DaVinci E2E (DavinciAndroidTest, FormMFADevicesTest, DavinciProtectTest)
+    var davinciClientId: String = ""
+        private set
+    var davinciDiscoveryEndpoint: String = ""
+        private set
+    var davinciAcrValues: String = ""
+        private set
+    var davinciProtectAcrValues: String = ""
+        private set
+    var davinciMfaAcrValues: String = ""
+        private set
+
+    // Form field tests (FormFieldsTest, FormFieldValidationTest, PollingCollectorE2ETests)
+    var davinciFormClientId: String = ""
+        private set
+    var davinciFormDiscoveryEndpoint: String = ""
+        private set
+    var davinciFormFieldsAcrValues: String = ""
+        private set
+    var davinciPollingAcrValues: String = ""
+        private set
+
+    // Credentials
+    var davinciUsername: String = ""
+        private set
+    var davinciPassword: String = ""
+        private set
+    var davinciVerificationCode: String = ""
+        private set
+    var davinciProtectUsername: String = ""
+        private set
+    var davinciProtectPassword: String = ""
+        private set
+
+    // Device Authorization Grant
+    var deviceClientId: String = ""
+        private set
+    var deviceDiscoveryEndpoint: String = ""
+        private set
+    var deviceApproverClientId: String = ""
+        private set
+    var deviceApproverDiscoveryEndpoint: String = ""
+        private set
+    var deviceApproverRedirectUri: String = ""
+        private set
+    var deviceApproverAcrValues: String = ""
+        private set
+    var deviceUsername: String = ""
+        private set
+    var devicePassword: String = ""
+        private set
+
+    init {
+        try {
+            val inputStream = ContextProvider.context.assets.open(CONFIG_FILE_NAME)
+            properties.load(inputStream)
+            inputStream.close()
+
+            davinciRedirectUri = properties.getProperty("DAVINCI_REDIRECT_URI", "")
+
+            davinciClientId = properties.getProperty("DAVINCI_CLIENT_ID", "")
+            davinciDiscoveryEndpoint = properties.getProperty("DAVINCI_DISCOVERY_ENDPOINT", "")
+            davinciAcrValues = properties.getProperty("DAVINCI_ACR_VALUES", "")
+            davinciProtectAcrValues = properties.getProperty("DAVINCI_PROTECT_ACR_VALUES", "")
+            davinciMfaAcrValues = properties.getProperty("DAVINCI_MFA_ACR_VALUES", "")
+
+            davinciFormClientId = properties.getProperty("DAVINCI_FORM_CLIENT_ID", "")
+            davinciFormDiscoveryEndpoint = properties.getProperty("DAVINCI_FORM_DISCOVERY_ENDPOINT", "")
+            davinciFormFieldsAcrValues = properties.getProperty("DAVINCI_FORM_FIELDS_ACR_VALUES", "")
+            davinciPollingAcrValues = properties.getProperty("DAVINCI_POLLING_ACR_VALUES", "")
+
+            davinciUsername = properties.getProperty("DAVINCI_USERNAME", "")
+            davinciPassword = properties.getProperty("DAVINCI_PASSWORD", "")
+            davinciVerificationCode = properties.getProperty("DAVINCI_VERIFICATION_CODE", "")
+            davinciProtectUsername = properties.getProperty("DAVINCI_PROTECT_USERNAME", "")
+            davinciProtectPassword = properties.getProperty("DAVINCI_PROTECT_PASSWORD", "")
+
+            deviceClientId = properties.getProperty("DEVICE_CLIENT_ID", "")
+            deviceDiscoveryEndpoint = properties.getProperty("DEVICE_DISCOVERY_ENDPOINT", "")
+            deviceApproverClientId = properties.getProperty("DEVICE_APPROVER_CLIENT_ID", "")
+            deviceApproverDiscoveryEndpoint = properties.getProperty("DEVICE_APPROVER_DISCOVERY_ENDPOINT", "")
+            deviceApproverRedirectUri = properties.getProperty("DEVICE_APPROVER_REDIRECT_URI", "")
+            deviceApproverAcrValues = properties.getProperty("DEVICE_APPROVER_ACR_VALUES", "")
+            deviceUsername = properties.getProperty("DEVICE_USERNAME", "")
+            devicePassword = properties.getProperty("DEVICE_PASSWORD", "")
+        } catch (e: IOException) {
+            android.util.Log.e("DaVinciTestConfig", "Error loading properties file: ${e.message}")
+        }
+    }
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciAndroidTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciAndroidTest.kt
@@ -42,11 +42,11 @@ class DavinciAndroidTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "021b83ce-a9b1-4ad4-8c1d-79e576eeab76"
-            discoveryEndpoint = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.davinciClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = " 79220c5e3a217a3d9b6739585cb160aa"
+            redirectUri = DaVinciTestConfig.davinciRedirectUri
+            acrValues = DaVinciTestConfig.davinciAcrValues
             //storage = dataStore
         }
     }
@@ -68,10 +68,9 @@ class DavinciAndroidTest {
         userLname = "User"
         usernamePrefix = "e2e"
 
-        // This user must exist in PingOne...
-        username = "e2euser@example.com"
-        password = "Demo1234#1"
-        verificationCode = "1234" // This is hardcoded value in the DaVinci flow
+        username = DaVinciTestConfig.davinciUsername
+        password = DaVinciTestConfig.davinciPassword
+        verificationCode = DaVinciTestConfig.davinciVerificationCode
 
         //Start with a clean session
         daVinci.user()?.logout()

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciProtectTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciProtectTest.kt
@@ -39,11 +39,11 @@ class DavinciProtectTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "021b83ce-a9b1-4ad4-8c1d-79e576eeab76"
-            discoveryEndpoint = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.davinciClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "f47c36d84a95e14dd93d05884792edd5"
+            redirectUri = DaVinciTestConfig.davinciRedirectUri
+            acrValues = DaVinciTestConfig.davinciProtectAcrValues
         }
     }
 
@@ -81,8 +81,8 @@ class DavinciProtectTest {
         assertTrue(result.isSuccess)
 
         // Fill the login form with username and password and click "Login"
-        (node.collectors[0] as? TextCollector)?.value = "jsmith"
-        (node.collectors[1] as? PasswordCollector)?.value = "whatever!"
+        (node.collectors[0] as? TextCollector)?.value = DaVinciTestConfig.davinciProtectUsername
+        (node.collectors[1] as? PasswordCollector)?.value = DaVinciTestConfig.davinciProtectPassword
         (node.collectors[2] as? SubmitCollector)?.value = "Login"
         node = node.next() as ContinueNode
 
@@ -114,7 +114,7 @@ class DavinciProtectTest {
         // Assertions for the 'event' object
         val eventObject = rawResponse.getJSONObject("event")
         val userObject = eventObject.getJSONObject("user")
-        assertEquals("jsmith", userObject.getString("name"))
+        assertEquals(DaVinciTestConfig.davinciProtectUsername, userObject.getString("name"))
 
         // Continue to the next node and finish the flow
         (node.collectors[4] as? SubmitCollector)?.value = "click"
@@ -155,8 +155,8 @@ class DavinciProtectTest {
         assertTrue(result.isSuccess)
 
         // Fill the login form with username and password and click "Login"
-        (node.collectors[1] as? TextCollector)?.value = "jsmith"
-        (node.collectors[2] as? PasswordCollector)?.value = "whatever!"
+        (node.collectors[1] as? TextCollector)?.value = DaVinciTestConfig.davinciProtectUsername
+        (node.collectors[2] as? PasswordCollector)?.value = DaVinciTestConfig.davinciProtectPassword
         (node.collectors[3] as? SubmitCollector)?.value = "Login"
         node = node.next() as ContinueNode
 
@@ -188,7 +188,7 @@ class DavinciProtectTest {
         // Assertions for the 'event' object
         val eventObject = rawResponse.getJSONObject("event")
         val userObject = eventObject.getJSONObject("user")
-        assertEquals("jsmith", userObject.getString("name"))
+        assertEquals(DaVinciTestConfig.davinciProtectUsername, userObject.getString("name"))
 
         // Continue to the next node and finish the flow
         (node.collectors[4] as? SubmitCollector)?.value = "click"

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTest.kt
@@ -53,9 +53,8 @@ class DeviceAuthorizationTest {
 
     private val client = OidcDeviceClient {
         logger = Logger.STANDARD
-        clientId = "d6505e10-d019-4f9d-ae76-d0648ca9c9c3"
-        discoveryEndpoint =
-            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+        clientId = DaVinciTestConfig.deviceClientId
+        discoveryEndpoint = DaVinciTestConfig.deviceDiscoveryEndpoint
         scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
         storage { fileName = "device_flow_test" }
     }
@@ -64,12 +63,11 @@ class DeviceAuthorizationTest {
     private val approvingDaVinci = DaVinci {
         logger = Logger.STANDARD
         module(Oidc) {
-            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-            discoveryEndpoint =
-                "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.deviceApproverClientId
+            discoveryEndpoint = DaVinciTestConfig.deviceApproverDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "25abee29d6271102825e4b076c8de7c3"
+            redirectUri = DaVinciTestConfig.deviceApproverRedirectUri
+            acrValues = DaVinciTestConfig.deviceApproverAcrValues
             storage { fileName = "device_flow_approver_test" }
         }
     }
@@ -192,8 +190,8 @@ class DeviceAuthorizationTest {
         node = node as ContinueNode
 
         // Step 1 — Sign On form: username + password.
-        (node.collectors[0] as? TextCollector)?.value = "e2euser"
-        (node.collectors[1] as? PasswordCollector)?.value = "2222"
+        (node.collectors[0] as? TextCollector)?.value = DaVinciTestConfig.deviceUsername
+        (node.collectors[1] as? PasswordCollector)?.value = DaVinciTestConfig.devicePassword
         (node.collectors[2] as? SubmitCollector)?.value = "Sign On"
         node = node.next()
         node = node as ContinueNode
@@ -260,8 +258,8 @@ class DeviceAuthorizationTest {
         node = node as ContinueNode
 
         // Step 1 — Sign On form.
-        (node.collectors[0] as? TextCollector)?.value = "e2euser"
-        (node.collectors[1] as? PasswordCollector)?.value = "2222"
+        (node.collectors[0] as? TextCollector)?.value = DaVinciTestConfig.deviceUsername
+        (node.collectors[1] as? PasswordCollector)?.value = DaVinciTestConfig.devicePassword
         (node.collectors[2] as? SubmitCollector)?.value = "Sign On"
         node = node.next()
         node = node as ContinueNode

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTest.kt
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import androidx.test.filters.LargeTest
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.oidc.DeviceAuthorizationResponse
+import com.pingidentity.oidc.DeviceFlowStatus
+import com.pingidentity.oidc.OidcDeviceClient
+import android.net.Uri
+import com.pingidentity.davinci.collector.FlowCollector
+import com.pingidentity.davinci.collector.PasswordCollector
+import com.pingidentity.davinci.collector.SubmitCollector
+import com.pingidentity.davinci.collector.TextCollector
+import com.pingidentity.davinci.module.Oidc
+import com.pingidentity.davinci.plugin.collectors
+import com.pingidentity.oidc.module.VERIFICATION_URI_COMPLETE
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.ErrorNode
+import com.pingidentity.utils.Result
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import org.junit.Ignore
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * E2E tests for the OAuth 2.0 Device Authorization Grant (RFC 8628) flow against PingOne/DaVinci.
+ *
+ * These tests exercise the requesting-device side only: they verify that the SDK correctly
+ * initiates the flow and polls the token endpoint. No approving-device interaction is performed,
+ * so the polling loop is expected to receive `authorization_pending` responses until the device
+ * code expires or the test cancels collection.
+ *
+ * Requires a live network connection to PingOne.
+ */
+@LargeTest
+class DeviceAuthorizationTest {
+
+    private val client = OidcDeviceClient {
+        logger = Logger.STANDARD
+        clientId = "d6505e10-d019-4f9d-ae76-d0648ca9c9c3"
+        discoveryEndpoint =
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+        scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
+        storage { fileName = "device_flow_test" }
+    }
+
+    // Approving-device DaVinci instance — same tenant, separate OIDC client/storage.
+    private val approvingDaVinci = DaVinci {
+        logger = Logger.STANDARD
+        module(Oidc) {
+            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+            discoveryEndpoint =
+                "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
+            redirectUri = "org.forgerock.demo://oauth2redirect"
+            acrValues = "25abee29d6271102825e4b076c8de7c3"
+            storage { fileName = "device_flow_approver_test" }
+        }
+    }
+
+    @BeforeTest
+    fun setUp(): Unit = runBlocking {
+        // Clear any leftover token from a previous test run so each test starts fresh.
+        client.user()?.logout()
+    }
+
+    /**
+     * TC-01: Start device authorization flow — verify user code, verification URL, and polling.
+     *
+     * Collects [DeviceFlowStatus.Started] and the first [DeviceFlowStatus.Polling] emission, then
+     * cancels the flow. This keeps the test under ~10 s (one 5 s poll interval) instead of waiting
+     * for the full device-code expiry (~30 s on this tenant).
+     *
+     * Verifies:
+     * - The first emission is [DeviceFlowStatus.Started] with a well-formed user code,
+     *   verification URI, and server-specified poll interval.
+     * - At least one [DeviceFlowStatus.Polling] emission follows, confirming the SDK polled
+     *   the token endpoint.
+     * - The first Polling emission carries the server-specified interval and a positive nextPollAt.
+     */
+    @Test(timeout = 20_000)
+    fun startFlowEmitsStartedThenPolling(): Unit = runBlocking {
+        val statuses = mutableListOf<DeviceFlowStatus>()
+        val pollingChannel = Channel<DeviceFlowStatus.Polling>(capacity = 1)
+
+        // Collect in the background; signal as soon as the first Polling arrives.
+        val job = async {
+            client.deviceAuthorization()
+                .onEach { status ->
+                    statuses.add(status)
+                    if (status is DeviceFlowStatus.Polling) pollingChannel.trySend(status)
+                }
+                .toList()
+        }
+
+        // Wait for the first Polling emission, then cancel — no need to wait for expiry.
+        pollingChannel.receive()
+        job.cancel()
+
+        // --- Started state ---
+        val started = statuses.first()
+        assertIs<DeviceFlowStatus.Started>(started)
+
+        val response: DeviceAuthorizationResponse = started.response
+
+        assertTrue(response.userCode.isNotBlank(), "userCode should not be blank")
+        assertTrue(
+            response.userCode.matches(Regex("[A-Z0-9]{4}-[A-Z0-9]{4}")),
+            "userCode '${response.userCode}' should match pattern XXXX-XXXX"
+        )
+
+        assertTrue(response.verificationUri.isNotBlank(), "verificationUri should not be blank")
+        assertTrue(
+            response.verificationUri.startsWith("https://auth.pingone.ca/"),
+            "verificationUri should start with 'https://auth.pingone.ca/'"
+        )
+
+        assertNotNull(response.verificationUriComplete, "verificationUriComplete should be present")
+        assertTrue(
+            response.verificationUriComplete!!.contains("user_code="),
+            "verificationUriComplete should contain 'user_code='"
+        )
+
+        assertTrue(response.deviceCode.isNotBlank(), "deviceCode should not be blank")
+        assertTrue(response.expiresIn > 0, "expiresIn should be positive")
+        assertEquals(5, response.interval, "interval should be 5 seconds (PingOne default)")
+
+        // --- Polling state ---
+        val firstPolling = statuses.filterIsInstance<DeviceFlowStatus.Polling>().first()
+        assertEquals(1, firstPolling.pollCount, "first pollCount should be 1")
+        assertEquals(response.interval, firstPolling.pollInterval,
+            "pollInterval should equal the server-specified interval")
+        assertTrue(firstPolling.nextPollAt > 0, "nextPollAt should be a positive epoch millis")
+    }
+
+    /**
+     * TC-02: Successful device authorization via DaVinci approval.
+     *
+     * Starts the device flow on the requesting side, then concurrently drives a DaVinci login
+     * flow on the approving side using [VERIFICATION_URI_COMPLETE]. The polling loop on the
+     * requesting side picks up the approval and emits [DeviceFlowStatus.Success].
+     *
+     * Verifies:
+     * - The requesting device receives [DeviceFlowStatus.Success] as the terminal state.
+     * - A valid access token is accessible via the returned [User].
+     * - [OidcDeviceClient.user] returns a non-null user after the flow completes.
+     */
+    @Test(timeout = 60_000)
+    fun deviceAuthorizationApprovalViaDaVinci(): Unit = runBlocking {
+        // Channel used to hand the verificationUriComplete from the collecting coroutine to the
+        // approving coroutine without starting a second device flow.
+        val startedChannel = Channel<DeviceFlowStatus.Started>(capacity = 1)
+
+        // Launch the device flow collection in the background so it keeps polling while we
+        // drive the approval flow below. onEach forwards the Started emission immediately
+        // so the approving side can begin without waiting for the full flow to complete.
+        val deviceFlowJob = async {
+            client.deviceAuthorization()
+                .onEach { status ->
+                    if (status is DeviceFlowStatus.Started) startedChannel.trySend(status)
+                }
+                .toList()
+        }
+
+        // Wait until the requesting device has a verification URI before approving.
+        val started = startedChannel.receive()
+        val verificationUriComplete = checkNotNull(started.response.verificationUriComplete) {
+            "verificationUriComplete must be present for DaVinci approval"
+        }
+
+        // Approving side: drive the DaVinci login flow with the verification URI.
+        // The Oidc module extracts user_code and submits it to the device endpoint on SuccessNode.
+        var node = approvingDaVinci.start {
+            VERIFICATION_URI_COMPLETE to Uri.parse(verificationUriComplete)
+        }
+        node = node as ContinueNode
+
+        // Step 1 — Sign On form: username + password.
+        (node.collectors[0] as? TextCollector)?.value = "e2euser"
+        (node.collectors[1] as? PasswordCollector)?.value = "2222"
+        (node.collectors[2] as? SubmitCollector)?.value = "Sign On"
+        node = node.next()
+        node = node as ContinueNode
+
+        // Step 2 — Device Code approval form: tap "Approve Device" (FLOW_BUTTON at index 1).
+        // ERROR_DISPLAY is not a registered collector type so it is excluded from the list:
+        // index 0 = TEXT (device-code), index 1 = FLOW_BUTTON (button-approve), index 2 = FLOW_BUTTON (button-reject).
+        (node.collectors[1] as? FlowCollector)?.value = "click"
+        // The approval call returns a DaVinci Connector (ContinueNode subclass) wrapping the
+        // "returnSuccessResponseRedirect" response, not a SuccessNode — that is the DaVinci SDK's
+        // expected behaviour for this flow. What matters is the requesting device receives Success.
+        val approvalResult = node.next()
+        assertIs<ContinueNode>(approvalResult)
+
+        // Requesting side: wait for the polling loop to pick up the approval.
+        val statuses = deviceFlowJob.await()
+        assertIs<DeviceFlowStatus.Success>(statuses.last())
+
+        val user = (statuses.last() as DeviceFlowStatus.Success).user
+        val token = user.token()
+        assertIs<Result.Success<*>>(token)
+        assertNotNull((token as Result.Success).value)
+
+        // Confirm the token is accessible via client.user() after the flow completes.
+        assertNotNull(client.user())
+
+        // Clean up: log out both sides.
+        client.user()?.logout()
+        approvingDaVinci.user()?.logout()
+    }
+
+    /**
+     * TC-03: Device authorization denied via DaVinci.
+     *
+     * Starts the device flow, drives a DaVinci login, then taps "Reject Device" on the approval
+     * form. The server returns `access_denied` on the next poll and the requesting side emits
+     * [DeviceFlowStatus.AccessDenied] as the terminal state.
+     *
+     * Verifies:
+     * - The DaVinci reject step returns an [ErrorNode] (server responds 400 with the rejection).
+     * - The requesting device receives [DeviceFlowStatus.AccessDenied] as the terminal state.
+     * - No token is stored ([OidcDeviceClient.user] returns null).
+     */
+    @Test(timeout = 60_000)
+    fun deviceAuthorizationRejectedViaDaVinci(): Unit = runBlocking {
+        val startedChannel = Channel<DeviceFlowStatus.Started>(capacity = 1)
+
+        val deviceFlowJob = async {
+            client.deviceAuthorization()
+                .onEach { status ->
+                    if (status is DeviceFlowStatus.Started) startedChannel.trySend(status)
+                }
+                .toList()
+        }
+
+        val started = startedChannel.receive()
+        val verificationUriComplete = checkNotNull(started.response.verificationUriComplete) {
+            "verificationUriComplete must be present for DaVinci rejection"
+        }
+
+        var node = approvingDaVinci.start {
+            VERIFICATION_URI_COMPLETE to Uri.parse(verificationUriComplete)
+        }
+        node = node as ContinueNode
+
+        // Step 1 — Sign On form.
+        (node.collectors[0] as? TextCollector)?.value = "e2euser"
+        (node.collectors[1] as? PasswordCollector)?.value = "2222"
+        (node.collectors[2] as? SubmitCollector)?.value = "Sign On"
+        node = node.next()
+        node = node as ContinueNode
+
+        // Step 2 — Device Code form: tap "Reject Device" (FLOW_BUTTON at index 2).
+        (node.collectors[2] as? FlowCollector)?.value = "click"
+        // The reject call returns an ErrorNode (server responds 400 "Device Authorization Rejected").
+        val rejectionResult = node.next()
+        assertIs<ErrorNode>(rejectionResult)
+
+        // Requesting side: the next poll after rejection returns access_denied.
+        val statuses = deviceFlowJob.await()
+        assertIs<DeviceFlowStatus.AccessDenied>(statuses.last())
+
+        // No token should be stored after a rejection.
+        assertNull(client.user())
+    }
+
+    /**
+     * TC-04: Device code expires without approval — flow emits Expired.
+     *
+     * Starts the device flow without approving on any second device and waits for the
+     * polling loop to exhaust the device-code lifetime. The final emission must be
+     * [DeviceFlowStatus.Expired] and no token should be stored.
+     *
+     * Verifies:
+     * - The first emission is [DeviceFlowStatus.Started].
+     * - At least one [DeviceFlowStatus.Polling] emission is present.
+     * - The terminal emission is [DeviceFlowStatus.Expired].
+     * - [OidcDeviceClient.user] returns null — no token was stored.
+     *
+     * Timeout is set well above the device-code lifetime on this tenant (~30 s) plus the
+     * maximum remaining poll interval, to avoid flakiness without waiting indefinitely.
+     */
+    // Disabled: this test waits for the full device-code lifetime (~30 s on this tenant) to elapse
+    // before asserting Expired, which makes it too slow for routine CI runs. Enable it explicitly
+    // when verifying expiry behaviour (e.g. after changes to the polling loop or token storage).
+    @Ignore("Slow: waits for full device-code expiry (~30 s). Enable manually when testing expiry behaviour.")
+    @Test(timeout = 90_000)
+    fun deviceCodeExpiresWithoutApproval(): Unit = runBlocking {
+        val statuses = client.deviceAuthorization().toList()
+
+        assertIs<DeviceFlowStatus.Started>(statuses.first())
+        assertTrue(
+            statuses.filterIsInstance<DeviceFlowStatus.Polling>().isNotEmpty(),
+            "Expected at least one Polling emission before expiry"
+        )
+        assertIs<DeviceFlowStatus.Expired>(statuses.last())
+        assertNull(client.user())
+    }
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTest.kt
@@ -76,6 +76,7 @@ class DeviceAuthorizationTest {
     fun setUp(): Unit = runBlocking {
         // Clear any leftover token from a previous test run so each test starts fresh.
         client.user()?.logout()
+        approvingDaVinci.user()?.logout()
     }
 
     /**
@@ -110,6 +111,7 @@ class DeviceAuthorizationTest {
         // Wait for the first Polling emission, then cancel — no need to wait for expiry.
         pollingChannel.receive()
         job.cancel()
+        job.join()
 
         // --- Started state ---
         val started = statuses.first()

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTestFlow.json
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DeviceAuthorizationTestFlow.json
@@ -1,0 +1,2199 @@
+{
+  "companyId": "300c4f2a-39d4-4ba9-a18a-f6de246006f4",
+  "authTokenExpireIds": [],
+  "connectorIds": [
+    "errorConnector",
+    "pingOneSSOConnector",
+    "functionsConnector",
+    "nodeConnector",
+    "variablesConnector",
+    "httpConnector",
+    "pingOneAuthenticationConnector",
+    "pingOneFormsConnector"
+  ],
+  "createdDate": 1781026593435,
+  "currentVersion": 51,
+  "customerId": "b046b8357f81a6b68a9a60227d631009",
+  "deployedDate": 1781026597398,
+  "description": "",
+  "flowStatus": "enabled",
+  "inputSchemaCompiled": {
+    "parameters": {
+      "type": "object",
+      "properties": {},
+      "additionalProperties": false,
+      "required": []
+    }
+  },
+  "isInputSchemaSaved": false,
+  "isOutputSchemaSaved": false,
+  "name": "Automation - Device Authorization",
+  "publishedVersion": 51,
+  "settings": {
+    "csp": "worker-src 'self' blob:; script-src 'self' https://cdn.jsdelivr.net https://code.jquery.com https://devsdk.singularkey.com http://cdnjs.cloudflare.com 'unsafe-inline' 'unsafe-eval';",
+    "enforcedCsp": "script-src 'nonce-rAnd0m' 'strict-dynamic' 'unsafe-eval' 'unsafe-inline' https: http:; object-src 'none'; base-uri 'none';",
+    "intermediateLoadingScreenCSS": "",
+    "intermediateLoadingScreenHTML": "",
+    "customTimeoutErrorScreenMessage": "",
+    "customTimeoutErrorScreenHTML": "",
+    "customTimeoutErrorScreenCSS": "",
+    "debugMode": false,
+    "cssLinks": [
+      "https://assets.pingone.com/ux/end-user-nano/0.1.0-alpha.9/end-user-nano.css",
+      "https://assets.pingone.com/ux/astro-nano/0.1.0-alpha.11/icons.css"
+    ],
+    "useCustomCSS": true,
+    "logLevel": 4,
+    "scrubSensitiveInfo": false,
+    "sensitiveInfoFields": [],
+    "useBetaAlgorithm": true,
+    "css": ".companyLogo {\n    height: 65px;\n}\n\n.icon-padding::before {\n  padding-right: 5px;\n}",
+    "customTitle": "Sign On",
+    "customFaviconLink": "https://assets.pingone.com/ux/ui-library/5.0.2/images/logo-pingidentity.png",
+    "cibaFlow": false
+  },
+  "timeouts": "null",
+  "trigger": {
+    "type": "AUTHENTICATION"
+  },
+  "updatedDate": 1781026597418,
+  "flowId": "f27618fe225f29dae7b4a1bc711e05b6",
+  "versionId": 51,
+  "graphData": {
+    "elements": {
+      "nodes": [
+        {
+          "data": {
+            "id": "0mkskx7cez",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected error has occurred\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Received an unexpected value"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Could not determine which button was selected\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Unexpected value received\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected value was received for button selection\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Received an unexpected value for the button selected to submit the form"
+              }
+            },
+            "idUnique": "upt2qd07bj",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1244,
+            "y": 694
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "dnu7jt3sjz",
+            "nodeType": "CONNECTION",
+            "connectionId": "94141bf2f1b9b59a5f5365ff135e02bb",
+            "connectorId": "pingOneSSOConnector",
+            "name": "PingOne",
+            "label": "PingOne SSO",
+            "status": "configured",
+            "capabilityName": "checkPassword",
+            "type": "action",
+            "properties": {
+              "userId": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingIdentity.svg\",\n        \"url\": \"id\",\n        \"data\": \"{{local.icv9ot1nro.payload.output.matchedUser.id}}\",\n        \"tooltip\": \"{{local.icv9ot1nro.payload.output.matchedUser.id}}\",\n        \"children\": [\n          {\n            \"text\": \"id\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "password": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"http.svg\",\n        \"url\": \"password\",\n        \"data\": \"{{local.65u7m8cm28.payload.output.password}}\",\n        \"tooltip\": \"{{local.65u7m8cm28.payload.output.password}}\",\n        \"children\": [\n          {\n            \"text\": \"password\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Validate Password"
+              },
+              "matchAttribute": {
+                "value": "id"
+              },
+              "identifier": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingIdentity.svg\",\n        \"url\": \"id\",\n        \"data\": \"{{local.cqm26fxq1v.payload.output.matchedUser.id}}\",\n        \"tooltip\": \"{{local.cqm26fxq1v.payload.output.matchedUser.id}}\",\n        \"children\": [\n          {\n            \"text\": \"id\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "checkPassword_localizedErrors": {
+                "properties": {
+                  "en": {
+                    "value": []
+                  }
+                }
+              },
+              "nodeDescription": {
+                "value": "Validates that the user submitted the correct password for the account associated with the username"
+              }
+            },
+            "idUnique": "0re8wbsb52"
+          },
+          "position": {
+            "x": 1544,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ar0n0chx6u",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1094,
+            "y": 604
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "nf63ecqmal",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"An unexpected error has occurred\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Received an unexpected value"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected password state was received\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Unexpected password state\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Received an unexpected password state value from PingOne\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Received an unexpected value for the password status"
+              }
+            },
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 2347,
+            "y": 690
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "coc8d1r51c",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 2077,
+            "y": 540
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "6p6muqqewx",
+            "nodeType": "CONNECTION",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
+            "connectorId": "functionsConnector",
+            "name": "Functions",
+            "label": "Functions",
+            "status": "configured",
+            "capabilityName": "AEqualsMultipleB",
+            "type": "trigger",
+            "properties": {
+              "leftValueA": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingIdentity.svg\",\n        \"url\": \"status\",\n        \"data\": \"{{local.dnu7jt3sjz.payload.output.rawResponse.status}}\",\n        \"tooltip\": \"{{local.dnu7jt3sjz.payload.output.rawResponse.status}}\",\n        \"children\": [\n          {\n            \"text\": \"status\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "rightValueMultiple": {
+                "value": [
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"OK\"\n      }\n    ]\n  }\n]",
+                    "id": "s6l99t4t39"
+                  }
+                ]
+              },
+              "nodeTitle": {
+                "value": "Check Password Status"
+              },
+              "nodeDescription": {
+                "value": "Branches based on the password status returned by PingOne"
+              }
+            },
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1957,
+            "y": 420
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "scrsg9o0e2",
+            "nodeType": "CONNECTION",
+            "connectionId": "3566e86a35c26e575396dcfb89a3dcc0",
+            "connectorId": "nodeConnector",
+            "name": "Teleport",
+            "label": "Node [2023-01-09]",
+            "status": "configured",
+            "capabilityName": "goToNode",
+            "type": "action",
+            "properties": {
+              "nodeInstanceId": {
+                "value": "6wqbbgt0cf"
+              },
+              "nodeTitle": {
+                "value": "Go to Sign On Success"
+              },
+              "p1UserId": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingIdentity.svg\",\n        \"url\": \"id\",\n        \"data\": \"{{local.cqm26fxq1v.payload.output.matchedUser.id}}\",\n        \"tooltip\": \"{{local.cqm26fxq1v.payload.output.matchedUser.id}}\",\n        \"children\": [\n          {\n            \"text\": \"id\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            }
+          },
+          "position": {
+            "x": 2317,
+            "y": 450
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "t3gotwkiy8",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 2137,
+            "y": 630
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "1rlxa0u217",
+            "nodeType": "EVAL",
+            "properties": {
+              "79aiikhgtb": {
+                "value": "anyTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 1657,
+            "y": 540
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "dniadms1az",
+            "nodeType": "CONNECTION",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
+            "connectorId": "functionsConnector",
+            "name": "Functions",
+            "label": "Functions",
+            "status": "configured",
+            "capabilityName": "AEqualsMultipleB",
+            "type": "trigger",
+            "properties": {
+              "leftValueA": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"http.svg\",\n        \"url\": \"buttonValue\",\n        \"data\": \"{{local.65u7m8cm28.payload.output.buttonValue}}\",\n        \"tooltip\": \"{{local.65u7m8cm28.payload.output.buttonValue}}\",\n        \"children\": [\n          {\n            \"text\": \"buttonValue\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "rightValueB": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"submit\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Sign On Form Button Action"
+              },
+              "rightValueMultiple": {
+                "value": [
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"SIGNON\"\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]",
+                    "id": "vgii63uk2p"
+                  }
+                ]
+              },
+              "nodeDescription": {
+                "value": "Check which button was clicked"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 944,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "enx05mvp8c",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1064,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "79aiikhgtb",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"Invalid username and/or password\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Password check failed"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Failed to validate the password for the username submitted\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \" Invalid username and/or password\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Username was not found or password was invalid\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Failed to validate the submitted password"
+              }
+            },
+            "idUnique": "30gdqzg51v",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1657,
+            "y": 690
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "dpo5892st9",
+            "nodeType": "CONNECTION",
+            "connectionId": "3566e86a35c26e575396dcfb89a3dcc0",
+            "connectorId": "nodeConnector",
+            "name": "Teleport",
+            "label": "Node",
+            "status": "configured",
+            "capabilityName": "startNode",
+            "type": "trigger",
+            "properties": {
+              "inputSchema": {
+                "value": "{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"success\": {\n\t\t\t\"type\": \"boolean\",\n\t\t\t\"displayName\": \"success\",\n\t\t\t\"preferredControlType\": \"textField\",\n\t\t\t\"enableParameters\": true,\n\t\t\t\"propertyName\": \"success\"\n\t\t}\n\t}\n}"
+              },
+              "nodeTitle": {
+                "value": "Sign On Start"
+              }
+            }
+          },
+          "position": {
+            "x": 314,
+            "y": 304
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xyquoj2bnj",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 464,
+            "y": 304
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "cqm26fxq1v",
+            "nodeType": "CONNECTION",
+            "connectionId": "94141bf2f1b9b59a5f5365ff135e02bb",
+            "connectorId": "pingOneSSOConnector",
+            "name": "PingOne",
+            "label": "PingOne SSO",
+            "status": "configured",
+            "capabilityName": "userLookup",
+            "type": "action",
+            "properties": {
+              "identifier": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"http.svg\",\n        \"url\": \"username\",\n        \"data\": \"{{local.howu8n9hsc.payload.output.username}}\",\n        \"tooltip\": \"{{local.howu8n9hsc.payload.output.username}}\",\n        \"children\": [\n          {\n            \"text\": \"username\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "matchAttributes": {
+                "value": [
+                  "username"
+                ]
+              },
+              "nodeTitle": {
+                "value": "User Lookup"
+              },
+              "userLookup_localizedErrors": {
+                "properties": {
+                  "en": {
+                    "value": []
+                  }
+                }
+              },
+              "nodeDescription": {
+                "value": "Attempts to find the user in PingOne by the submitted username"
+              },
+              "userIdentifierForFindUser": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"http.svg\",\n        \"url\": \"username\",\n        \"data\": \"{{local.65u7m8cm28.payload.output.username}}\",\n        \"tooltip\": \"{{local.65u7m8cm28.payload.output.username}}\",\n        \"children\": [\n          {\n            \"text\": \"username\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "idUnique": "qdjikxg105"
+          },
+          "position": {
+            "x": 1244,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "flfi8l5inc",
+            "nodeType": "EVAL",
+            "properties": {
+              "dnu7jt3sjz": {
+                "value": "allTriggersTrue"
+              },
+              "79aiikhgtb": {
+                "value": "anyTriggersFalse"
+              },
+              "l9sribk1l0": {
+                "value": "anyTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 1364,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "usfhtwgo7x",
+            "nodeType": "EVAL",
+            "properties": {
+              "79aiikhgtb": {
+                "value": "anyTriggersFalse"
+              },
+              "83vu4kprq4": {
+                "value": "anyTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 1717,
+            "y": 390
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "pqu44gofi8",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 464,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "r7n4svgqft",
+            "nodeType": "CONNECTION",
+            "connectionId": "06922a684039827499bdbdd97f49827b",
+            "connectorId": "variablesConnector",
+            "name": "Variables",
+            "label": "Variables",
+            "status": "configured",
+            "capabilityName": "saveValue",
+            "type": "trigger",
+            "properties": {
+              "saveVariables": {
+                "value": [
+                  {
+                    "name": "companyLogo",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"https://assets.pingone.com/ux/ui-library/5.0.2/images/logo-pingidentity.png\"\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]",
+                    "key": 0.3651977481717872,
+                    "label": "companyLogo (string - flowInstance)",
+                    "type": "string"
+                  },
+                  {
+                    "name": "companyName",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Ping Identity\"\n      }\n    ]\n  }\n]",
+                    "key": 0.2827866731051578,
+                    "label": "companyName (string - flowInstance)",
+                    "type": "string"
+                  }
+                ]
+              },
+              "nodeTitle": {
+                "value": "companyName & companyLogo"
+              },
+              "nodeDescription": {
+                "value": "Set variables used in flow execution"
+              }
+            },
+            "idUnique": "mbb1ucl3yi",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 344,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "65u7m8cm28",
+            "nodeType": "CONNECTION",
+            "connectionId": "867ed4363b2bc21c860085ad2baa817d",
+            "connectorId": "httpConnector",
+            "name": "Http",
+            "label": "Http",
+            "status": "configured",
+            "capabilityName": "customHTMLTemplate",
+            "type": "trigger",
+            "properties": {
+              "textOne": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Welcome to \"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"variable.svg\",\n        \"url\": \"companyName\",\n        \"data\": \"{{global.variables.companyName}}\",\n        \"tooltip\": \"{{global.variables.companyName}}\",\n        \"children\": [\n          {\n            \"text\": \"companyName\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "customHTML": {
+                "value": "<div class=\"end-user-nano\">\n  <div\n    class=\"bg-light d-flex flex-column justify-content-center align-items-center position-absolute top-0 start-0 bottom-0 end-0 overflow-auto\">\n    <div style=\"max-width: 400px; min-width: 400px; width: 100%\">\n      <div class=\"card shadow mb-2\">\n        <main aria-labelledby=\"title\">\n          <div class=\"card-body p-5 d-flex flex-column\">\n            <img class=\"companyLogo align-self-center mb-5\" src=\"{{global.variables.companyLogo}}\" alt=\"{{global.variables.companyName}}\">\n\n            {{#if title}}\n            <h1 id=\"title\" class=\"text-center mb-4\">{{title}}</h1>\n            {{/if}}\n\n            {{#if textOne}}\n            <p class=\"text-muted text-center\">{{textOne}}</p>\n            {{/if}}\n\n            {{#if textTwo}}\n            <p class=\"text-muted text-center\">{{textTwo}}</p>\n            {{/if}}\n\n            <!-- Generic Error Message -->\n            <p class=\"text-danger mdi mdi-alert-circle text-center icon-padding\" id=\"feedbackError\" data-id=\"feedback\"\n              data-skcomponent=\"skerror\" aria-live=\"assertive\"></p>\n\n            <form id=\"signonForm\" aria-labelledby=\"title\" data-id=\"signonForm\">\n              <div class=\"mb-4 form-floating\">\n                <input class=\"form-control\" id=\"username\" name=\"username\" placeholder=\"Username\"\n                  autocomplete=\"\"  data-id=\"username-input\" aria-required=\"true\"\n                  aria-describedby=\"usernameLabel\" />\n                <label id=\"usernameLabel\" for=\"username\">Username</label>\n              </div>\n              <div id=\"passwordDiv\" class=\"mb-4 form-floating\">\n                <input class=\"form-control\" type=\"password\" id=\"password\" name=\"password\" placeholder=\"Password\"\n                  autocomplete=\"\" data-id=\"password-input\" aria-required=\"true\"\n                  aria-describedby=\"passwordLabel\" />\n                <label id=\"passwordLabel\" for=\"password\">Password</label>\n              </div>\n              <div class=\"d-flex flex-column\">\n                <button data-id=\"button\" type=\"submit\" class=\"btn btn-primary mb-3\" data-skcomponent=\"skbutton\"\n                  data-skbuttontype=\"form-submit\" id=\"btnSignIn\" data-skform=\"signonForm\"\n                  data-skbuttonvalue=\"SIGNON\">\n                  Sign On\n                </button>\n              </div>\n            </form>\n          </div>\n        </main>\n      </div>\n    </div>\n  </div>\n</div>\n"
+              },
+              "formFieldsList": {
+                "value": [
+                  {
+                    "preferredControlType": "textField",
+                    "preferredDataType": "string",
+                    "propertyName": "username",
+                    "displayName": "Username",
+                    "hashedVisibility": false,
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+                  },
+                  {
+                    "propertyName": "password",
+                    "preferredControlType": "textField",
+                    "preferredDataType": "string",
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]",
+                    "hashedVisibility": true,
+                    "displayName": "Password"
+                  },
+                  {
+                    "preferredControlType": "textField",
+                    "preferredDataType": "string",
+                    "propertyName": "buttonValue"
+                  }
+                ]
+              },
+              "nodeTitle": {
+                "value": "Sign On"
+              },
+              "customCSS": {
+                "value": ""
+              },
+              "validationRules": {
+                "value": []
+              },
+              "backgroundColor": {
+                "value": "#afd5ffff"
+              },
+              "customScript": {
+                "value": "const setFieldFocus = (id) => {\n    const element = document.getElementById(id);\n    if (element) {\n        element.focus();\n    }\n};\n\nconst makePasswordToggle = (id) => {\n    const container = document.getElementById(id);\n    if (container) {\n        const password = container.getElementsByTagName(\"input\")[0];\n        const toggler = document.createElement(\"button\");\n        toggler.setAttribute(\"type\", \"button\");\n        toggler.setAttribute(\"aria-label\", \"Show/Hide Password\");\n        toggler.className = \"btn mdi mdi-eye-off-outline position-absolute end-0 top-50 translate-middle-y\";\n        container.appendChild(toggler);\n\n        const showHidePassword = () => {\n            if (password.type === \"password\") {\n                password.type = \"text\";\n                toggler.classList.add(\"mdi-eye-outline\");\n                toggler.classList.remove(\"mdi-eye-off-outline\");\n            } else {\n                password.type = \"password\";\n                toggler.classList.add(\"mdi-eye-off-outline\");\n                toggler.classList.remove(\"mdi-eye-outline\");\n            }\n            password.focus();\n        };\n\n        toggler.addEventListener(\"click\", showHidePassword);\n    }\n};\n\nconst start = () => {\n    makePasswordToggle(\"passwordDiv\");\n    setFieldFocus(\"username\");\n};\n\nif (document.readyState === \"loading\") {\n    document.addEventListener(\"DOMContentLoaded\", start);\n} else {\n    start();\n}\n"
+              },
+              "inputSchema": {
+                "value": "{\n  \"type\": \"object\",\n  \"properties\": {\n    \"title\": {\n      \"type\": \"string\",\n      \"displayName\": \"Title\",\n      \"preferredControlType\": \"textField\",\n      \"enableParameters\": true,\n      \"propertyName\": \"title\"\n    },\n    \"textOne\": {\n      \"type\": \"string\",\n      \"displayName\": \"Text One\",\n      \"preferredControlType\": \"textField\",\n      \"enableParameters\": true,\n      \"propertyName\": \"textOne\"\n    },\n    \"textTwo\": {\n      \"type\": \"string\",\n      \"displayName\": \"Text Two\",\n      \"preferredControlType\": \"textField\",\n      \"enableParameters\": true,\n      \"propertyName\": \"textTwo\"\n    }\n  }\n}"
+              },
+              "outputSchema": {
+                "value": {}
+              },
+              "title": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Sign On\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Enter username and password"
+              }
+            },
+            "isDisabled": false
+          },
+          "position": {
+            "x": 667,
+            "y": 450
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ww8avrzf7x",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 764,
+            "y": 424
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "4xpprmwyrf",
+            "nodeType": "CONNECTION",
+            "connectionId": "c3e6a164bde107954e93f5c09f0c8bce",
+            "connectorId": "pingOneAuthenticationConnector",
+            "name": "PingOne Authentication",
+            "label": "PingOne Authentication",
+            "status": "configured",
+            "capabilityName": "returnSuccessResponseRedirect",
+            "type": "action",
+            "properties": {
+              "userId": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"teleport.svg\",\n        \"url\": \"p1UserId\",\n        \"data\": \"{{local.6wqbbgt0cf.payload.output.p1UserId}}\",\n        \"tooltip\": \"{{local.6wqbbgt0cf.payload.output.p1UserId}}\",\n        \"children\": [\n          {\n            \"text\": \"p1UserId\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "authenticationMethods": {
+                "value": "pwd"
+              },
+              "idleTimeout": {
+                "value": 43200
+              },
+              "backgroundColor": {
+                "value": "#9dc967ff"
+              },
+              "nodeTitle": {
+                "value": "Return success"
+              },
+              "nodeDescription": {
+                "value": "Returns successful flow completion back to the PingOne application connection"
+              },
+              "overrideAuthState": {
+                "value": true
+              }
+            }
+          },
+          "position": {
+            "x": 1740,
+            "y": 870
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "4qr3a1ly6i",
+            "connectionId": "c3e6a164bde107954e93f5c09f0c8bce",
+            "nodeType": "CONNECTION",
+            "status": "configured",
+            "connectorId": "pingOneAuthenticationConnector",
+            "name": "PingOne Authentication",
+            "label": "PingOne Authentication",
+            "type": "action",
+            "capabilityName": "authorizeUserCode",
+            "properties": {
+              "idleTimeout": {
+                "value": 43200
+              },
+              "userId": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"teleport.svg\",\n        \"url\": \"p1UserId\",\n        \"data\": \"{{local.6wqbbgt0cf.payload.output.p1UserId}}\",\n        \"tooltip\": \"{{local.6wqbbgt0cf.payload.output.p1UserId}}\",\n        \"children\": [\n          {\n            \"text\": \"p1UserId\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "userCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingone-forms.svg\",\n        \"url\": \"device-code\",\n        \"data\": \"{{local.am4o18ij24.payload.output.formData.device-code}}\",\n        \"tooltip\": \"{{local.am4o18ij24.payload.output.formData.device-code}}\",\n        \"children\": [\n          {\n            \"text\": \"device-code\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "authenticationMethods": {
+                "value": "pwd"
+              },
+              "overrideAuthState": {
+                "value": true
+              }
+            }
+          },
+          "position": {
+            "x": 1260,
+            "y": 990
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "am4o18ij24",
+            "connectionId": "eb6a94a33f2f479eff234e8fa5049459",
+            "nodeType": "CONNECTION",
+            "status": "configured",
+            "connectorId": "pingOneFormsConnector",
+            "name": "Form",
+            "label": "PingOne Forms",
+            "type": "action",
+            "capabilityName": "customForm",
+            "properties": {
+              "formData": {
+                "value": [
+                  {
+                    "key": "device-code",
+                    "value": "[{\"children\":[{\"text\":\"\"},{\"text\":\"{{global.parameters.authorizationRequest.user_code}}\"},{\"text\":\"\"}]}]"
+                  }
+                ]
+              },
+              "dynamicText": {
+                "value": []
+              },
+              "form": {
+                "value": "0444b814-30d9-4b0d-9f2a-eb8ffd8bc719"
+              },
+              "nodeTitle": {
+                "value": "Device Code"
+              }
+            },
+            "capabilityClass": "render"
+          },
+          "position": {
+            "x": 570,
+            "y": 1080
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "99ej63dg08",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 397,
+            "y": 1020
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "6wqbbgt0cf",
+            "nodeType": "CONNECTION",
+            "connectionId": "3566e86a35c26e575396dcfb89a3dcc0",
+            "connectorId": "nodeConnector",
+            "name": "Teleport",
+            "label": "Node [2023-01-09]",
+            "status": "configured",
+            "capabilityName": "startNode",
+            "type": "trigger",
+            "properties": {
+              "inputSchema": {
+                "value": "{\n\t\"type\": \"object\",\n\t\"properties\": {\n\t\t\"p1UserId\": {\n\t\t\t\"type\": \"string\",\n\t\t\t\"displayName\": \"PingOne User Id\",\n\t\t\t\"preferredControlType\": \"textField\",\n\t\t\t\"enableParameters\": true,\n\t\t\t\"propertyName\": \"p1UserId\"\n\t\t}\n\t}\n}"
+              },
+              "nodeTitle": {
+                "value": "Device Authorization"
+              }
+            },
+            "idUnique": "51gprf5c44"
+          },
+          "position": {
+            "x": 277,
+            "y": 990
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "fbo0gxgvh3",
+            "nodeType": "EVAL",
+            "properties": {
+              "hinf4hsv40": {
+                "value": "anyTriggersFalse"
+              }
+            }
+          },
+          "position": {
+            "x": 1440,
+            "y": 960
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "hinf4hsv40",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"Device Authorization Failed (invalid user code)\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Invalid user code"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Failed to authorize device (invalid user code)\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \" Invalid username and/or password\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Invalid device code\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Failed to validate the user code"
+              }
+            },
+            "idUnique": "32vajj3oxi",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1740,
+            "y": 1050
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ak1po42jji",
+            "nodeType": "CONNECTION",
+            "connectionId": "de650ca45593b82c49064ead10b9fe17",
+            "connectorId": "functionsConnector",
+            "name": "Functions",
+            "label": "Functions",
+            "status": "configured",
+            "capabilityName": "AEqualsMultipleB",
+            "type": "trigger",
+            "properties": {
+              "leftValueA": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingone-forms.svg\",\n        \"url\": \"buttonValue\",\n        \"data\": \"{{local.am4o18ij24.payload.output.event.buttonValue}}\",\n        \"tooltip\": \"{{local.am4o18ij24.payload.output.event.buttonValue}}\",\n        \"children\": [\n          {\n            \"text\": \"buttonValue\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              },
+              "rightValueB": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"submit\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Sign On Form Button Action"
+              },
+              "rightValueMultiple": {
+                "value": [
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"button-approve\"\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]",
+                    "id": "vgii63uk2p"
+                  },
+                  {
+                    "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"button-\"\n      },\n      {\n        \"text\": \"reject\"\n      }\n    ]\n  }\n]",
+                    "id": "ubbqs3xo9r"
+                  }
+                ]
+              },
+              "nodeDescription": {
+                "value": "Check which button was clicked"
+              }
+            },
+            "isDisabled": false,
+            "capabilityClass": "backend",
+            "idUnique": "9oicffd4od"
+          },
+          "position": {
+            "x": 930,
+            "y": 1050
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "lq4c2z9b3p",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 720,
+            "y": 1080
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zmu945r3an",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected error has occurred\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Received an unexpected value"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Could not determine which button was selected\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Unexpected value received\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"An unexpected value was received for button selection\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "Received an unexpected value for the button selected to submit the form"
+              }
+            },
+            "idUnique": "j4hakprse3",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1230,
+            "y": 1350
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "16kq9hnuss",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1080,
+            "y": 1350
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "92z1olggw0",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1080,
+            "y": 1050
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "d8pteq7u4o",
+            "connectionId": "c3e6a164bde107954e93f5c09f0c8bce",
+            "nodeType": "CONNECTION",
+            "status": "configured",
+            "connectorId": "pingOneAuthenticationConnector",
+            "name": "PingOne Authentication",
+            "label": "PingOne Authentication",
+            "type": "action",
+            "capabilityName": "declineUserCode",
+            "properties": {
+              "userCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"type\": \"link\",\n        \"src\": \"pingone-forms.svg\",\n        \"url\": \"device-code\",\n        \"data\": \"{{local.am4o18ij24.payload.output.formData.device-code}}\",\n        \"tooltip\": \"{{local.am4o18ij24.payload.output.formData.device-code}}\",\n        \"children\": [\n          {\n            \"text\": \"device-code\"\n          }\n        ]\n      },\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"\"\n      }\n    ]\n  }\n]"
+              }
+            },
+            "idUnique": "mj6cddpkze"
+          },
+          "position": {
+            "x": 1260,
+            "y": 1200
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "tqezjfaxui",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1080,
+            "y": 1200
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "6v4ccrn421",
+            "nodeType": "CONNECTION",
+            "connectionId": "53ab83a4a4ab919d9f2cb02d9e111ac8",
+            "connectorId": "errorConnector",
+            "name": "Error Message",
+            "label": "Error Customize",
+            "status": "configured",
+            "capabilityName": "customErrorMessage",
+            "type": "action",
+            "properties": {
+              "errorMessage": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \"Device Authorization Rejected\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeTitle": {
+                "value": "Decline device authorization"
+              },
+              "errorDescription": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"User rejected device authorization\"\n      }\n    ]\n  }\n]"
+              },
+              "errorCode": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"\"\n      },\n      {\n        \"text\": \" Invalid username and/or password\"\n      }\n    ]\n  }\n]"
+              },
+              "errorReason": {
+                "value": "[\n  {\n    \"children\": [\n      {\n        \"text\": \"Invalid device code\"\n      }\n    ]\n  }\n]"
+              },
+              "nodeDescription": {
+                "value": "User declines device authorization"
+              }
+            },
+            "idUnique": "xqyqrlskxy",
+            "capabilityClass": "backend"
+          },
+          "position": {
+            "x": 1590,
+            "y": 1230
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "l4sprd82cr",
+            "nodeType": "EVAL"
+          },
+          "position": {
+            "x": 1395,
+            "y": 1200
+          },
+          "group": "nodes",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": false,
+          "classes": ""
+        }
+      ],
+      "edges": [
+        {
+          "data": {
+            "id": "gowc6cwx0j",
+            "source": "l4sprd82cr",
+            "target": "6v4ccrn421"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zry8hun03e",
+            "source": "pqu44gofi8",
+            "target": "65u7m8cm28"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "5v06y7u1rh",
+            "source": "fbo0gxgvh3",
+            "target": "4xpprmwyrf"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "qh6av93fvo",
+            "source": "4qr3a1ly6i",
+            "target": "fbo0gxgvh3"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "naz76y4du7",
+            "source": "ww8avrzf7x",
+            "target": "dniadms1az"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "efdeqd0o6a",
+            "source": "6wqbbgt0cf",
+            "target": "99ej63dg08"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "74ml03abbl",
+            "source": "99ej63dg08",
+            "target": "am4o18ij24"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "j4a8prxlin",
+            "source": "fbo0gxgvh3",
+            "target": "hinf4hsv40"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "zfc5msz1fd",
+            "source": "ar0n0chx6u",
+            "target": "0mkskx7cez"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "2prwok64ky",
+            "source": "dpo5892st9",
+            "target": "xyquoj2bnj"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "vav60pvoe0",
+            "source": "dnu7jt3sjz",
+            "target": "usfhtwgo7x"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "gbbc1gk3j3",
+            "source": "flfi8l5inc",
+            "target": "79aiikhgtb"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "a92evago2f",
+            "source": "flfi8l5inc",
+            "target": "dnu7jt3sjz"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xow1pai316",
+            "source": "6p6muqqewx",
+            "target": "t3gotwkiy8",
+            "multiValueSourceId": "-1"
+          },
+          "position": {
+            "x": 64,
+            "y": 92
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "j2rw7ieefg",
+            "source": "t3gotwkiy8",
+            "target": "nf63ecqmal"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "xiryepnjg3",
+            "source": "dniadms1az",
+            "target": "ar0n0chx6u",
+            "multiValueSourceId": "-1"
+          },
+          "position": {
+            "x": 64,
+            "y": 92
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "ul2vtbic0g",
+            "source": "coc8d1r51c",
+            "target": "scrsg9o0e2"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "p3xtyleneh",
+            "source": "r7n4svgqft",
+            "target": "pqu44gofi8"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "348vadbb4j",
+            "source": "dnu7jt3sjz",
+            "target": "1rlxa0u217"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "p57p3kbioo",
+            "source": "dniadms1az",
+            "target": "enx05mvp8c",
+            "multiValueSourceId": "vgii63uk2p"
+          },
+          "position": {
+            "x": 64,
+            "y": 52
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "8cp4eninbl",
+            "source": "cqm26fxq1v",
+            "target": "flfi8l5inc"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "k4ae67mny2",
+            "source": "65u7m8cm28",
+            "target": "ww8avrzf7x"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "tndis7tgip",
+            "source": "dpo5892st9",
+            "target": "xyquoj2bnj"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "8wpjy5fr4m",
+            "source": "usfhtwgo7x",
+            "target": "6p6muqqewx"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "7shinfbm42",
+            "source": "6p6muqqewx",
+            "target": "coc8d1r51c",
+            "multiValueSourceId": "s6l99t4t39"
+          },
+          "position": {
+            "x": 64,
+            "y": 52
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "a92at8wmwy",
+            "source": "1rlxa0u217",
+            "target": "79aiikhgtb"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "0i3tkbyy8b",
+            "source": "enx05mvp8c",
+            "target": "cqm26fxq1v"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "w9e0rakj65",
+            "source": "xyquoj2bnj",
+            "target": "65u7m8cm28"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "i6lud58ymq",
+            "source": "dpo5892st9",
+            "target": "xyquoj2bnj"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "8ldsm7shne",
+            "source": "am4o18ij24",
+            "target": "lq4c2z9b3p"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "0660n0fj39",
+            "source": "lq4c2z9b3p",
+            "target": "ak1po42jji"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "rdbph6ephk",
+            "source": "ak1po42jji",
+            "target": "16kq9hnuss",
+            "multiValueSourceId": "-1"
+          },
+          "position": {
+            "x": 64,
+            "y": 132
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "nom5xfizxq",
+            "source": "16kq9hnuss",
+            "target": "zmu945r3an"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "hbikd4b2pc",
+            "source": "ak1po42jji",
+            "target": "92z1olggw0",
+            "multiValueSourceId": "vgii63uk2p"
+          },
+          "position": {
+            "x": 64,
+            "y": 52
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "5qrb9fzrh4",
+            "source": "92z1olggw0",
+            "target": "4qr3a1ly6i"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "i1masusc5j",
+            "source": "ak1po42jji",
+            "target": "tqezjfaxui",
+            "multiValueSourceId": "ubbqs3xo9r"
+          },
+          "position": {
+            "x": 64,
+            "y": 92
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "wuz95a1l3c",
+            "source": "tqezjfaxui",
+            "target": "d8pteq7u4o"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        },
+        {
+          "data": {
+            "id": "x0sr7i0sgu",
+            "source": "d8pteq7u4o",
+            "target": "l4sprd82cr"
+          },
+          "position": {
+            "x": 0,
+            "y": 0
+          },
+          "group": "edges",
+          "removed": false,
+          "selected": false,
+          "selectable": true,
+          "locked": false,
+          "grabbable": true,
+          "pannable": true,
+          "classes": ""
+        }
+      ]
+    },
+    "data": {},
+    "zoomingEnabled": true,
+    "userZoomingEnabled": true,
+    "zoom": 1,
+    "minZoom": 1e-50,
+    "maxZoom": 1e+50,
+    "panningEnabled": true,
+    "userPanningEnabled": true,
+    "pan": {
+      "x": 0,
+      "y": 0
+    },
+    "boxSelectionEnabled": true,
+    "renderer": {
+      "name": "null"
+    }
+  },
+  "inputSchema": [],
+  "flowColor": "#CACED3",
+  "savedDate": 1781026593214,
+  "variables": [
+    {
+      "context": "flowInstance",
+      "createdDate": 1777929309378,
+      "fields": {
+        "type": "string",
+        "displayName": "Url for company's logo image",
+        "mutable": true,
+        "min": 0,
+        "max": 2000,
+        "sizeInBytes": 0
+      },
+      "id": "18aad499-0823-42e3-bc1a-ebff78f8432b",
+      "type": "property",
+      "visibility": "private",
+      "name": "companyLogo##SK##flowInstance",
+      "companyId": "300c4f2a-39d4-4ba9-a18a-f6de246006f4"
+    },
+    {
+      "context": "flowInstance",
+      "createdDate": 1777929309377,
+      "fields": {
+        "type": "string",
+        "displayName": "",
+        "mutable": true,
+        "min": 0,
+        "max": 2000,
+        "sizeInBytes": 0
+      },
+      "id": "b85921bf-bd61-4f4a-bed3-63458005122b",
+      "type": "property",
+      "visibility": "private",
+      "name": "companyName##SK##flowInstance",
+      "companyId": "300c4f2a-39d4-4ba9-a18a-f6de246006f4"
+    }
+  ],
+  "forms": {
+    "0444b814-30d9-4b0d-9f2a-eb8ffd8bc719": {
+      "id": "0444b814-30d9-4b0d-9f2a-eb8ffd8bc719",
+      "environment": {
+        "id": "300c4f2a-39d4-4ba9-a18a-f6de246006f4"
+      },
+      "name": "Automation - Device Code",
+      "description": "",
+      "category": "CUSTOM",
+      "components": {
+        "fields": [
+          {
+            "type": "ERROR_DISPLAY",
+            "position": {
+              "row": 0,
+              "col": 0
+            }
+          },
+          {
+            "type": "TEXT",
+            "position": {
+              "row": 1,
+              "col": 0
+            },
+            "key": "device-code",
+            "label": "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Device Code\"}]}]",
+            "required": true,
+            "validation": {
+              "type": "NONE",
+              "regex": "",
+              "errorMessage": ""
+            },
+            "otherOptionEnabled": false,
+            "otherOptionAttributeDisabled": false,
+            "attributeDisabled": false
+          },
+          {
+            "type": "FLOW_BUTTON",
+            "position": {
+              "row": 2,
+              "col": 0
+            },
+            "key": "button-approve",
+            "label": "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Approve Device\"}]}]"
+          },
+          {
+            "type": "FLOW_BUTTON",
+            "position": {
+              "row": 3,
+              "col": 0
+            },
+            "key": "button-reject",
+            "label": "[{\"type\":\"paragraph\",\"children\":[{\"text\":\"Reject Device\"}]}]"
+          }
+        ]
+      },
+      "cols": 4,
+      "markOptional": true,
+      "markRequired": false,
+      "textAutoCompleteEnabled": false,
+      "passwordAutoCompleteEnabled": false,
+      "translationMethod": "TRANSLATE",
+      "created": "2026-06-08T19:54:57.051Z",
+      "modified": "2026-06-09T17:31:14.065Z",
+      "readOnly": false
+    }
+  },
+  "connections": []
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -48,11 +48,11 @@ class FormFieldValidationTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-            discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.davinciFormClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciFormDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
+            redirectUri = DaVinciTestConfig.davinciRedirectUri
+            acrValues = DaVinciTestConfig.davinciFormFieldsAcrValues
             //storage = dataStore
         }
     }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -65,11 +65,11 @@ class FormFieldsTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-            discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.davinciFormClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciFormDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "b63ac7fb5db6d893efdd5e29d06a7477"
+            redirectUri = DaVinciTestConfig.davinciRedirectUri
+            acrValues = DaVinciTestConfig.davinciFormFieldsAcrValues
             //storage = dataStore
         }
     }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormMFADevicesTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormMFADevicesTest.kt
@@ -49,11 +49,11 @@ class FormMFADevicesTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "021b83ce-a9b1-4ad4-8c1d-79e576eeab76"
-            discoveryEndpoint = "https://auth.pingone.ca/02fb4743-189a-4bc7-9d6c-a919edfe6447/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.davinciClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "1557008a3c8b6105d5f4e8e053ac7a29"
+            redirectUri = DaVinciTestConfig.davinciRedirectUri
+            acrValues = DaVinciTestConfig.davinciMfaAcrValues
         }
     }
 
@@ -78,7 +78,7 @@ class FormMFADevicesTest {
     @BeforeTest
     fun setUp() = runTest {
         usernamePrefix = "MFA"
-        password = "Demo1234#1"
+        password = DaVinciTestConfig.davinciPassword
         username = usernamePrefix + System.currentTimeMillis() + "@example.com"
         userFname = "GAGA"
         userLname = "User"

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -48,11 +48,11 @@ class PollingCollectorE2ETests {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-            discoveryEndpoint = "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+            clientId = DaVinciTestConfig.davinciFormClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciFormDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
-            redirectUri = "org.forgerock.demo://oauth2redirect"
-            acrValues = "fae6bc3d08a5c4f5b8ff95175b117278"
+            redirectUri = DaVinciTestConfig.davinciRedirectUri
+            acrValues = DaVinciTestConfig.davinciPollingAcrValues
         }
     }
 

--- a/davinci/src/main/assets/davinci_test_config.properties
+++ b/davinci/src/main/assets/davinci_test_config.properties
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+#
+# This software may be modified and distributed under the terms
+# of the MIT license. See the LICENSE file for details.
+#
+# DaVinci e2e test configuration.
+# At CI time this file is overwritten by the DAVINCI_E2E_CONFIG secret.
+# Locally, fill in the values below to run the tests against your own environment.
+#
+
+# -- Tenant / environment shared across most test suites ----------------------
+DAVINCI_DISCOVERY_ENDPOINT=
+DAVINCI_REDIRECT_URI=
+
+# -- DaVinci E2E (DavinciAndroidTest, FormMFADevicesTest, DavinciProtectTest) -
+DAVINCI_CLIENT_ID=
+
+# -- Form field tests (FormFieldsTest, FormFieldValidationTest, PollingCollectorE2ETests) -
+DAVINCI_FORM_DISCOVERY_ENDPOINT=
+DAVINCI_FORM_CLIENT_ID=
+
+# -- ACR values (one per DaVinci flow / policy) -------------------------------
+DAVINCI_ACR_VALUES=
+DAVINCI_PROTECT_ACR_VALUES=
+DAVINCI_MFA_ACR_VALUES=
+DAVINCI_FORM_FIELDS_ACR_VALUES=
+DAVINCI_POLLING_ACR_VALUES=
+
+# -- Credentials --------------------------------------------------------------
+DAVINCI_USERNAME=
+DAVINCI_PASSWORD=
+DAVINCI_VERIFICATION_CODE=
+DAVINCI_PROTECT_USERNAME=
+DAVINCI_PROTECT_PASSWORD=
+
+# -- Device Authorization Grant (DeviceAuthorizationTest) ---------------------
+DEVICE_CLIENT_ID=
+DEVICE_DISCOVERY_ENDPOINT=
+DEVICE_APPROVER_CLIENT_ID=
+DEVICE_APPROVER_DISCOVERY_ENDPOINT=
+DEVICE_APPROVER_REDIRECT_URI=
+DEVICE_APPROVER_ACR_VALUES=
+DEVICE_USERNAME=
+DEVICE_PASSWORD=


### PR DESCRIPTION
## JIRA

[SDKS-4783](https://pingidentity.atlassian.net/browse/SDKS-4783) QA for Device Authorization Grant Support

## Summary

- Adds `DeviceAuthorizationTest.kt` — four instrumented E2E tests covering the device authorization grant flow (RFC 8628) against the PingOne/DaVinci test tenant:
  - **TC-01** (`startFlowEmitsStartedThenPolling`) — verifies `DeviceAuthorizationResponse` fields (user code format, verification URI, interval) and that polling starts; cancelled after the first `Polling` emission to keep the test under ~10 s
  - **TC-02** (`deviceAuthorizationApprovalViaDaVinci`) — full happy-path approval: DaVinci login → Approve Device → `DeviceFlowStatus.Success` with a valid stored token
  - **TC-03** (`deviceAuthorizationRejectedViaDaVinci`) — rejection path: DaVinci login → Reject Device → `ErrorNode` on approver side → `DeviceFlowStatus.AccessDenied` on requesting side, no token stored
  - **TC-04** (`deviceCodeExpiresWithoutApproval`) — expiry path; annotated `@Ignore` to avoid ~30 s runtime in CI, enable manually when testing expiry behaviour
- Adds `DeviceAuthorizationTestFlow.json` — DaVinci flow export used by TC-02 and TC-03


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Android end-to-end tests for the OAuth2 Device Authorization flow: start, polling, approval, rejection, and expiry scenarios; tests clear state between roles.
* **New Features**
  * Added a device-authorization UI/flow for device code entry and approve/reject interactions, including rich sign-on steps.
* **Chores**
  * Added a test config template and updated CI/workflows to supply it and prepare/publish the debug app artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->