### PR TITLE
SDKS-5116: Surface distinct wrong-number failure for Push Number Challenge

### DIFF
--- a/foundation/utils/src/main/kotlin/com/pingidentity/exception/ApiException.kt
+++ b/foundation/utils/src/main/kotlin/com/pingidentity/exception/ApiException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -17,7 +17,7 @@ package com.pingidentity.exception
  * @param status The status code of the API response.
  * @param content The content message of the API response.
  */
-class ApiException(val status: Int, val content: String) : Exception(content) {
+open class ApiException(val status: Int, val content: String) : Exception(content) {
 
     /**
      * Overrides the toString function from the Exception class.

--- a/mfa/push/src/androidTest/kotlin/com/pingidentity/mfa/push/TestPushHandler.kt
+++ b/mfa/push/src/androidTest/kotlin/com/pingidentity/mfa/push/TestPushHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025-2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/mfa/push/src/androidTest/kotlin/com/pingidentity/mfa/push/TestPushHandler.kt
+++ b/mfa/push/src/androidTest/kotlin/com/pingidentity/mfa/push/TestPushHandler.kt
@@ -132,18 +132,18 @@ class TestPushHandler(private val logger: Logger = Logger.logger) : PushHandler 
         credential: PushCredential,
         notification: PushNotification,
         params: Map<String, Any>
-    ): Boolean {
+    ): Result<Boolean> {
         // For testing purposes, always return success
-        return true
+        return Result.success(true)
     }
     
     override suspend fun sendDenial(
         credential: PushCredential,
         notification: PushNotification,
         params: Map<String, Any>
-    ): Boolean {
+    ): Result<Boolean> {
         // For testing purposes, always return success
-        return true
+        return Result.success(true)
     }
     
     override suspend fun setDeviceToken(

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushHandler.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushHandler.kt
@@ -252,7 +252,7 @@ internal class PingAMPushHandler(
         credential: PushCredential,
         notification: PushNotification,
         params: Map<String, Any>
-    ): Boolean {
+    ): Result<Boolean> {
         logger.d("Sending PingAM approval for notification: ${notification.id}")
 
         var challengeResponse: String? = null
@@ -264,7 +264,7 @@ internal class PingAMPushHandler(
 
                 if (userProvidedResponse == null) {
                     logger.w("Challenge response is required for challenge-based authentication")
-                    return false
+                    return Result.success(false)
                 }
 
                 // Use the user-provided challenge response directly
@@ -285,12 +285,14 @@ internal class PingAMPushHandler(
         }
 
         // Send the authentication response
-        return pushResponder.authenticate(
-            credential = credential,
-            notification = notification,
-            approve = true,
-            challengeResponse = challengeResponse
-        )
+        return runCatching {
+            pushResponder.authenticate(
+                credential = credential,
+                notification = notification,
+                approve = true,
+                challengeResponse = challengeResponse
+            )
+        }
     }
     
     /**
@@ -305,16 +307,18 @@ internal class PingAMPushHandler(
         credential: PushCredential,
         notification: PushNotification,
         params: Map<String, Any>
-    ): Boolean {
+    ): Result<Boolean> {
         logger.d("Sending PingAM denial for notification: ${notification.id}")
 
         // Send the authentication response with deny=true
-        return pushResponder.authenticate(
-            credential = credential,
-            notification = notification,
-            approve = false,
-            challengeResponse = null // No challenge response needed for denial
-        )
+        return runCatching {
+            pushResponder.authenticate(
+                credential = credential,
+                notification = notification,
+                approve = false,
+                challengeResponse = null // No challenge response needed for denial
+            )
+        }
     }
 
     /**

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushHandler.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushHandler.kt
@@ -29,6 +29,7 @@ import com.pingidentity.mfa.push.PushConstants.KEY_TIME_INTERVAL
 import com.pingidentity.mfa.push.PushConstants.KEY_TTL
 import com.pingidentity.mfa.push.PushConstants.KEY_USERNAME
 import com.pingidentity.network.HttpClient
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * This class processes push notifications from PingAM service, handling the parsing of JWT messages,
@@ -292,7 +293,7 @@ internal class PingAMPushHandler(
                 approve = true,
                 challengeResponse = challengeResponse
             )
-        }
+        }.onFailure { if (it is CancellationException) throw it }
     }
     
     /**
@@ -318,7 +319,7 @@ internal class PingAMPushHandler(
                 approve = false,
                 challengeResponse = null // No challenge response needed for denial
             )
-        }
+        }.onFailure { if (it is CancellationException) throw it }
     }
 
     /**

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushResponder.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushResponder.kt
@@ -12,15 +12,19 @@ import com.pingidentity.exception.ApiException
 import com.pingidentity.logger.Logger
 import com.pingidentity.mfa.commons.util.JwtUtils
 import com.pingidentity.mfa.push.PushConstants.RESPONSE_ALGORITHM
+import com.pingidentity.mfa.push.exception.PushNumberChallengeException
 import com.pingidentity.network.HttpClient
 import com.pingidentity.network.HttpResponse
 import com.pingidentity.network.isSuccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import java.net.URL
 import java.security.InvalidKeyException
@@ -37,7 +41,7 @@ import javax.crypto.spec.SecretKeySpec
  */
 class PingAMPushResponder(
     private val httpClient: HttpClient,
-    private val logger: Logger = Logger.Companion.logger
+    private val logger: Logger = Logger.logger
 ) {
 
     /**
@@ -245,10 +249,19 @@ class PingAMPushResponder(
             // Check if the response was successful
             if (response.status.isSuccess()) {
                 return@withContext true
+            } else if (response.status == 400 && notification.numbersChallenge != null) {
+                val body = response.body()
+                val message = runCatching {
+                    Json.parseToJsonElement(body).jsonObject["message"]?.jsonPrimitive?.content
+                }.getOrNull() ?: body
+                throw PushNumberChallengeException(response.status, message)
             } else {
                 throw ApiException(response.status, response.body())
             }
-        } catch (e: Exception) {
+        } catch (e: PushNumberChallengeException) {
+            logger.e("Number challenge failed", e)
+            throw e
+         } catch (e: Exception) {
             coroutineContext.ensureActive()
             logger.e("Authentication response failed", e)
             return@withContext false

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushResponder.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushResponder.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import java.net.HttpURLConnection
 import java.net.URL
 import java.security.InvalidKeyException
 import java.security.NoSuchAlgorithmException
@@ -249,7 +250,7 @@ class PingAMPushResponder(
             // Check if the response was successful
             if (response.status.isSuccess()) {
                 return@withContext true
-            } else if (response.status == 400 && notification.numbersChallenge != null) {
+            } else if (response.status == HttpURLConnection.HTTP_BAD_REQUEST && notification.numbersChallenge != null) {
                 val body = response.body()
                 val message = runCatching {
                     Json.parseToJsonElement(body).jsonObject["message"]?.jsonPrimitive?.content

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushResponder.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PingAMPushResponder.kt
@@ -254,7 +254,7 @@ class PingAMPushResponder(
                 val body = response.body()
                 val message = runCatching {
                     Json.parseToJsonElement(body).jsonObject["message"]?.jsonPrimitive?.content
-                }.getOrNull() ?: body
+                }.getOrNull() ?: "Number challenge predicate not met"
                 throw PushNumberChallengeException(response.status, message)
             } else {
                 throw ApiException(response.status, response.body())

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushClient.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushClient.kt
@@ -15,7 +15,6 @@ import com.pingidentity.mfa.commons.policy.MfaPolicyEvaluator
 import com.pingidentity.mfa.push.storage.PushStorage
 import com.pingidentity.mfa.push.storage.SQLPushStorage
 import com.pingidentity.storage.sqlite.passphrase.KeyStorePassphraseProvider
-import com.pingidentity.storage.sqlite.passphrase.NonePassphraseProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -26,7 +25,6 @@ import kotlinx.coroutines.withContext
  * This client handles Push credential management and notification handling.
  *
  * @param configuration The Push configuration.
- * @param storage The PushStorage implementation to use. If null, a default SQLPushStorage will be created.
  */
 class PushClient internal constructor(
     private val configuration: PushConfiguration,
@@ -400,9 +398,16 @@ class PushClient internal constructor(
      * This method approves the authentication request for the given challenge notification
      * with the provided challenge response.
      *
+     * If the user selected the wrong number in a Push Number Challenge, AM returns HTTP 400 and
+     * this method returns [Result.failure] wrapping a [com.pingidentity.mfa.push.exception.PushNumberChallengeException].
+     * This is distinct from a generic network or server failure ([com.pingidentity.exception.ApiException]),
+     * allowing callers to surface a user-friendly "wrong number" message or offer a retry.
+     *
      * @param notificationId The ID of the notification to approve.
      * @param challengeResponse The challenge response provided by the user.
-     * @return A Result containing a Boolean indicating success or an Exception in case of failure.
+     * @return A Result containing a Boolean indicating success, or a [Result.failure] with
+     *   [com.pingidentity.mfa.push.exception.PushNumberChallengeException] for a wrong number selection,
+     *   or another exception for generic failures.
      */
     suspend fun approveChallengeNotification(notificationId: String, challengeResponse: String): Result<Boolean> {
         return try {

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushHandler.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025-2026  Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -69,14 +69,16 @@ interface PushHandler {
      * @param credential The credential to use for the response.
      * @param notification The notification to approve.
      * @param params Additional parameters.
-     * @return True if the approval was sent successfully, false otherwise.
+     * @return [Result.success] with `true` on success, [Result.success] with `false` if the
+     * approval could not be sent due to missing input, or [Result.failure] wrapping an exception
+     * if a server or network error occurred.
      */
     suspend fun sendApproval(
         credential: PushCredential,
         notification: PushNotification,
         params: Map<String, Any>
-    ): Boolean
-    
+    ): Result<Boolean>
+
     /**
      * Send a denial response for a notification.
      * How the denial is sent depends on the platform and the implementation of this handler.
@@ -86,13 +88,14 @@ interface PushHandler {
      * @param credential The credential to use for the response.
      * @param notification The notification to deny.
      * @param params Additional parameters.
-     * @return True if the denial was sent successfully, false otherwise.
+     * @return [Result.success] with `true` on success, or [Result.failure] wrapping an exception
+     * if a server or network error occurred.
      */
     suspend fun sendDenial(
         credential: PushCredential,
         notification: PushNotification,
         params: Map<String, Any>
-    ): Boolean
+    ): Result<Boolean>
 
     /**
      * Register or update the device token. This is typically called when the

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushService.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushService.kt
@@ -729,7 +729,7 @@ internal class PushService(
             val handler = pushHandlers[platform] ?: throw MfaException("No handler for platform: $platform")
 
             // Send the approval with any additional parameters
-            val result = handler.sendApproval(credential, notification, params)
+            val result = handler.sendApproval(credential, notification, params).getOrThrow()
             if (result) {
                 // Update the notification status
                 notification.markApproved()
@@ -801,7 +801,7 @@ internal class PushService(
             val handler = pushHandlers[platform] ?: throw MfaException("No handler for platform: $platform")
 
             // Send the denial with any additional parameters
-            val result = handler.sendDenial(credential, notification, params)
+            val result = handler.sendDenial(credential, notification, params).getOrThrow()
             if (result) {
                 // Update the notification status
                 notification.markDenied()

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushService.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/PushService.kt
@@ -33,6 +33,7 @@ import com.pingidentity.mfa.push.PushConstants.KEY_USERNAME
 import com.pingidentity.mfa.push.exception.DeviceTokenMissingException
 import com.pingidentity.mfa.push.exception.NotificationExpiredException
 import com.pingidentity.mfa.push.exception.NotificationNotFoundException
+import com.pingidentity.mfa.push.exception.PushNumberChallengeException
 import com.pingidentity.mfa.push.storage.PushStorage
 import com.pingidentity.network.HttpClient
 import kotlinx.coroutines.currentCoroutineContext
@@ -746,6 +747,8 @@ internal class PushService(
         } catch (e: CredentialNotFoundException) {
             throw e
         } catch (e: CredentialLockedException) {
+            throw e
+        } catch (e: PushNumberChallengeException) {
             throw e
         } catch (e: Exception) {
             currentCoroutineContext().ensureActive()

--- a/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/exception/PushNumberChallengeException.kt
+++ b/mfa/push/src/main/kotlin/com/pingidentity/mfa/push/exception/PushNumberChallengeException.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.mfa.push.exception
+
+import com.pingidentity.exception.ApiException
+
+/**
+ * Exception thrown when a push number challenge fails.
+ *
+ * This exception is thrown when the server responds with an error during a push number challenge operation.
+ * It contains the status code and the error message from the server response.
+ *
+ * @param status The status code of the API response.
+ * @param message The error message from the API response.
+ */
+class PushNumberChallengeException(
+    status: Int,
+    message: String,
+) : ApiException(content = message, status = status)

--- a/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PingAMPushHandlerTest.kt
+++ b/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PingAMPushHandlerTest.kt
@@ -196,9 +196,9 @@ class PingAMPushHandlerTest {
             testNotification.copy(pushType = PushType.CHALLENGE),
             mapOf("challengeResponse" to "test-response")
         )
-        
+
         // Verify result
-        assertTrue(result)
+        assertTrue(result.getOrThrow())
         
         // Verify responder was called with correct parameters
         coVerify { 
@@ -229,9 +229,9 @@ class PingAMPushHandlerTest {
             testNotification,
             emptyMap()
         )
-        
+
         // Verify result
-        assertTrue(result)
+        assertTrue(result.getOrThrow())
         
         // Verify responder was called with correct parameters
         coVerify { 
@@ -535,9 +535,9 @@ class PingAMPushHandlerTest {
             biometricNotification,
             mapOf("authenticationMethod" to "fingerprint")
         )
-        
+
         // Verify result
-        assertTrue(result)
+        assertTrue(result.getOrThrow())
         
         // Verify responder was called with null challengeResponse for biometric
         coVerify { 
@@ -561,9 +561,9 @@ class PingAMPushHandlerTest {
             challengeNotification,
             emptyMap()
         )
-        
+
         // Verify result is false (because challengeResponse is required)
-        assertFalse(result)
+        assertFalse(result.getOrThrow())
         
         // Verify responder was NOT called
         coVerify(exactly = 0) { 
@@ -592,9 +592,9 @@ class PingAMPushHandlerTest {
             defaultNotification,
             emptyMap()
         )
-        
+
         // Verify result
-        assertTrue(result)
+        assertTrue(result.getOrThrow())
         
         // Verify responder was called with null challengeResponse for default type
         coVerify { 

--- a/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PingAMPushResponderTest.kt
+++ b/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PingAMPushResponderTest.kt
@@ -809,6 +809,56 @@ class PingAMPushResponderTest {
     }
 
     @Test
+    fun `test authenticate 400 on number challenge with empty body uses default message`() = runTest {
+        val mockEngine = MockEngine.Companion { _ ->
+            respond(
+                content = "",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        val pushResponder = PingAMPushResponder(httpClient, mockLogger)
+
+        val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
+
+        try {
+            pushResponder.authenticate(testCredential, notificationWithNumberChallenge, true, "45")
+            Assert.fail("Expected PushNumberChallengeException to be thrown")
+        } catch (e: PushNumberChallengeException) {
+            Assert.assertEquals(400, e.status)
+            Assert.assertEquals("Number challenge predicate not met", e.message)
+        }
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `test authenticate 400 on number challenge with body missing message field uses default message`() = runTest {
+        val mockEngine = MockEngine.Companion { _ ->
+            respond(
+                content = """{"code":400,"reason":"Bad Request"}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        val pushResponder = PingAMPushResponder(httpClient, mockLogger)
+
+        val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
+
+        try {
+            pushResponder.authenticate(testCredential, notificationWithNumberChallenge, true, "45")
+            Assert.fail("Expected PushNumberChallengeException to be thrown")
+        } catch (e: PushNumberChallengeException) {
+            Assert.assertEquals(400, e.status)
+            Assert.assertEquals("Number challenge predicate not met", e.message)
+        }
+
+        httpClient.close()
+    }
+
+    @Test
     fun `test authenticate 400 without number challenge returns false`() = runTest {
         val mockEngine = MockEngine.Companion { _ ->
             respondError(HttpStatusCode.BadRequest)

--- a/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PingAMPushResponderTest.kt
+++ b/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PingAMPushResponderTest.kt
@@ -24,6 +24,7 @@ import com.pingidentity.mfa.push.PushConstants.KEY_MECHANISM_UID
 import com.pingidentity.mfa.push.PushConstants.KEY_MESSAGE_ID
 import com.pingidentity.mfa.push.PushConstants.KEY_RESPONSE
 import com.pingidentity.mfa.push.PushConstants.KEY_USERNAME
+import com.pingidentity.mfa.push.exception.PushNumberChallengeException
 import com.pingidentity.network.ktor.KtorHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -756,6 +757,85 @@ class PingAMPushResponderTest {
         val result = pushResponder.register(testCredential, params)
 
         // Verify result is false
+        Assert.assertFalse(result)
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `test authenticate 400 on number challenge throws PushNumberChallengeException`() = runTest {
+        val mockEngine = MockEngine.Companion { _ ->
+            respondError(HttpStatusCode.BadRequest)
+        }
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        val pushResponder = PingAMPushResponder(httpClient, mockLogger)
+
+        val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
+
+        try {
+            pushResponder.authenticate(testCredential, notificationWithNumberChallenge, true, "45")
+            Assert.fail("Expected PushNumberChallengeException to be thrown")
+        } catch (e: PushNumberChallengeException) {
+            Assert.assertEquals(400, e.status)
+        }
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `test authenticate 400 on number challenge extracts message from response body`() = runTest {
+        val errorMessage = "Number challenge predicate not met."
+        val mockEngine = MockEngine.Companion { _ ->
+            respond(
+                content = """{"code":400,"reason":"Bad Request","message":"$errorMessage"}""",
+                status = HttpStatusCode.BadRequest,
+                headers = headersOf("Content-Type", "application/json")
+            )
+        }
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        val pushResponder = PingAMPushResponder(httpClient, mockLogger)
+
+        val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
+
+        try {
+            pushResponder.authenticate(testCredential, notificationWithNumberChallenge, true, "45")
+            Assert.fail("Expected PushNumberChallengeException to be thrown")
+        } catch (e: PushNumberChallengeException) {
+            Assert.assertEquals(400, e.status)
+            Assert.assertEquals(errorMessage, e.message)
+        }
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `test authenticate 400 without number challenge returns false`() = runTest {
+        val mockEngine = MockEngine.Companion { _ ->
+            respondError(HttpStatusCode.BadRequest)
+        }
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        val pushResponder = PingAMPushResponder(httpClient, mockLogger)
+
+        // Standard notification (no numbersChallenge) — 400 should swallow to false
+        val result = pushResponder.authenticate(testCredential, testNotification, true, null)
+
+        Assert.assertFalse(result)
+
+        httpClient.close()
+    }
+
+    @Test
+    fun `test authenticate 500 server error returns false`() = runTest {
+        val mockEngine = MockEngine.Companion { _ ->
+            respondError(HttpStatusCode.InternalServerError)
+        }
+        val httpClient = KtorHttpClient(HttpClient(mockEngine))
+        val pushResponder = PingAMPushResponder(httpClient, mockLogger)
+
+        val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
+
+        val result = pushResponder.authenticate(testCredential, notificationWithNumberChallenge, true, "45")
+
         Assert.assertFalse(result)
 
         httpClient.close()

--- a/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PushServiceTest.kt
+++ b/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PushServiceTest.kt
@@ -14,6 +14,7 @@ import com.pingidentity.mfa.commons.exception.MfaException
 import com.pingidentity.mfa.push.exception.DeviceTokenMissingException
 import com.pingidentity.mfa.push.exception.NotificationExpiredException
 import com.pingidentity.mfa.push.exception.NotificationNotFoundException
+import com.pingidentity.mfa.push.exception.PushNumberChallengeException
 import com.pingidentity.mfa.push.storage.PushStorage
 import com.pingidentity.network.ktor.KtorHttpClient
 import io.ktor.client.HttpClient
@@ -1329,7 +1330,7 @@ class PushServiceTest {
     fun `test approve expired notification throws NotificationExpiredException`() = runTest {
         // Given
         val expiredNotification = testNotification.copy(
-            createdAt = java.util.Date(System.currentTimeMillis() - 120000), // 2 minutes ago
+            createdAt = Date(System.currentTimeMillis() - 120000), // 2 minutes ago
             ttl = 60 // 60 seconds TTL
         )
         coEvery { mockStorage.retrievePushNotification(testNotificationId) } returns expiredNotification
@@ -1349,7 +1350,7 @@ class PushServiceTest {
     fun `test deny expired notification throws NotificationExpiredException`() = runTest {
         // Given
         val expiredNotification = testNotification.copy(
-            createdAt = java.util.Date(System.currentTimeMillis() - 120000), // 2 minutes ago
+            createdAt = Date(System.currentTimeMillis() - 120000), // 2 minutes ago
             ttl = 60 // 60 seconds TTL
         )
         coEvery { mockStorage.retrievePushNotification(testNotificationId) } returns expiredNotification
@@ -1453,6 +1454,33 @@ class PushServiceTest {
         } catch (e: DeviceTokenMissingException) {
             assert(e.message?.contains("Device token not set") == true)
             assert(e.message?.contains("Call setDeviceToken()") == true)
+        }
+    }
+
+    @Test
+    fun `test approveNotification propagates PushNumberChallengeException`() = runTest {
+        // Given
+        val mockHandler = mockk<PushHandler>()
+        val pushService = PushService(
+            storage = mockStorage,
+            configuration = configWithCache,
+            httpClient = KtorHttpClient(mockHttpClient),
+            policyEvaluator = mockPolicyEvaluator,
+            handlers = mapOf(PushPlatform.PING_AM.name to mockHandler)
+        )
+
+        val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
+        coEvery { mockStorage.retrievePushNotification(testNotificationId) } returns notificationWithNumberChallenge
+        coEvery { mockStorage.retrievePushCredential(testCredentialId) } returns testCredential
+        coEvery { mockHandler.sendApproval(any(), any(), any()) } throws
+            PushNumberChallengeException(400, "Number challenge failed: the selected number was incorrect")
+
+        // When/Then — PushNumberChallengeException must not be swallowed into MfaException
+        try {
+            pushService.approveNotification(testNotificationId)
+            assert(false) { "Expected PushNumberChallengeException" }
+        } catch (e: PushNumberChallengeException) {
+            assertEquals(400, e.status)
         }
     }
 }

--- a/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PushServiceTest.kt
+++ b/mfa/push/src/test/kotlin/com/pingidentity/mfa/push/PushServiceTest.kt
@@ -329,7 +329,7 @@ class PushServiceTest {
         val mockHandler = mockk<PushHandler>()
 
         // Mock handler methods - sendApproval is a suspend function
-        coEvery { mockHandler.sendApproval(any(), any(), any()) } returns true
+        coEvery { mockHandler.sendApproval(any(), any(), any()) } returns Result.success(true)
 
         val pushService = PushService(
             storage = mockStorage,
@@ -358,7 +358,7 @@ class PushServiceTest {
         val mockHandler = mockk<PushHandler>()
 
         // Mock handler methods - sendDenial is a suspend function
-        coEvery { mockHandler.sendDenial(any(), any(), any()) } returns true
+        coEvery { mockHandler.sendDenial(any(), any(), any()) } returns Result.success(true)
 
         val pushService = PushService(
             storage = mockStorage,
@@ -1090,7 +1090,7 @@ class PushServiceTest {
 
         coEvery { mockStorage.retrievePushNotification(testNotificationId) } returns testNotification
         coEvery { mockStorage.retrievePushCredential(testCredentialId) } returns testCredential
-        coEvery { mockHandler.sendApproval(any(), any(), any()) } returns false
+        coEvery { mockHandler.sendApproval(any(), any(), any()) } returns Result.success(false)
 
         // When
         val result = pushService.approveNotification(testNotificationId)
@@ -1114,7 +1114,7 @@ class PushServiceTest {
 
         coEvery { mockStorage.retrievePushNotification(testNotificationId) } returns testNotification
         coEvery { mockStorage.retrievePushCredential(testCredentialId) } returns testCredential
-        coEvery { mockHandler.sendDenial(any(), any(), any()) } returns false
+        coEvery { mockHandler.sendDenial(any(), any(), any()) } returns Result.success(false)
 
         // When
         val result = pushService.denyNotification(testNotificationId)
@@ -1472,8 +1472,8 @@ class PushServiceTest {
         val notificationWithNumberChallenge = testNotification.copy(numbersChallenge = "23 45 67")
         coEvery { mockStorage.retrievePushNotification(testNotificationId) } returns notificationWithNumberChallenge
         coEvery { mockStorage.retrievePushCredential(testCredentialId) } returns testCredential
-        coEvery { mockHandler.sendApproval(any(), any(), any()) } throws
-            PushNumberChallengeException(400, "Number challenge failed: the selected number was incorrect")
+        coEvery { mockHandler.sendApproval(any(), any(), any()) } returns
+            Result.failure(PushNumberChallengeException(400, "Number challenge failed: the selected number was incorrect"))
 
         // When/Then — PushNumberChallengeException must not be swallowed into MfaException
         try {

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/authenticator/ui/NotificationResponseScreen.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/authenticator/ui/NotificationResponseScreen.kt
@@ -465,7 +465,7 @@ fun NotificationResponseScreen(
                         Spacer(modifier = Modifier.height(24.dp))
                         
                         OutlinedButton(
-                            onClick = onDismiss,
+                            onClick = { onDeny?.invoke() },
                             modifier = Modifier.fillMaxWidth(0.7f),
                             colors = ButtonDefaults.outlinedButtonColors(
                                 contentColor = MaterialTheme.colorScheme.error


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5116](https://pingidentity.atlassian.net/browse/SDKS-5116)

# Description
This PR update the Ping Android mfa/push module so that AM 400 responses for wrong Push Number Challenge selections propagate as a distinct failure instead of being swallowed and returned as false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated exception for Push Number Challenge failures (HTTP 400 when a number challenge is present), including extracting an error message from the response body (or using a default).
* **Bug Fixes**
  * Improved push authentication/approval behavior: HTTP 400/500 handling is now correct for number-challenge vs non-challenge flows, and approval propagates the number-challenge exception without wrapping.
  * Updated the sample app so “cancel authentication” invokes the optional deny callback.
* **Documentation**
  * Updated approval/denial behavior and contracts to use `Result<Boolean>` outcomes.
* **Tests**
  * Added/updated tests to cover the new 400/500 flows and `Result`-based approval/denial behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->