### PR TITLE
SDKS-5184: Update sample app to showcase JSON config

### DIFF
--- a/samples/pingsampleapp/src/main/assets/DaVinciJsonConfig.json
+++ b/samples/pingsampleapp/src/main/assets/DaVinciJsonConfig.json
@@ -1,0 +1,27 @@
+{
+  "timeout": 30000,
+  "log": "DEBUG",
+  "oidc": {
+    "clientId": "my-client-id",
+    "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+    "scopes": [
+      "openid",
+      "profile",
+      "email"
+    ],
+    "redirectUri": "app:/oauth2redirect",
+    "signOutRedirectUri": "app:/logout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "custom-state-value",
+    "nonce": "custom-nonce-value",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level3",
+    "additionalParameters": {
+      "custom_param": "custom_value",
+      "max_age": "3600"
+    }
+  }
+}

--- a/samples/pingsampleapp/src/main/assets/journeyJsonConfig.json
+++ b/samples/pingsampleapp/src/main/assets/journeyJsonConfig.json
@@ -1,0 +1,32 @@
+{
+  "timeout": 30000,
+  "log": "DEBUG",
+  "journey": {
+    "serverUrl": "https://example.com/am",
+    "realm": "alpha",
+    "cookieName": "iPlanetDirectoryPro"
+  },
+  "oidc": {
+    "clientId": "my-client-id",
+    "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+    "scopes": [
+      "openid",
+      "profile",
+      "email"
+    ],
+    "redirectUri": "app:/oauth2redirect",
+    "signOutRedirectUri": "app:/logout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "custom-state-value",
+    "nonce": "custom-nonce-value",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level3",
+    "additionalParameters": {
+      "custom_param": "custom_value",
+      "max_age": "3600"
+    }
+  }
+}

--- a/samples/pingsampleapp/src/main/assets/openIdJsonConfig.json
+++ b/samples/pingsampleapp/src/main/assets/openIdJsonConfig.json
@@ -1,0 +1,35 @@
+{
+  "timeout": 30000,
+  "log": "DEBUG",
+  "oidc": {
+    "clientId": "my-client-id",
+    "discoveryEndpoint": "https://example.com/.well-known/openid-configuration",
+    "scopes": [
+      "openid",
+      "profile",
+      "email"
+    ],
+    "redirectUri": "app:/oauth2redirect",
+    "signOutRedirectUri": "app:/logout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "custom-state-value",
+    "nonce": "custom-nonce-value",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level3",
+    "additionalParameters": {
+      "custom_param": "custom_value",
+      "max_age": "3600"
+    },
+    "openId": {
+      "authorizationEndpoint": "https://example.com/am/oauth2/alpha/authorize",
+      "tokenEndpoint": "https://example.com/am/oauth2/alpha/access_token",
+      "userinfoEndpoint": "https://example.com/am/oauth2/alpha/userinfo",
+      "endSessionEndpoint": "https://example.com/am/oauth2/alpha/session/end",
+      "revocationEndpoint": "https://example.com/am/oauth2/alpha/token/revoke",
+      "deviceAuthorizationEndpoint": "https://example.com/device/code"
+    }
+  }
+}

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/Env.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/Env.kt
@@ -692,7 +692,7 @@ private fun DeviceAuthSheetContent(
         ConfigField("ACR Values", cfg.acrValues) { cfg = cfg.copy(acrValues = it) }
         ConfigField("Authorization Endpoint", cfg.authorizationEndpoint) { cfg = cfg.copy(authorizationEndpoint = it) }
         ConfigField("Token Endpoint", cfg.tokenEndpoint) { cfg = cfg.copy(tokenEndpoint = it) }
-        ConfigField("Userinfo Endpoint", cfg.userinfoEndpoint) { cfg = cfg.copy(userinfoEndpoint = it) }
+        ConfigField("Userinfo Endpoint", cfg.userInfoEndpoint) { cfg = cfg.copy(userInfoEndpoint = it) }
         ConfigField("End Session Endpoint", cfg.endSessionEndpoint) { cfg = cfg.copy(endSessionEndpoint = it) }
         ConfigField("Revocation Endpoint", cfg.revocationEndpoint) { cfg = cfg.copy(revocationEndpoint = it) }
         ConfigField("Device Authorization Endpoint", cfg.deviceAuthorizationEndpoint) { cfg = cfg.copy(deviceAuthorizationEndpoint = it) }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -132,7 +132,7 @@ internal fun loadAssetConfigs(): AssetConfigs {
         val displayName = fileName.removeSuffix(".json")
         runCatching {
             val root = Json.parseToJsonElement(
-                context.assets.open(fileName).bufferedReader().readText()
+                context.assets.open(fileName).bufferedReader().use { it.readText() }
             ).jsonObject
             val isDaVinci = root.contains("journey").not()
             val oidc = root["oidc"]?.jsonObject ?: return@runCatching
@@ -157,18 +157,18 @@ internal fun loadAssetConfigs(): AssetConfigs {
                 redirectUri = redirectUri,
                 display = displayName,
             ))
-            if (openIdObj != null) deviceAuth.add(DeviceAuthConfigState(
+            if (openIdObj != null || isDaVinci) deviceAuth.add(DeviceAuthConfigState(
                 clientId = clientId,
                 discoveryEndpoint = discoveryEndpoint,
                 scopes = scopes,
                 display = displayName,
                 acrValues = oidc.str("acrValues"),
-                authorizationEndpoint = openIdObj.str("authorizationEndpoint"),
-                tokenEndpoint = openIdObj.str("tokenEndpoint"),
-                userInfoEndpoint = openIdObj.str("userInfoEndpoint"),
-                endSessionEndpoint = openIdObj.str("endSessionEndpoint"),
-                revocationEndpoint = openIdObj.str("revocationEndpoint"),
-                deviceAuthorizationEndpoint = openIdObj.str("deviceAuthorizationEndpoint"),
+                authorizationEndpoint = openIdObj?.str("authorizationEndpoint") ?: "",
+                tokenEndpoint = openIdObj?.str("tokenEndpoint") ?: "",
+                userInfoEndpoint = openIdObj?.str("userInfoEndpoint") ?: "",
+                endSessionEndpoint = openIdObj?.str("endSessionEndpoint") ?: "",
+                revocationEndpoint = openIdObj?.str("revocationEndpoint") ?: "",
+                deviceAuthorizationEndpoint = openIdObj?.str("deviceAuthorizationEndpoint") ?: "",
             ))
             if (isDaVinci) davinci.add(OidcConfigState(
                 clientId = clientId,
@@ -191,52 +191,6 @@ internal fun loadAssetConfigs(): AssetConfigs {
     return AssetConfigs(journey, davinci, web, deviceAuth)
 }
 
-
-// ---------------------------------------------------------------------------
-// Default preset configs (used as fallbacks when no saved config exists)
-// ---------------------------------------------------------------------------
-
-internal val defaultJourneyConfig = JourneyConfigState(
-    serverUrl = "https://www.example.com/am",
-    realm = "alpha",
-    cookie = "",
-    clientId = "dummy",
-    discoveryEndpoint = "https://www.example.com/am/oauth2/alpha/.well-known/openid-configuration",
-    scopes = "openid,email,address,profile,phone",
-    redirectUri = "org.forgerock.demo:/oauth2redirect",
-    display = "Journey Test Config",
-)
-
-internal val defaultDaVinciConfig = OidcConfigState(
-    clientId = "dummy",
-    discoveryEndpoint = "https://auth.pingone.ca/dummy/as/.well-known/openid-configuration",
-    scopes = "openid,email,address,phone,profile",
-    redirectUri = "org.forgerock.demo://oauth2redirect",
-    arcValue = "123",
-    display = "DaVinci Test Config",
-)
-
-internal val defaultDeviceAuthConfig = DeviceAuthConfigState(
-    clientId = "dummy",
-    discoveryEndpoint = "https://example.com/am/oauth2/alpha/.well-known/openid-configuration",
-    scopes = "openid",
-    display = "Device Authorization",
-    authorizationEndpoint = "https://example.com/am/oauth2/alpha/authorize",
-    tokenEndpoint = "https://example.com/am/oauth2/alpha/access_token",
-    userInfoEndpoint = "https://example.com/am/oauth2/alpha/userinfo",
-    endSessionEndpoint = "https://example.com/am/oauth2/alpha/session/end",
-    revocationEndpoint = "https://example.com/am/oauth2/alpha/token/revoke",
-    deviceAuthorizationEndpoint = "https://example.com/am/oauth2/realms/root/realms/alpha/device/code",
-)
-
-internal val defaultWebConfig = OidcConfigState(
-    clientId = "dummy",
-    discoveryEndpoint = "https://www.example.com/am/oauth2/alpha/.well-known/openid-configuration",
-    scopes = "openid,email,address,profile,phone",
-    redirectUri = "org.forgerock.demo:/oauth2redirect",
-    display = "OIDC Forgeblock",
-)
-
 // ---------------------------------------------------------------------------
 // Global SDK instance holders (consumed by other ViewModels)
 // ---------------------------------------------------------------------------
@@ -247,9 +201,9 @@ var daVinci: DaVinci? = null
 var web: OidcWebClient? = null
 var oidcDeviceClient: OidcDeviceClient? = null
 /** Used by Journey's IdP (social identity provider) callback. Set only by [buildJourney]. */
-lateinit var redirectUri: Uri
+var redirectUri: Uri = Uri.EMPTY
 /** Used by DaVinci's Social Login button. Set only by [buildDaVinci]. Never overwritten by Journey. */
-lateinit var daVinciRedirectUri: Uri
+var daVinciRedirectUri: Uri = Uri.EMPTY
 
 // ---------------------------------------------------------------------------
 // Package-level SDK builders (called both at app startup and from ViewModel)
@@ -385,22 +339,23 @@ internal fun buildDeviceAuthClient(config: DeviceAuthConfigState) {
  * Loads the last-saved configs from DataStore and applies them to the global
  * SDK instances so all flows are ready immediately when the app starts,
  * before the user ever visits the Configuration screen.
+ * If no config has been saved yet, no SDK instance is built.
  */
 suspend fun initConfigs() {
     val prefs = ContextProvider.context.settingDataStore.data.first()
 
     val jConfig = prefs[stringPreferencesKey("j_clientId")]?.let { clientId ->
         JourneyConfigState(
-            serverUrl = prefs[stringPreferencesKey("j_serverUrl")] ?: defaultJourneyConfig.serverUrl,
-            realm = prefs[stringPreferencesKey("j_realm")] ?: defaultJourneyConfig.realm,
-            cookie = prefs[stringPreferencesKey("j_cookie")] ?: defaultJourneyConfig.cookie,
+            serverUrl = prefs[stringPreferencesKey("j_serverUrl")] ?: "",
+            realm = prefs[stringPreferencesKey("j_realm")] ?: "",
+            cookie = prefs[stringPreferencesKey("j_cookie")] ?: "",
             clientId = clientId,
             discoveryEndpoint = prefs[stringPreferencesKey("j_discoveryEndpoint")] ?: "",
             scopes = prefs[stringPreferencesKey("j_scopes")] ?: "",
             redirectUri = prefs[stringPreferencesKey("j_redirectUri")] ?: "",
             display = prefs[stringPreferencesKey("j_display")] ?: "",
         )
-    } ?: defaultJourneyConfig
+    }
 
     val dvConfig = prefs[stringPreferencesKey("dv_clientId")]?.let { clientId ->
         OidcConfigState(
@@ -411,7 +366,7 @@ suspend fun initConfigs() {
             display = prefs[stringPreferencesKey("dv_display")] ?: "",
             arcValue = prefs[stringPreferencesKey("dv_arcValue")] ?: "",
         )
-    } ?: defaultDaVinciConfig
+    }
 
     val wConfig = prefs[stringPreferencesKey("w_clientId")]?.let { clientId ->
         OidcConfigState(
@@ -421,7 +376,7 @@ suspend fun initConfigs() {
             redirectUri = prefs[stringPreferencesKey("w_redirectUri")] ?: "",
             display = prefs[stringPreferencesKey("w_display")] ?: "",
         )
-    } ?: defaultWebConfig
+    }
 
     val daConfig = prefs[stringPreferencesKey("da_clientId")]?.let { clientId ->
         DeviceAuthConfigState(
@@ -437,13 +392,13 @@ suspend fun initConfigs() {
             deviceAuthorizationEndpoint = prefs[stringPreferencesKey("da_deviceAuthorizationEndpoint")] ?: "",
             acrValues = prefs[stringPreferencesKey("da_acrValues")] ?: "",
         )
-    } ?: defaultDeviceAuthConfig
+    }
 
     // Each builder writes to its own global; no ordering dependency.
-    buildJourney(jConfig)
-    buildWeb(wConfig)
-    buildDaVinci(dvConfig)
-    buildDeviceAuthClient(daConfig)
+    jConfig?.let { buildJourney(it) }
+    wConfig?.let { buildWeb(it) }
+    dvConfig?.let { buildDaVinci(it) }
+    daConfig?.let { buildDeviceAuthClient(it) }
 }
 
 // ---------------------------------------------------------------------------
@@ -452,71 +407,16 @@ suspend fun initConfigs() {
 
 class EnvViewModel : ViewModel() {
 
-    // -- Built-in preset lists (asset files are prepended in init) ------------
-
-    private val builtInJourneyPresets = listOf(
-        defaultJourneyConfig,
-        JourneyConfigState(
-            serverUrl = "http://192.168.86.32:8080/openam",
-            realm = "root",
-            cookie = "",
-            clientId = "AndroidTest2",
-            discoveryEndpoint = "http://192.168.86.32:8080/openam/oauth2/.well-known/openid-configuration",
-            scopes = "openid,email,address,profile,phone",
-            redirectUri = "org.forgerock.demo:/oauth2redirect",
-            display = "Localhost",
-        ),
-    )
-
-    private val builtInDaVinciPresets = listOf(
-        defaultDaVinciConfig,
-        OidcConfigState(
-            clientId = "dummy",
-            discoveryEndpoint = "https://auth.pingone.ca/dummy/as/.well-known/openid-configuration",
-            scopes = "openid,email,address,phone,profile",
-            redirectUri = "org.forgerock.demo://oauth2redirect",
-            display = "DaVinci Prod Config",
-        ),
-        OidcConfigState(
-            clientId = "dummy",
-            discoveryEndpoint = "https://auth.pingone.com/dummy/as/.well-known/openid-configuration",
-            scopes = "openid,email,address",
-            redirectUri = "com.pingidentity.demo://oauth2redirect",
-            display = "Social Config",
-        ),
-    )
-
-    private val builtInWebPresets = listOf(
-        defaultWebConfig,
-        OidcConfigState(
-            clientId = "dummy",
-            discoveryEndpoint = "https://auth.test-one-pingone.com/dummy/as/.well-known/openid-configuration",
-            scopes = "openid,email,address",
-            redirectUri = "org.forgerock.demo://oauth2redirect",
-            display = "OIDC PingOne",
-        ),
-    )
-
-    private val builtInDeviceAuthPresets = listOf(
-        defaultDeviceAuthConfig,
-        DeviceAuthConfigState(
-            clientId = "dummyPingOne",
-            discoveryEndpoint = "https://auth.pingone.ca/dummy/as/.well-known/openid-configuration",
-            scopes = "openid",
-            display = "Dummy",
-        ),
-    )
-
-    var journeyPresets by mutableStateOf(builtInJourneyPresets)
+    var journeyPresets by mutableStateOf(emptyList<JourneyConfigState>())
         private set
 
-    var daVinciPresets by mutableStateOf(builtInDaVinciPresets)
+    var daVinciPresets by mutableStateOf(emptyList<OidcConfigState>())
         private set
 
-    var webPresets by mutableStateOf(builtInWebPresets)
+    var webPresets by mutableStateOf(emptyList<OidcConfigState>())
         private set
 
-    var deviceAuthPresets by mutableStateOf(builtInDeviceAuthPresets)
+    var deviceAuthPresets by mutableStateOf(emptyList<DeviceAuthConfigState>())
         private set
 
     // -- Currently applied configs -------------------------------------------
@@ -562,10 +462,10 @@ class EnvViewModel : ViewModel() {
             val daCustom = loadCustomDeviceAuthFromDataStore()
 
             withContext(Dispatchers.Main) {
-                if (assetConfigs.journey.isNotEmpty()) journeyPresets = assetConfigs.journey + builtInJourneyPresets
-                if (assetConfigs.davinci.isNotEmpty()) daVinciPresets = assetConfigs.davinci + builtInDaVinciPresets
-                if (assetConfigs.web.isNotEmpty()) webPresets = assetConfigs.web + builtInWebPresets
-                if (assetConfigs.deviceAuth.isNotEmpty()) deviceAuthPresets = assetConfigs.deviceAuth + builtInDeviceAuthPresets
+                journeyPresets = assetConfigs.journey
+                daVinciPresets = assetConfigs.davinci
+                webPresets = assetConfigs.web
+                deviceAuthPresets = assetConfigs.deviceAuth
                 customJourneyConfigs = jCustom
                 customDaVinciConfigs = dvCustom
                 customWebConfigs = wCustom
@@ -574,10 +474,10 @@ class EnvViewModel : ViewModel() {
                 appliedDaVinciConfig = dvApplied
                 appliedWebConfig = wApplied
                 appliedDeviceAuthConfig = daApplied
-                buildJourneyInstance(jApplied)
-                buildDaVinciInstance(dvApplied)
-                buildWebInstance(wApplied)
-                buildDeviceAuthInstance(daApplied)
+                jApplied?.let { buildJourneyInstance(it) }
+                dvApplied?.let { buildDaVinciInstance(it) }
+                wApplied?.let { buildWebInstance(it) }
+                daApplied?.let { buildDeviceAuthInstance(it) }
             }
         }
     }
@@ -623,9 +523,10 @@ class EnvViewModel : ViewModel() {
     fun deleteCustomJourneyConfig(index: Int) {
         val deleted = customJourneyConfigs[index]
         customJourneyConfigs = customJourneyConfigs.toMutableList().also { it.removeAt(index) }
-        // If the deleted config was active, fall back to the first preset
         if (appliedJourneyConfig?.display == deleted.display) {
-            selectJourneyConfig(journeyPresets[0])
+            val fallback = journeyPresets.firstOrNull()
+            if (fallback != null) selectJourneyConfig(fallback)
+            else { appliedJourneyConfig = null; journey = null }
         }
         viewModelScope.launch(Dispatchers.IO) { persistCustomJourneyConfigs(customJourneyConfigs) }
     }
@@ -643,9 +544,10 @@ class EnvViewModel : ViewModel() {
     fun deleteCustomDaVinciConfig(index: Int) {
         val deleted = customDaVinciConfigs[index]
         customDaVinciConfigs = customDaVinciConfigs.toMutableList().also { it.removeAt(index) }
-        // If the deleted config was active, fall back to the first preset
         if (appliedDaVinciConfig?.display == deleted.display) {
-            selectDaVinciConfig(daVinciPresets[0])
+            val fallback = daVinciPresets.firstOrNull()
+            if (fallback != null) selectDaVinciConfig(fallback)
+            else { appliedDaVinciConfig = null; daVinci = null }
         }
         viewModelScope.launch(Dispatchers.IO) { persistCustomDaVinciConfigs(customDaVinciConfigs) }
     }
@@ -663,9 +565,10 @@ class EnvViewModel : ViewModel() {
     fun deleteCustomWebConfig(index: Int) {
         val deleted = customWebConfigs[index]
         customWebConfigs = customWebConfigs.toMutableList().also { it.removeAt(index) }
-        // If the deleted config was active, fall back to the first preset
         if (appliedWebConfig?.display == deleted.display) {
-            selectWebConfig(webPresets[0])
+            val fallback = webPresets.firstOrNull()
+            if (fallback != null) selectWebConfig(fallback)
+            else { appliedWebConfig = null; web = null }
         }
         viewModelScope.launch(Dispatchers.IO) { persistCustomWebConfigs(customWebConfigs) }
     }
@@ -703,9 +606,10 @@ class EnvViewModel : ViewModel() {
     fun deleteCustomDeviceAuthConfig(index: Int) {
         val deleted = customDeviceAuthConfigs[index]
         customDeviceAuthConfigs = customDeviceAuthConfigs.toMutableList().also { it.removeAt(index) }
-        // If the deleted config was active, fall back to the first preset
         if (appliedDeviceAuthConfig?.display == deleted.display) {
-            selectDeviceAuthConfig(deviceAuthPresets[0])
+            val fallback = deviceAuthPresets.firstOrNull()
+            if (fallback != null) selectDeviceAuthConfig(fallback)
+            else { appliedDeviceAuthConfig = null; oidcDeviceClient = null }
         }
         viewModelScope.launch(Dispatchers.IO) { persistCustomDeviceAuthConfigs(customDeviceAuthConfigs) }
     }
@@ -719,13 +623,13 @@ class EnvViewModel : ViewModel() {
 
     // -- DataStore: load applied configs -------------------------------------
 
-    private suspend fun loadAppliedJourneyFromDataStore(): JourneyConfigState {
+    private suspend fun loadAppliedJourneyFromDataStore(): JourneyConfigState? {
         val prefs = ContextProvider.context.settingDataStore.data.first()
-        val clientId = prefs[stringPreferencesKey("j_clientId")] ?: return journeyPresets[0]
+        val clientId = prefs[stringPreferencesKey("j_clientId")] ?: return null
         return JourneyConfigState(
-            serverUrl = prefs[stringPreferencesKey("j_serverUrl")] ?: journeyPresets[0].serverUrl,
-            realm = prefs[stringPreferencesKey("j_realm")] ?: journeyPresets[0].realm,
-            cookie = prefs[stringPreferencesKey("j_cookie")] ?: journeyPresets[0].cookie,
+            serverUrl = prefs[stringPreferencesKey("j_serverUrl")] ?: "",
+            realm = prefs[stringPreferencesKey("j_realm")] ?: "",
+            cookie = prefs[stringPreferencesKey("j_cookie")] ?: "",
             clientId = clientId,
             discoveryEndpoint = prefs[stringPreferencesKey("j_discoveryEndpoint")] ?: "",
             scopes = prefs[stringPreferencesKey("j_scopes")] ?: "",
@@ -734,9 +638,9 @@ class EnvViewModel : ViewModel() {
         )
     }
 
-    private suspend fun loadAppliedDaVinciFromDataStore(): OidcConfigState {
+    private suspend fun loadAppliedDaVinciFromDataStore(): OidcConfigState? {
         val prefs = ContextProvider.context.settingDataStore.data.first()
-        val clientId = prefs[stringPreferencesKey("dv_clientId")] ?: return daVinciPresets[0]
+        val clientId = prefs[stringPreferencesKey("dv_clientId")] ?: return null
         return OidcConfigState(
             clientId = clientId,
             discoveryEndpoint = prefs[stringPreferencesKey("dv_discoveryEndpoint")] ?: "",
@@ -747,9 +651,9 @@ class EnvViewModel : ViewModel() {
         )
     }
 
-    private suspend fun loadAppliedWebFromDataStore(): OidcConfigState {
+    private suspend fun loadAppliedWebFromDataStore(): OidcConfigState? {
         val prefs = ContextProvider.context.settingDataStore.data.first()
-        val clientId = prefs[stringPreferencesKey("w_clientId")] ?: return webPresets[0]
+        val clientId = prefs[stringPreferencesKey("w_clientId")] ?: return null
         return OidcConfigState(
             clientId = clientId,
             discoveryEndpoint = prefs[stringPreferencesKey("w_discoveryEndpoint")] ?: "",
@@ -759,9 +663,9 @@ class EnvViewModel : ViewModel() {
         )
     }
 
-    private suspend fun loadAppliedDeviceAuthConfig(): DeviceAuthConfigState {
+    private suspend fun loadAppliedDeviceAuthConfig(): DeviceAuthConfigState? {
         val prefs = ContextProvider.context.settingDataStore.data.first()
-        val clientId = prefs[stringPreferencesKey("da_clientId")] ?: return defaultDeviceAuthConfig
+        val clientId = prefs[stringPreferencesKey("da_clientId")] ?: return null
         return DeviceAuthConfigState(
             clientId = clientId,
             discoveryEndpoint = prefs[stringPreferencesKey("da_discoveryEndpoint")] ?: "",

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -8,7 +8,6 @@
 package com.pingidentity.samples.pingsampleapp.config
 
 import android.net.Uri
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -33,10 +32,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import org.json.JSONArray
-import org.json.JSONObject
+import kotlinx.serialization.json.buildJsonArray
+
 
 // ---------------------------------------------------------------------------
 // Config state data classes
@@ -69,12 +73,140 @@ data class DeviceAuthConfigState(
     val display: String = "Device Authorization",
     val authorizationEndpoint: String = "",
     val tokenEndpoint: String = "",
-    val userinfoEndpoint: String = "",
+    val userInfoEndpoint: String = "",
     val endSessionEndpoint: String = "",
     val revocationEndpoint: String = "",
     val deviceAuthorizationEndpoint: String = "",
     val acrValues: String = "",
 )
+
+// ---------------------------------------------------------------------------
+// JSON asset file loader
+// ---------------------------------------------------------------------------
+
+internal enum class AssetConfigType { JOURNEY, DAVINCI, WEB, DEVICE_AUTH }
+
+internal data class AssetConfigs(
+    val journey: List<JourneyConfigState> = emptyList(),
+    val davinci: List<OidcConfigState> = emptyList(),
+    val web: List<OidcConfigState> = emptyList(),
+    val deviceAuth: List<DeviceAuthConfigState> = emptyList(),
+)
+
+/**
+ * Scans all `*.json` files in the `assets/` directory and parses each one as an SDK-native
+ * configuration object. The results are surfaced as read-only presets in the configuration UI.
+ *
+ * Each file must follow the SDK's native JSON shape:
+ * ```json
+ * {
+ *   "journey": { "serverUrl": "...", "realm": "...", "cookieName": "..." },
+ *   "oidc":    { "clientId": "...", "discoveryEndpoint": "...", ... }
+ * }
+ * ```
+ *
+ * The **filename** (without the `.json` extension) is used as the display name in the UI.
+ * For example, `journey-prod.json` appears as `journey-prod` in the preset list.
+ *
+ * Config type is inferred from the JSON structure — no explicit `"type"` field is needed:
+ * - `"journey"` key present → [JourneyConfigState]
+ * - `"oidc.openId"` key present → [DeviceAuthConfigState]
+ * - Neither of the above → [OidcConfigState] (DaVinci)
+ *
+ * Files that do not contain an `"oidc"` object are silently skipped.
+ * Any parse error for an individual file is silently ignored; other files are still processed.
+ *
+ * @return [AssetConfigs] containing the parsed configs grouped by type.
+ */
+internal fun loadAssetConfigs(): AssetConfigs {
+    val context = ContextProvider.context
+    val fileNames = context.assets.list("") ?: return AssetConfigs()
+    val journey = mutableListOf<JourneyConfigState>()
+    val davinci = mutableListOf<OidcConfigState>()
+    val web = mutableListOf<OidcConfigState>()
+    val deviceAuth = mutableListOf<DeviceAuthConfigState>()
+
+    fun JsonObject.str(key: String) = this[key]?.jsonPrimitive?.content ?: ""
+
+    for (fileName in fileNames) {
+        if (!fileName.endsWith(".json")) continue
+        val displayName = fileName.removeSuffix(".json")
+        runCatching {
+            val root = Json.parseToJsonElement(
+                context.assets.open(fileName).bufferedReader().readText()
+            ).jsonObject
+            val isDaVinci = root.contains("journey").not()
+            val oidc = root["oidc"]?.jsonObject ?: return@runCatching
+            val journeyObj = root["journey"]?.jsonObject
+            val openIdObj = oidc["openId"]?.jsonObject
+
+            val scopes = oidc["scopes"]?.let { el ->
+                runCatching { el.jsonArray.joinToString(",") { it.jsonPrimitive.content } }
+                    .getOrElse { el.jsonPrimitive.content }
+            } ?: ""
+            val clientId = oidc.str("clientId")
+            val discoveryEndpoint = oidc.str("discoveryEndpoint")
+            val redirectUri = oidc.str("redirectUri")
+
+            val type: AssetConfigType = when {
+                journeyObj != null -> AssetConfigType.JOURNEY
+                openIdObj != null -> AssetConfigType.DEVICE_AUTH
+                isDaVinci -> AssetConfigType.DAVINCI
+                else -> AssetConfigType.WEB
+            }
+
+            when (type) {
+                AssetConfigType.JOURNEY -> journey.add(JourneyConfigState(
+                    serverUrl = journeyObj?.str("serverUrl") ?: "",
+                    realm = journeyObj?.str("realm") ?: "",
+                    cookie = journeyObj?.str("cookieName") ?: "",
+                    clientId = clientId,
+                    discoveryEndpoint = discoveryEndpoint,
+                    scopes = scopes,
+                    redirectUri = redirectUri,
+                    display = displayName,
+                ))
+                AssetConfigType.DAVINCI -> davinci.add(OidcConfigState(
+                    clientId = clientId,
+                    discoveryEndpoint = discoveryEndpoint,
+                    scopes = scopes,
+                    redirectUri = redirectUri,
+                    display = displayName,
+                    arcValue = oidc.str("acrValues"),
+                ))
+                AssetConfigType.DEVICE_AUTH -> deviceAuth.add(DeviceAuthConfigState(
+                    clientId = clientId,
+                    discoveryEndpoint = discoveryEndpoint,
+                    scopes = scopes,
+                    display = displayName,
+                    acrValues = oidc.str("acrValues"),
+                    authorizationEndpoint = openIdObj?.str("authorizationEndpoint") ?: "",
+                    tokenEndpoint = openIdObj?.str("tokenEndpoint") ?: "",
+                    userInfoEndpoint = openIdObj?.str("userInfoEndpoint") ?: "",
+                    endSessionEndpoint = openIdObj?.str("endSessionEndpoint") ?: "",
+                    revocationEndpoint = openIdObj?.str("revocationEndpoint") ?: "",
+                    deviceAuthorizationEndpoint = openIdObj?.str("deviceAuthorizationEndpoint") ?: "",
+                ))
+                else -> web.add(OidcConfigState(
+                    clientId = clientId,
+                    discoveryEndpoint = discoveryEndpoint,
+                    scopes = scopes,
+                    redirectUri = redirectUri,
+                    display = displayName,
+                ))
+            }
+            web.add(OidcConfigState(
+                clientId = clientId,
+                discoveryEndpoint = discoveryEndpoint,
+                scopes = scopes,
+                redirectUri = redirectUri,
+                display = displayName,
+            ))
+        }
+    }
+    return AssetConfigs(journey, davinci, web, deviceAuth)
+}
+
 
 // ---------------------------------------------------------------------------
 // Default preset configs (used as fallbacks when no saved config exists)
@@ -107,7 +239,7 @@ internal val defaultDeviceAuthConfig = DeviceAuthConfigState(
     display = "Device Authorization",
     authorizationEndpoint = "https://example.com/am/oauth2/alpha/authorize",
     tokenEndpoint = "https://example.com/am/oauth2/alpha/access_token",
-    userinfoEndpoint = "https://example.com/am/oauth2/alpha/userinfo",
+    userInfoEndpoint = "https://example.com/am/oauth2/alpha/userinfo",
     endSessionEndpoint = "https://example.com/am/oauth2/alpha/session/end",
     revocationEndpoint = "https://example.com/am/oauth2/alpha/token/revoke",
     deviceAuthorizationEndpoint = "https://example.com/am/oauth2/realms/root/realms/alpha/device/code",
@@ -235,9 +367,9 @@ internal fun buildDeviceAuthClient(config: DeviceAuthConfigState) {
                         JsonConfigKey.TOKEN_ENDPOINT,
                         config.tokenEndpoint
                     )
-                    if (config.userinfoEndpoint.isNotBlank()) put(
+                    if (config.userInfoEndpoint.isNotBlank()) put(
                         JsonConfigKey.USER_INFO_ENDPOINT,
-                        config.userinfoEndpoint
+                        config.userInfoEndpoint
                     )
                     if (config.endSessionEndpoint.isNotBlank()) put(
                         JsonConfigKey.END_SESSION_ENDPOINT,
@@ -315,7 +447,7 @@ suspend fun initConfigs() {
             display = prefs[stringPreferencesKey("da_display")] ?: "",
             authorizationEndpoint = prefs[stringPreferencesKey("da_authorizationEndpoint")] ?: "",
             tokenEndpoint = prefs[stringPreferencesKey("da_tokenEndpoint")] ?: "",
-            userinfoEndpoint = prefs[stringPreferencesKey("da_userinfoEndpoint")] ?: "",
+            userInfoEndpoint = prefs[stringPreferencesKey("da_userInfoEndpoint")] ?: "",
             endSessionEndpoint = prefs[stringPreferencesKey("da_endSessionEndpoint")] ?: "",
             revocationEndpoint = prefs[stringPreferencesKey("da_revocationEndpoint")] ?: "",
             deviceAuthorizationEndpoint = prefs[stringPreferencesKey("da_deviceAuthorizationEndpoint")] ?: "",
@@ -336,9 +468,9 @@ suspend fun initConfigs() {
 
 class EnvViewModel : ViewModel() {
 
-    // -- Preset lists (read-only, built-in) ----------------------------------
+    // -- Built-in preset lists (asset files are prepended in init) ------------
 
-    val journeyPresets = listOf(
+    private val builtInJourneyPresets = listOf(
         defaultJourneyConfig,
         JourneyConfigState(
             serverUrl = "http://192.168.86.32:8080/openam",
@@ -352,7 +484,7 @@ class EnvViewModel : ViewModel() {
         ),
     )
 
-    val daVinciPresets = listOf(
+    private val builtInDaVinciPresets = listOf(
         defaultDaVinciConfig,
         OidcConfigState(
             clientId = "dummy",
@@ -370,7 +502,7 @@ class EnvViewModel : ViewModel() {
         ),
     )
 
-    val webPresets = listOf(
+    private val builtInWebPresets = listOf(
         defaultWebConfig,
         OidcConfigState(
             clientId = "dummy",
@@ -381,7 +513,7 @@ class EnvViewModel : ViewModel() {
         ),
     )
 
-    val deviceAuthPresets = listOf(
+    private val builtInDeviceAuthPresets = listOf(
         defaultDeviceAuthConfig,
         DeviceAuthConfigState(
             clientId = "dummyPingOne",
@@ -390,6 +522,18 @@ class EnvViewModel : ViewModel() {
             display = "Dummy",
         ),
     )
+
+    var journeyPresets by mutableStateOf(builtInJourneyPresets)
+        private set
+
+    var daVinciPresets by mutableStateOf(builtInDaVinciPresets)
+        private set
+
+    var webPresets by mutableStateOf(builtInWebPresets)
+        private set
+
+    var deviceAuthPresets by mutableStateOf(builtInDeviceAuthPresets)
+        private set
 
     // -- Currently applied configs -------------------------------------------
 
@@ -423,6 +567,7 @@ class EnvViewModel : ViewModel() {
 
     init {
         viewModelScope.launch(Dispatchers.IO) {
+            val assetConfigs = loadAssetConfigs()
             val jApplied = loadAppliedJourneyFromDataStore()
             val dvApplied = loadAppliedDaVinciFromDataStore()
             val wApplied = loadAppliedWebFromDataStore()
@@ -433,6 +578,10 @@ class EnvViewModel : ViewModel() {
             val daCustom = loadCustomDeviceAuthFromDataStore()
 
             withContext(Dispatchers.Main) {
+                if (assetConfigs.journey.isNotEmpty()) journeyPresets = assetConfigs.journey + builtInJourneyPresets
+                if (assetConfigs.davinci.isNotEmpty()) daVinciPresets = assetConfigs.davinci + builtInDaVinciPresets
+                if (assetConfigs.web.isNotEmpty()) webPresets = assetConfigs.web + builtInWebPresets
+                if (assetConfigs.deviceAuth.isNotEmpty()) deviceAuthPresets = assetConfigs.deviceAuth + builtInDeviceAuthPresets
                 customJourneyConfigs = jCustom
                 customDaVinciConfigs = dvCustom
                 customWebConfigs = wCustom
@@ -636,7 +785,7 @@ class EnvViewModel : ViewModel() {
             display = prefs[stringPreferencesKey("da_display")] ?: "",
             authorizationEndpoint = prefs[stringPreferencesKey("da_authorizationEndpoint")] ?: "",
             tokenEndpoint = prefs[stringPreferencesKey("da_tokenEndpoint")] ?: "",
-            userinfoEndpoint = prefs[stringPreferencesKey("da_userinfoEndpoint")] ?: "",
+            userInfoEndpoint = prefs[stringPreferencesKey("da_userInfoEndpoint")] ?: "",
             endSessionEndpoint = prefs[stringPreferencesKey("da_endSessionEndpoint")] ?: "",
             revocationEndpoint = prefs[stringPreferencesKey("da_revocationEndpoint")] ?: "",
             deviceAuthorizationEndpoint = prefs[stringPreferencesKey("da_deviceAuthorizationEndpoint")] ?: "",
@@ -714,7 +863,7 @@ class EnvViewModel : ViewModel() {
             prefs[stringPreferencesKey("da_display")] = config.display
             prefs[stringPreferencesKey("da_authorizationEndpoint")] = config.authorizationEndpoint
             prefs[stringPreferencesKey("da_tokenEndpoint")] = config.tokenEndpoint
-            prefs[stringPreferencesKey("da_userinfoEndpoint")] = config.userinfoEndpoint
+            prefs[stringPreferencesKey("da_userInfoEndpoint")] = config.userInfoEndpoint
             prefs[stringPreferencesKey("da_endSessionEndpoint")] = config.endSessionEndpoint
             prefs[stringPreferencesKey("da_revocationEndpoint")] = config.revocationEndpoint
             prefs[stringPreferencesKey("da_deviceAuthorizationEndpoint")] = config.deviceAuthorizationEndpoint
@@ -750,96 +899,81 @@ class EnvViewModel : ViewModel() {
 
     // -- JSON serialization --------------------------------------------------
 
-    private fun serializeJourneyConfigs(configs: List<JourneyConfigState>): String {
-        val array = JSONArray()
-        configs.forEach { c ->
-            array.put(JSONObject().apply {
-                put("serverUrl", c.serverUrl); put("realm", c.realm); put("cookie", c.cookie)
-                put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
-                put("scopes", c.scopes); put("redirectUri", c.redirectUri); put("display", c.display)
-            })
-        }
-        return array.toString()
-    }
+    private fun serializeJourneyConfigs(configs: List<JourneyConfigState>): String =
+        buildJsonArray {
+            configs.forEach { c ->
+                add(buildJsonObject {
+                    put("serverUrl", c.serverUrl); put("realm", c.realm); put("cookie", c.cookie)
+                    put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
+                    put("scopes", c.scopes); put("redirectUri", c.redirectUri); put("display", c.display)
+                })
+            }
+        }.toString()
 
     private fun deserializeJourneyConfigs(json: String): List<JourneyConfigState> = runCatching {
-        val array = JSONArray(json)
-        (0 until array.length()).map {
-            val o = array.getJSONObject(it)
+        Json.parseToJsonElement(json).jsonArray.map { el ->
+            val o = el.jsonObject
+            fun str(k: String) = o[k]?.jsonPrimitive?.content ?: ""
             JourneyConfigState(
-                serverUrl = o.optString("serverUrl", ""),
-                realm = o.optString("realm", ""),
-                cookie = o.optString("cookie", ""),
-                clientId = o.optString("clientId", ""),
-                discoveryEndpoint = o.optString("discoveryEndpoint", ""),
-                scopes = o.optString("scopes", ""),
-                redirectUri = o.optString("redirectUri", ""),
-                display = o.optString("display", ""),
+                serverUrl = str("serverUrl"), realm = str("realm"), cookie = str("cookie"),
+                clientId = str("clientId"), discoveryEndpoint = str("discoveryEndpoint"),
+                scopes = str("scopes"), redirectUri = str("redirectUri"), display = str("display"),
             )
         }
     }.getOrDefault(emptyList())
 
-    private fun serializeOidcConfigs(configs: List<OidcConfigState>): String {
-        val array = JSONArray()
-        configs.forEach { c ->
-            array.put(JSONObject().apply {
-                put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
-                put("scopes", c.scopes); put("redirectUri", c.redirectUri); put("display", c.display)
-                put("arcValue", c.arcValue)
-            })
-        }
-        return array.toString()
-    }
+    private fun serializeOidcConfigs(configs: List<OidcConfigState>): String =
+        buildJsonArray {
+            configs.forEach { c ->
+                add(buildJsonObject {
+                    put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
+                    put("scopes", c.scopes); put("redirectUri", c.redirectUri)
+                    put("display", c.display); put("arcValue", c.arcValue)
+                })
+            }
+        }.toString()
 
     private fun deserializeOidcConfigs(json: String): List<OidcConfigState> = runCatching {
-        val array = JSONArray(json)
-        (0 until array.length()).map {
-            val o = array.getJSONObject(it)
+        Json.parseToJsonElement(json).jsonArray.map { el ->
+            val o = el.jsonObject
+            fun str(k: String) = o[k]?.jsonPrimitive?.content ?: ""
             OidcConfigState(
-                clientId = o.optString("clientId", ""),
-                discoveryEndpoint = o.optString("discoveryEndpoint", ""),
-                scopes = o.optString("scopes", ""),
-                redirectUri = o.optString("redirectUri", ""),
-                display = o.optString("display", ""),
-                arcValue = o.optString("arcValue", ""),
+                clientId = str("clientId"), discoveryEndpoint = str("discoveryEndpoint"),
+                scopes = str("scopes"), redirectUri = str("redirectUri"),
+                display = str("display"), arcValue = str("arcValue"),
             )
         }
     }.getOrDefault(emptyList())
 
-    private fun serializeDeviceAuthConfigs(configs: List<DeviceAuthConfigState>): String {
-        val array = JSONArray()
-        configs.forEach { c ->
-            array.put(JSONObject().apply {
-                put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
-                put("scopes", c.scopes); put("display", c.display)
-                put("authorizationEndpoint", c.authorizationEndpoint)
-                put("tokenEndpoint", c.tokenEndpoint)
-                put("userinfoEndpoint", c.userinfoEndpoint)
-                put("endSessionEndpoint", c.endSessionEndpoint)
-                put("revocationEndpoint", c.revocationEndpoint)
-                put("deviceAuthorizationEndpoint", c.deviceAuthorizationEndpoint)
-                put("acrValues", c.acrValues)
-            })
-        }
-        return array.toString()
-    }
+    private fun serializeDeviceAuthConfigs(configs: List<DeviceAuthConfigState>): String =
+        buildJsonArray {
+            configs.forEach { c ->
+                add(buildJsonObject {
+                    put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
+                    put("scopes", c.scopes); put("display", c.display)
+                    put("authorizationEndpoint", c.authorizationEndpoint)
+                    put("tokenEndpoint", c.tokenEndpoint); put("userInfoEndpoint", c.userInfoEndpoint)
+                    put("endSessionEndpoint", c.endSessionEndpoint)
+                    put("revocationEndpoint", c.revocationEndpoint)
+                    put("deviceAuthorizationEndpoint", c.deviceAuthorizationEndpoint)
+                    put("acrValues", c.acrValues)
+                })
+            }
+        }.toString()
 
     private fun deserializeDeviceAuthConfigs(json: String): List<DeviceAuthConfigState> = runCatching {
-        val array = JSONArray(json)
-        (0 until array.length()).map {
-            val o = array.getJSONObject(it)
+        Json.parseToJsonElement(json).jsonArray.map { el ->
+            val o = el.jsonObject
+            fun str(k: String) = o[k]?.jsonPrimitive?.content ?: ""
             DeviceAuthConfigState(
-                clientId = o.optString("clientId", ""),
-                discoveryEndpoint = o.optString("discoveryEndpoint", ""),
-                scopes = o.optString("scopes", ""),
-                display = o.optString("display", ""),
-                authorizationEndpoint = o.optString("authorizationEndpoint", ""),
-                tokenEndpoint = o.optString("tokenEndpoint", ""),
-                userinfoEndpoint = o.optString("userinfoEndpoint", ""),
-                endSessionEndpoint = o.optString("endSessionEndpoint", ""),
-                revocationEndpoint = o.optString("revocationEndpoint", ""),
-                deviceAuthorizationEndpoint = o.optString("deviceAuthorizationEndpoint", ""),
-                acrValues = o.optString("acrValues", ""),
+                clientId = str("clientId"), discoveryEndpoint = str("discoveryEndpoint"),
+                scopes = str("scopes"), display = str("display"),
+                authorizationEndpoint = str("authorizationEndpoint"),
+                tokenEndpoint = str("tokenEndpoint"), userInfoEndpoint = str("userInfoEndpoint"),
+                endSessionEndpoint = str("endSessionEndpoint"),
+                revocationEndpoint = str("revocationEndpoint"),
+                deviceAuthorizationEndpoint = str("deviceAuthorizationEndpoint"),
+                acrValues = str("acrValues"),
             )
         }
     }.getOrDefault(emptyList())

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -84,8 +84,6 @@ data class DeviceAuthConfigState(
 // JSON asset file loader
 // ---------------------------------------------------------------------------
 
-internal enum class AssetConfigType { JOURNEY, DAVINCI, WEB, DEVICE_AUTH }
-
 internal data class AssetConfigs(
     val journey: List<JourneyConfigState> = emptyList(),
     val davinci: List<OidcConfigState> = emptyList(),
@@ -108,10 +106,11 @@ internal data class AssetConfigs(
  * The **filename** (without the `.json` extension) is used as the display name in the UI.
  * For example, `journey-prod.json` appears as `journey-prod` in the preset list.
  *
- * Config type is inferred from the JSON structure — no explicit `"type"` field is needed:
- * - `"journey"` key present → [JourneyConfigState]
- * - `"oidc.openId"` key present → [DeviceAuthConfigState]
- * - Neither of the above → [OidcConfigState] (DaVinci)
+ * A single file can populate multiple config types — checks are independent:
+ * - `"journey"` key present → adds a [JourneyConfigState]
+ * - `"oidc.openId"` key present → adds a [DeviceAuthConfigState]
+ * - No `"journey"` key → adds a DaVinci [OidcConfigState]
+ * - A Web [OidcConfigState] config will always be added.
  *
  * Files that do not contain an `"oidc"` object are silently skipped.
  * Any parse error for an individual file is silently ignored; other files are still processed.
@@ -148,53 +147,38 @@ internal fun loadAssetConfigs(): AssetConfigs {
             val discoveryEndpoint = oidc.str("discoveryEndpoint")
             val redirectUri = oidc.str("redirectUri")
 
-            val type: AssetConfigType = when {
-                journeyObj != null -> AssetConfigType.JOURNEY
-                openIdObj != null -> AssetConfigType.DEVICE_AUTH
-                isDaVinci -> AssetConfigType.DAVINCI
-                else -> AssetConfigType.WEB
-            }
+            if (journeyObj != null) journey.add(JourneyConfigState(
+                serverUrl = journeyObj.str("serverUrl"),
+                realm = journeyObj.str("realm"),
+                cookie = journeyObj.str("cookieName"),
+                clientId = clientId,
+                discoveryEndpoint = discoveryEndpoint,
+                scopes = scopes,
+                redirectUri = redirectUri,
+                display = displayName,
+            ))
+            if (openIdObj != null) deviceAuth.add(DeviceAuthConfigState(
+                clientId = clientId,
+                discoveryEndpoint = discoveryEndpoint,
+                scopes = scopes,
+                display = displayName,
+                acrValues = oidc.str("acrValues"),
+                authorizationEndpoint = openIdObj.str("authorizationEndpoint"),
+                tokenEndpoint = openIdObj.str("tokenEndpoint"),
+                userInfoEndpoint = openIdObj.str("userInfoEndpoint"),
+                endSessionEndpoint = openIdObj.str("endSessionEndpoint"),
+                revocationEndpoint = openIdObj.str("revocationEndpoint"),
+                deviceAuthorizationEndpoint = openIdObj.str("deviceAuthorizationEndpoint"),
+            ))
+            if (isDaVinci) davinci.add(OidcConfigState(
+                clientId = clientId,
+                discoveryEndpoint = discoveryEndpoint,
+                scopes = scopes,
+                redirectUri = redirectUri,
+                display = displayName,
+                arcValue = oidc.str("acrValues"),
+            ))
 
-            when (type) {
-                AssetConfigType.JOURNEY -> journey.add(JourneyConfigState(
-                    serverUrl = journeyObj?.str("serverUrl") ?: "",
-                    realm = journeyObj?.str("realm") ?: "",
-                    cookie = journeyObj?.str("cookieName") ?: "",
-                    clientId = clientId,
-                    discoveryEndpoint = discoveryEndpoint,
-                    scopes = scopes,
-                    redirectUri = redirectUri,
-                    display = displayName,
-                ))
-                AssetConfigType.DAVINCI -> davinci.add(OidcConfigState(
-                    clientId = clientId,
-                    discoveryEndpoint = discoveryEndpoint,
-                    scopes = scopes,
-                    redirectUri = redirectUri,
-                    display = displayName,
-                    arcValue = oidc.str("acrValues"),
-                ))
-                AssetConfigType.DEVICE_AUTH -> deviceAuth.add(DeviceAuthConfigState(
-                    clientId = clientId,
-                    discoveryEndpoint = discoveryEndpoint,
-                    scopes = scopes,
-                    display = displayName,
-                    acrValues = oidc.str("acrValues"),
-                    authorizationEndpoint = openIdObj?.str("authorizationEndpoint") ?: "",
-                    tokenEndpoint = openIdObj?.str("tokenEndpoint") ?: "",
-                    userInfoEndpoint = openIdObj?.str("userInfoEndpoint") ?: "",
-                    endSessionEndpoint = openIdObj?.str("endSessionEndpoint") ?: "",
-                    revocationEndpoint = openIdObj?.str("revocationEndpoint") ?: "",
-                    deviceAuthorizationEndpoint = openIdObj?.str("deviceAuthorizationEndpoint") ?: "",
-                ))
-                else -> web.add(OidcConfigState(
-                    clientId = clientId,
-                    discoveryEndpoint = discoveryEndpoint,
-                    scopes = scopes,
-                    redirectUri = redirectUri,
-                    display = displayName,
-                ))
-            }
             web.add(OidcConfigState(
                 clientId = clientId,
                 discoveryEndpoint = discoveryEndpoint,

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/TokenViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/token/TokenViewModel.kt
@@ -108,55 +108,49 @@ class TokenViewModel : ViewModel() {
     // Journey Token Operations
     private fun journeyAccessToken() {
         viewModelScope.launch {
-            journey?.journeyUser()?.let {
-                when (val result = it.token()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                journey?.journeyUser()?.let {
+                    when (val result = it.token()) {
+                        is Failure -> state.update { state ->
                             state.copy(journeyToken = null, journeyError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(journeyToken = result.value, journeyError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(journeyToken = null, journeyError = null)
-                }
+                } ?: state.update { it.copy(journeyToken = null, journeyError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(journeyToken = null, journeyError = null) }
             }
         }
     }
 
     private fun journeyRevoke() {
         viewModelScope.launch {
-            journey?.journeyUser()?.revoke()
-            state.update {
-                it.copy(journeyToken = null, journeyError = null)
+            try {
+                journey?.journeyUser()?.revoke()
+            } catch (e: Exception) {
+                // ignore revoke errors
             }
+            state.update { it.copy(journeyToken = null, journeyError = null) }
         }
     }
 
     private fun journeyRefresh() {
         viewModelScope.launch {
-            journey?.journeyUser()?.let {
-                when (val result = it.refresh()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                journey?.journeyUser()?.let {
+                    when (val result = it.refresh()) {
+                        is Failure -> state.update { state ->
                             state.copy(journeyToken = null, journeyError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(journeyToken = result.value, journeyError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(journeyToken = null, journeyError = null)
-                }
+                } ?: state.update { it.copy(journeyToken = null, journeyError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(journeyToken = null, journeyError = null) }
             }
         }
     }
@@ -164,55 +158,49 @@ class TokenViewModel : ViewModel() {
     // DaVinci Token Operations
     private fun daVinciAccessToken() {
         viewModelScope.launch {
-            daVinci?.davinciUser()?.let {
-                when (val result = it.token()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                daVinci?.davinciUser()?.let {
+                    when (val result = it.token()) {
+                        is Failure -> state.update { state ->
                             state.copy(daVinciToken = null, daVinciError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(daVinciToken = result.value, daVinciError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(daVinciToken = null, daVinciError = null)
-                }
+                } ?: state.update { it.copy(daVinciToken = null, daVinciError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(daVinciToken = null, daVinciError = null) }
             }
         }
     }
 
     private fun daVinciRevoke() {
         viewModelScope.launch {
-            daVinci?.davinciUser()?.revoke()
-            state.update {
-                it.copy(daVinciToken = null, daVinciError = null)
+            try {
+                daVinci?.davinciUser()?.revoke()
+            } catch (e: Exception) {
+                // ignore revoke errors
             }
+            state.update { it.copy(daVinciToken = null, daVinciError = null) }
         }
     }
 
     private fun daVinciRefresh() {
         viewModelScope.launch {
-            daVinci?.davinciUser()?.let {
-                when (val result = it.refresh()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                daVinci?.davinciUser()?.let {
+                    when (val result = it.refresh()) {
+                        is Failure -> state.update { state ->
                             state.copy(daVinciToken = null, daVinciError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(daVinciToken = result.value, daVinciError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(daVinciToken = null, daVinciError = null)
-                }
+                } ?: state.update { it.copy(daVinciToken = null, daVinciError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(daVinciToken = null, daVinciError = null) }
             }
         }
     }
@@ -220,55 +208,49 @@ class TokenViewModel : ViewModel() {
     // OIDC Token Operations
     private fun oidcAccessToken() {
         viewModelScope.launch {
-            web?.user()?.let {
-                when (val result = it.token()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                web?.user()?.let {
+                    when (val result = it.token()) {
+                        is Failure -> state.update { state ->
                             state.copy(oidcToken = null, oidcError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(oidcToken = result.value, oidcError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(oidcToken = null, oidcError = null)
-                }
+                } ?: state.update { it.copy(oidcToken = null, oidcError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(oidcToken = null, oidcError = null) }
             }
         }
     }
 
     private fun oidcRevoke() {
         viewModelScope.launch {
-            web?.user()?.revoke()
-            state.update {
-                it.copy(oidcToken = null, oidcError = null)
+            try {
+                web?.user()?.revoke()
+            } catch (e: Exception) {
+                // ignore revoke errors
             }
+            state.update { it.copy(oidcToken = null, oidcError = null) }
         }
     }
 
     private fun oidcRefresh() {
         viewModelScope.launch {
-            web?.user()?.let {
-                when (val result = it.refresh()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                web?.user()?.let {
+                    when (val result = it.refresh()) {
+                        is Failure -> state.update { state ->
                             state.copy(oidcToken = null, oidcError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(oidcToken = result.value, oidcError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(oidcToken = null, oidcError = null)
-                }
+                } ?: state.update { it.copy(oidcToken = null, oidcError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(oidcToken = null, oidcError = null) }
             }
         }
     }
@@ -276,60 +258,52 @@ class TokenViewModel : ViewModel() {
     // Auth Grant Token Operations
     private fun authGrantAccessToken() {
         viewModelScope.launch {
-            oidcDeviceClient?.user()?.let {
-                when (val result = it.token()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                oidcDeviceClient?.user()?.let {
+                    when (val result = it.token()) {
+                        is Failure -> state.update { state ->
                             state.copy(authGrantToken = null, authGrantError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(authGrantToken = result.value, authGrantError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(authGrantToken = null, authGrantError = null)
-                }
+                } ?: state.update { it.copy(authGrantToken = null, authGrantError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(authGrantToken = null, authGrantError = null) }
             }
         }
     }
 
     private fun authGrantRevoke() {
         viewModelScope.launch {
-            oidcDeviceClient?.user()?.revoke()
-            state.update {
-                it.copy(authGrantToken = null, authGrantError = null)
+            try {
+                oidcDeviceClient?.user()?.revoke()
+            } catch (e: Exception) {
+                // ignore revoke errors
             }
+            state.update { it.copy(authGrantToken = null, authGrantError = null) }
         }
     }
 
     private fun authGrantRefresh() {
         viewModelScope.launch {
-            oidcDeviceClient?.user()?.let {
-                when (val result = it.refresh()) {
-                    is Failure -> {
-                        state.update { state ->
+            try {
+                oidcDeviceClient?.user()?.let {
+                    when (val result = it.refresh()) {
+                        is Failure -> state.update { state ->
                             state.copy(authGrantToken = null, authGrantError = result.value)
                         }
-                    }
-                    is Success -> {
-                        state.update { state ->
+                        is Success -> state.update { state ->
                             state.copy(authGrantToken = result.value, authGrantError = null)
                         }
                     }
-                }
-            } ?: run {
-                state.update {
-                    it.copy(authGrantToken = null, authGrantError = null)
-                }
+                } ?: state.update { it.copy(authGrantToken = null, authGrantError = null) }
+            } catch (e: Exception) {
+                state.update { it.copy(authGrantToken = null, authGrantError = null) }
             }
         }
     }
-
-
 
     companion object {
         fun factory(): ViewModelProvider.Factory = object : ViewModelProvider.Factory {

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/userprofile/UserProfileViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/userprofile/UserProfileViewModel.kt
@@ -101,14 +101,18 @@ class UserProfileViewModel : ViewModel() {
     // Journey Operations
     private fun journeyUserInfo() {
         viewModelScope.launch {
-            val user = journey?.journeyUser()
-            if (user == null) {
+            try {
+                val user = journey?.journeyUser()
+                if (user == null) {
+                    state.update { s -> s.copy(journeyUser = null, journeyError = null) }
+                    return@launch
+                }
+                when (val result = user.userinfo(false)) {
+                    is Result.Failure -> state.update { s -> s.copy(journeyUser = null, journeyError = result.value) }
+                    is Result.Success -> state.update { s -> s.copy(journeyUser = result.value, journeyError = null) }
+                }
+            } catch (e: Exception) {
                 state.update { s -> s.copy(journeyUser = null, journeyError = null) }
-                return@launch
-            }
-            when (val result = user.userinfo(false)) {
-                is Result.Failure -> state.update { s -> s.copy(journeyUser = null, journeyError = result.value) }
-                is Result.Success -> state.update { s -> s.copy(journeyUser = result.value, journeyError = null) }
             }
         }
     }
@@ -122,14 +126,18 @@ class UserProfileViewModel : ViewModel() {
     // DaVinci Operations
     private fun daVinciUserInfo() {
         viewModelScope.launch {
-            val user = daVinci?.davinciUser()
-            if (user == null) {
+            try {
+                val user = daVinci?.davinciUser()
+                if (user == null) {
+                    state.update { s -> s.copy(daVinciUser = null, daVinciError = null) }
+                    return@launch
+                }
+                when (val result = user.userinfo(false)) {
+                    is Result.Failure -> state.update { s -> s.copy(daVinciUser = null, daVinciError = result.value) }
+                    is Result.Success -> state.update { s -> s.copy(daVinciUser = result.value, daVinciError = null) }
+                }
+            } catch (e: Exception) {
                 state.update { s -> s.copy(daVinciUser = null, daVinciError = null) }
-                return@launch
-            }
-            when (val result = user.userinfo(false)) {
-                is Result.Failure -> state.update { s -> s.copy(daVinciUser = null, daVinciError = result.value) }
-                is Result.Success -> state.update { s -> s.copy(daVinciUser = result.value, daVinciError = null) }
             }
         }
     }
@@ -143,14 +151,18 @@ class UserProfileViewModel : ViewModel() {
     // OIDC Operations
     private fun oidcUserInfo() {
         viewModelScope.launch {
-            val user = web?.user()
-            if (user == null) {
+            try {
+                val user = web?.user()
+                if (user == null) {
+                    state.update { s -> s.copy(oidcUser = null, oidcError = null) }
+                    return@launch
+                }
+                when (val result = user.userinfo(false)) {
+                    is Result.Failure -> state.update { s -> s.copy(oidcUser = null, oidcError = result.value) }
+                    is Result.Success -> state.update { s -> s.copy(oidcUser = result.value, oidcError = null) }
+                }
+            } catch (e: Exception) {
                 state.update { s -> s.copy(oidcUser = null, oidcError = null) }
-                return@launch
-            }
-            when (val result = user.userinfo(false)) {
-                is Result.Failure -> state.update { s -> s.copy(oidcUser = null, oidcError = result.value) }
-                is Result.Success -> state.update { s -> s.copy(oidcUser = result.value, oidcError = null) }
             }
         }
     }
@@ -164,14 +176,18 @@ class UserProfileViewModel : ViewModel() {
     // Auth Grant Operations
     fun authGrantUserInfo() {
         viewModelScope.launch {
-            val user = oidcDeviceClient?.user()
-            if (user == null) {
+            try {
+                val user = oidcDeviceClient?.user()
+                if (user == null) {
+                    state.update { s -> s.copy(authGrantUser = null, authGrantError = null) }
+                    return@launch
+                }
+                when (val result = user.userinfo(false)) {
+                    is Result.Failure -> state.update { s -> s.copy(authGrantUser = null, authGrantError = result.value) }
+                    is Result.Success -> state.update { s -> s.copy(authGrantUser = result.value, authGrantError = null) }
+                }
+            } catch (e: Exception) {
                 state.update { s -> s.copy(authGrantUser = null, authGrantError = null) }
-                return@launch
-            }
-            when (val result = user.userinfo(false)) {
-                is Result.Failure -> state.update { s -> s.copy(authGrantUser = null, authGrantError = result.value) }
-                is Result.Success -> state.update { s -> s.copy(authGrantUser = result.value, authGrantError = null) }
             }
         }
     }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5184](https://pingidentity.atlassian.net/browse/SDKS-5184)

# Description
This PR provides an option to load json files of configuration. 
<img width="1408" height="2974" alt="image" src="https://github.com/user-attachments/assets/32af0ad0-bc07-42e9-97c4-159695353d6d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new sample OIDC configuration files (DaVinci, Journey, and OpenID) with configurable timeouts, logging, and additional authentication parameters.
* **Refactor**
  * Improved configuration preset loading by auto-discovering bundled JSON assets and using safer JSON-based persistence and application of presets.
  * Updated environment preset state initialization to be more predictable and only activate SDK setup when required identifiers are present.
* **Bug Fixes**
  * Standardized Device Auth user-info endpoint naming across the UI and saved configuration.
  * Added stronger error handling for token and user-info requests to prevent crashes and clear stale results on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->