### PR TITLE
[fix] SDKS-5074 Introduce InvalidUriException in mfa-commons for typed OATH URI parse errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ xcuserdata
 .kotlin
 .polaris/
 .claude/settings.local.json
+.sdk/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 #### Fixed
-- Fixed OATH URI parser to throw typed `InvalidUriException` instead of generic `IllegalArgumentException` for structural URI errors [SDKS-5074]
+- Fixed OATH and Push URI parsers to propagate typed `InvalidUriException` for structural URI parse errors [SDKS-5074]
 
 ## [2.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+#### Fixed
+- Fixed OATH URI parser to throw typed `InvalidUriException` instead of generic `IllegalArgumentException` for structural URI errors [SDKS-5074]
+
 ## [2.0.1]
 
 #### Fixed

--- a/mfa/commons/src/main/kotlin/com/pingidentity/mfa/commons/UriParser.kt
+++ b/mfa/commons/src/main/kotlin/com/pingidentity/mfa/commons/UriParser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,7 @@
 package com.pingidentity.mfa.commons
 
 import android.util.Base64
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 
 /**
  * Base class for URI parsers with common functionality.
@@ -43,7 +44,7 @@ abstract class UriParser {
                 val labelIssuer = labelComponents[0]
                 if (issuerParam != null && labelIssuer.isNotEmpty() && 
                     !issuerParam.equals(labelIssuer, ignoreCase = true)) {
-                    throw IllegalArgumentException("Issuer parameter ($issuerParam) doesn't match label issuer ($labelIssuer)")
+                    throw InvalidUriException("Issuer parameter ($issuerParam) doesn't match label issuer ($labelIssuer)")
                 }
                 
                 // Use the label issuer if it exists, otherwise use the parameter

--- a/mfa/commons/src/main/kotlin/com/pingidentity/mfa/commons/exception/MfaException.kt
+++ b/mfa/commons/src/main/kotlin/com/pingidentity/mfa/commons/exception/MfaException.kt
@@ -97,6 +97,22 @@ class MfaPolicyViolationException(
 ) : MfaException(message, cause)
 
 /**
+ * Exception thrown when an MFA URI is structurally invalid or cannot be parsed.
+ *
+ * Reusable across OATH and Push URI parsers. Thrown for scheme mismatches, unrecognised
+ * OATH types, missing required parameters (e.g. `secret`), issuer/label mismatches, and
+ * any other structural parse failures. Value-validation errors (e.g. `digits` out of
+ * range) remain as [IllegalArgumentException] at the throw site.
+ *
+ * @param message A human-readable description of the parse failure.
+ * @param cause The underlying cause of the exception, if any.
+ */
+class InvalidUriException(
+    message: String? = null,
+    cause: Throwable? = null
+) : MfaException(message, cause)
+
+/**
  * Exception thrown when attempting to register a credential that already exists.
  * 
  * This exception is thrown when a credential with the same issuer and account name

--- a/mfa/oath/src/main/kotlin/com/pingidentity/mfa/oath/OathCredential.kt
+++ b/mfa/oath/src/main/kotlin/com/pingidentity/mfa/oath/OathCredential.kt
@@ -19,6 +19,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import com.pingidentity.mfa.commons.json
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 import java.util.Date
 import java.util.UUID
 
@@ -113,7 +114,8 @@ data class OathCredential(
          *
          * @param uri The URI string.
          * @return An OathCredential.
-         * @throws IllegalArgumentException if the URI is invalid.
+         * @throws InvalidUriException if the URI is structurally invalid (scheme mismatch, missing required parameters).
+         * @throws IllegalArgumentException if a URI parameter value fails validation (e.g. digits not 6 or 8, period ≤ 0).
          */
         suspend fun fromUri(uri: String): OathCredential {
             return OathUriParser.parse(uri)

--- a/mfa/oath/src/main/kotlin/com/pingidentity/mfa/oath/OathUriParser.kt
+++ b/mfa/oath/src/main/kotlin/com/pingidentity/mfa/oath/OathUriParser.kt
@@ -9,6 +9,7 @@ package com.pingidentity.mfa.oath
 
 import android.net.Uri
 import com.pingidentity.mfa.commons.UriParser
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -44,7 +45,10 @@ object OathUriParser : UriParser() {
      *
      * @param uri The URI string.
      * @return An OathCredential.
-     * @throws IllegalArgumentException if the URI is invalid.
+     * @throws InvalidUriException if the URI is structurally invalid (bad scheme, unknown OATH type,
+     *   missing required parameters, or any unexpected parse failure).
+     * @throws IllegalArgumentException if a parameter value fails validation (e.g. digits not 6 or 8,
+     *   period ≤ 0, counter < 0).
      */
     suspend fun parse(uri: String): OathCredential = withContext(Dispatchers.IO) {
         try {
@@ -53,14 +57,14 @@ object OathUriParser : UriParser() {
             // Check scheme
             val scheme = parsedUri.scheme?.lowercase() ?: ""
             if (scheme != OTPAUTH_SCHEME && scheme != MFAUTH_SCHEME) {
-                throw IllegalArgumentException("Invalid URI scheme: $scheme, expected: $OTPAUTH_SCHEME or $MFAUTH_SCHEME")
+                throw InvalidUriException("Invalid URI scheme: $scheme, expected: $OTPAUTH_SCHEME or $MFAUTH_SCHEME")
             }
             
             // Get type
             val type = when (val typeStr = parsedUri.authority?.lowercase()) {
                 TOTP -> OathType.TOTP
                 HOTP -> OathType.HOTP
-                else -> throw IllegalArgumentException("Invalid OATH type: $typeStr, expected: $TOTP or $HOTP")
+                else -> throw InvalidUriException("Invalid OATH type: $typeStr, expected: $TOTP or $HOTP")
             }
             
             // Parse label (path without leading '/')
@@ -79,7 +83,7 @@ object OathUriParser : UriParser() {
             
             // Get required parameters
             val secret = parsedUri.getQueryParameter(SECRET_PARAM)
-                ?: throw IllegalArgumentException("Missing required parameter: $SECRET_PARAM")
+                ?: throw InvalidUriException("Missing required parameter: $SECRET_PARAM")
 
             // Get optional parameters or use defaults
             val algorithmStr = parsedUri.getQueryParameter(ALGORITHM_PARAM)?.uppercase() ?: DEFAULT_ALGORITHM
@@ -163,10 +167,10 @@ object OathUriParser : UriParser() {
             )
         } catch (e: Exception) {
             coroutineContext.ensureActive()
-            if (e is IllegalArgumentException) {
+            if (e is InvalidUriException || e is IllegalArgumentException) {
                 throw e
             } else {
-                throw IllegalArgumentException("Invalid OATH URI: $uri", e)
+                throw InvalidUriException("Invalid OATH URI: $uri", e)
             }
         }
     }

--- a/mfa/oath/src/test/kotlin/com/pingidentity/mfa/oath/OathCredentialTest.kt
+++ b/mfa/oath/src/test/kotlin/com/pingidentity/mfa/oath/OathCredentialTest.kt
@@ -7,6 +7,7 @@
 
 package com.pingidentity.mfa.oath
 
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -164,9 +165,14 @@ class OathCredentialTest {
         assertNotNull(credential.id)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test
     fun `test from URI with invalid scheme`() = runTest {
-        OathCredential.fromUri("invalid://totp/Test%20Issuer:testuser@example.com?secret=JBSWY3DPEHPK3PXP")
+        try {
+            OathCredential.fromUri("invalid://totp/Test%20Issuer:testuser@example.com?secret=JBSWY3DPEHPK3PXP")
+            fail("Expected InvalidUriException for invalid scheme")
+        } catch (e: InvalidUriException) {
+            assertTrue(e.message?.contains("scheme") == true)
+        }
     }
 
     @Test

--- a/mfa/oath/src/test/kotlin/com/pingidentity/mfa/oath/OathUriParserTest.kt
+++ b/mfa/oath/src/test/kotlin/com/pingidentity/mfa/oath/OathUriParserTest.kt
@@ -7,12 +7,16 @@
 
 package com.pingidentity.mfa.oath
 
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
-import org.junit.Test
+import com.pingidentity.mfa.commons.exception.InvalidUriException
+import com.pingidentity.mfa.commons.exception.MfaException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
+import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -236,5 +240,109 @@ class OathUriParserTest {
         assertEquals(6, credential.digits)
         assertEquals(1, credential.period)
     }
-    
+
+    // --- Task 4.1: InvalidUriException thrown for URI-structure failures ---
+
+    @Test
+    fun `test parse URI with invalid scheme throws InvalidUriException`() = runTest {
+        val uri = "https://totp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+        try {
+            OathUriParser.parse(uri)
+            fail("Expected InvalidUriException for invalid scheme")
+        } catch (e: InvalidUriException) {
+            assertNotNull(e.message)
+        }
+    }
+
+    @Test
+    fun `test parse URI with invalid OATH type throws InvalidUriException`() = runTest {
+        val uri = "otpauth://wrong/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+        try {
+            OathUriParser.parse(uri)
+            fail("Expected InvalidUriException for invalid OATH type")
+        } catch (e: InvalidUriException) {
+            assertNotNull(e.message)
+        }
+    }
+
+    @Test
+    fun `test parse URI with missing secret throws InvalidUriException`() = runTest {
+        val uri = "otpauth://totp/Example:alice@example.com?issuer=Example"
+        try {
+            OathUriParser.parse(uri)
+            fail("Expected InvalidUriException for missing secret")
+        } catch (e: InvalidUriException) {
+            assertNotNull(e.message)
+        }
+    }
+
+    @Test
+    fun `test parse URI with issuer label mismatch throws InvalidUriException`() = runTest {
+        // Label says "A" but issuer param says "B" — parseLabelComponents raises InvalidUriException
+        val uri = "otpauth://totp/A:bob@example.com?secret=JBSWY3DPEHPK3PXP&issuer=B"
+        try {
+            OathUriParser.parse(uri)
+            fail("Expected InvalidUriException for issuer/label mismatch")
+        } catch (e: InvalidUriException) {
+            assertNotNull(e.message)
+        }
+    }
+
+    // --- Task 4.2: Family consistency and split-boundary regression ---
+
+    @Test
+    fun `InvalidUriException is catchable as MfaException`() = runTest {
+        val uri = "https://totp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example"
+        var caught: Exception? = null
+        try {
+            OathUriParser.parse(uri)
+        } catch (e: MfaException) {
+            caught = e
+        }
+        assertNotNull("Expected MfaException to be thrown", caught)
+        assertTrue(
+            "InvalidUriException must be an instance of MfaException",
+            caught is InvalidUriException,
+        )
+    }
+
+    @Test
+    fun `value-validation failures are IllegalArgumentException and not InvalidUriException`() = runTest {
+        // digits violation
+        val digitsUri = "otpauth://totp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&digits=7"
+        var digitsEx: Exception? = null
+        try {
+            OathUriParser.parse(digitsUri)
+        } catch (e: Exception) {
+            digitsEx = e
+        }
+        assertNotNull("Expected exception for invalid digits", digitsEx)
+        assertTrue("digits violation must be IllegalArgumentException", digitsEx is IllegalArgumentException)
+        assertFalse("digits violation must NOT be InvalidUriException", digitsEx is InvalidUriException)
+
+        // period violation
+        val periodUri = "otpauth://totp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&period=0"
+        var periodEx: Exception? = null
+        try {
+            OathUriParser.parse(periodUri)
+        } catch (e: Exception) {
+            periodEx = e
+        }
+        assertNotNull("Expected exception for invalid period", periodEx)
+        assertTrue("period violation must be IllegalArgumentException", periodEx is IllegalArgumentException)
+        assertFalse("period violation must NOT be InvalidUriException", periodEx is InvalidUriException)
+
+        // counter violation
+        val counterUri = "otpauth://hotp/Example:alice@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&counter=-1"
+        var counterEx: Exception? = null
+        try {
+            OathUriParser.parse(counterUri)
+        } catch (e: Exception) {
+            counterEx = e
+        }
+        assertNotNull("Expected exception for invalid counter", counterEx)
+        assertTrue("counter violation must be IllegalArgumentException", counterEx is IllegalArgumentException)
+        assertFalse("counter violation must NOT be InvalidUriException", counterEx is InvalidUriException)
+    }
+
 }

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushCredential.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushCredential.kt
@@ -12,11 +12,13 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 import java.util.Date
 import java.util.UUID
 
@@ -94,7 +96,7 @@ data class PushCredential(
          *
          * @param jsonString The JSON string.
          * @return A PushCredential.
-         * @throws kotlinx.serialization.SerializationException if the JSON is invalid.
+         * @throws SerializationException if the JSON is invalid.
          */
         fun fromJson(jsonString: String): PushCredential {
             return json.decodeFromString(jsonString)
@@ -106,7 +108,8 @@ data class PushCredential(
          *
          * @param uri The URI string.
          * @return A PushCredential.
-         * @throws IllegalArgumentException if the URI is invalid.
+         * @throws InvalidUriException if the URI is structurally invalid (scheme mismatch, missing required parameters).
+         * @throws IllegalArgumentException if a URI parameter value fails validation.
          */
         fun fromUri(uri: String): PushCredential {
             return PushUriParser.parse(uri)

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushUriParser.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushUriParser.kt
@@ -9,6 +9,7 @@ package com.pingidentity.mfa.push
 
 import android.net.Uri
 import com.pingidentity.mfa.commons.UriParser
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 import androidx.core.net.toUri
 
 /**
@@ -36,7 +37,8 @@ object PushUriParser : UriParser() {
      *
      * @param uri The URI string.
      * @return A PushCredential.
-     * @throws IllegalArgumentException if the URI is invalid.
+     * @throws InvalidUriException if the URI is structurally invalid (scheme mismatch, issuer/label mismatch).
+     * @throws IllegalArgumentException if a required parameter is missing.
      */
     fun parse(uri: String): PushCredential {
         try {
@@ -144,10 +146,10 @@ object PushUriParser : UriParser() {
             )
 
         } catch (e: Exception) {
-            if (e is IllegalArgumentException) {
+            if (e is InvalidUriException || e is IllegalArgumentException) {
                 throw e
             } else {
-                throw IllegalArgumentException("Invalid Push URI: $uri", e)
+                throw InvalidUriException("Invalid Push URI: $uri", e)
             }
         }
     }

--- a/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PushUriParserTest.kt
+++ b/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PushUriParserTest.kt
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import android.util.Base64
+import com.pingidentity.mfa.commons.exception.InvalidUriException
 
 /**
  * Unit tests for PushUriParser class.
@@ -212,6 +213,13 @@ class PushUriParserTest {
         assertEquals(credential.sharedSecret, reparsedCredential.sharedSecret)
     }
     
+    @Test(expected = InvalidUriException::class)
+    fun `test parse URI with mismatched issuer param throws InvalidUriException`() {
+        // Label says "forgerock" but issuer= param says "Acme" — parseLabelComponents throws InvalidUriException
+        val uri = "pushauth://push/forgerock:user?a=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPWF1dGhlbnRpY2F0ZQ&r=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPXJlZ2lzdGVy&s=b3uYLkQ7dRPjBaIzV0t_aijoXRgMq-NP5AwVAvRfa_E&issuer=Acme"
+        PushUriParser.parse(uri)
+    }
+
     @Test(expected = IllegalArgumentException::class)
     fun `test parse URI with missing registration endpoint`() {
         val uri = "pushauth://push/forgerock:user?a=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPWF1dGhlbnRpY2F0ZQ&s=b3uYLkQ7dRPjBaIzV0t_aijoXRgMq-NP5AwVAvRfa_E"


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5074](https://pingidentity.atlassian.net/browse/SDKS-5074) "[Android] Add dedicated InvalidUriException to mfa-commons for OATH URI parsing errors"

# Description

Introduce a dedicated, typed `InvalidUriException` in `mfa:commons` so callers — notably the React Native OATH bridge (`OathErrorMapper.kt`) — can distinguish OATH URI structural/parsing failures from general argument-validation failures without sniffing `e.message` for the substring `"uri"`. The new exception extends the module's `MfaException` family. URI-structure throw sites in `OathUriParser.parse()` (invalid scheme, invalid OATH type, missing required `secret`, the catch-all wrapper) and the shared `UriParser.parseLabelComponents` issuer/label-mismatch check are reclassified to throw `InvalidUriException`, while genuine value-validation errors (invalid digits, period, counter) remain `IllegalArgumentException`. This reaches parity with the iOS `OathError.invalidUri` case. The exception is placed in `commons` (not `oath`) so the parallel `PushUriParser` can adopt it later with no further module changes.

**Phases completed:**
- Phase 1 — Add the `InvalidUriException` type to mfa-commons: Added `InvalidUriException : MfaException` to `MfaException.kt`
- Phase 2 — Reclassify URI-structure throw sites in the shared base parser: `UriParser.parseLabelComponents` issuer/label mismatch → `InvalidUriException`
- Phase 3 — Reclassify URI-structure throw sites in OathUriParser: scheme, type, missing-secret, catch-all → `InvalidUriException`; value-validation stays `IllegalArgumentException`
- Phase 4 — Tests for typed exception + full module build: 6 new tests (4 typed-exception, 2 regression); full `mfa:oath` + `mfa:commons` build

**Note:** The downstream React Native bridge (`OathErrorMapper.kt`, RN repo) must be updated separately to `catch (e: InvalidUriException)` and remove the `e.message` string-sniffing heuristic. Coordinate that PR alongside this SDK release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated `InvalidUriException` for structurally invalid/unparseable MFA URIs.

* **Bug Fixes**
  * Updated OATH and Push URI parsers to throw `InvalidUriException` (instead of generic exceptions) for structural/validation issues such as scheme/type/secret requirements and issuer mismatches.

* **Documentation**
  * Updated the changelog and KDoc/@throws notes to reflect the new exception behavior.
  
* **Tests**
  * Expanded OATH and Push negative-case tests to verify `InvalidUriException` is thrown for URI structural problems, while invalid parameter values continue to result in `IllegalArgumentException`.

* **Chores**
  * Updated `.gitignore` to ignore the `.sdk/` directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->