### PR TITLE
SDKS-5068: QA for the Unified SDK Configuration

### DIFF
--- a/davinci/src/androidTest/assets/full-davinci-config.json
+++ b/davinci/src/androidTest/assets/full-davinci-config.json
@@ -1,0 +1,32 @@
+{
+  "timeout": 30000,
+  "log": "WARN",
+  "oidc": {
+    "clientId": "a6859a12-5e6e-4f64-96bb-cc8577706bee",
+    "discoveryEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "org.forgerock.demo://oauth2redirect",
+    "signOutRedirectUri": "org.forgerock.demo://signout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "test-state",
+    "nonce": "test-nonce",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level2",
+    "par": true,
+    "additionalParameters": {
+      "max_age": "3600",
+      "custom_param": "custom_value"
+    },
+    "openId": {
+      "authorizationEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/authorize",
+      "tokenEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/token",
+      "userInfoEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/userinfo",
+      "endSessionEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/signoff",
+      "revocationEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/revoke",
+      "deviceAuthorizationEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/device_authorization"
+    }
+  }
+}

--- a/davinci/src/androidTest/assets/full-oidc-deviceclient.json
+++ b/davinci/src/androidTest/assets/full-oidc-deviceclient.json
@@ -1,0 +1,32 @@
+{
+  "timeout": 30000,
+  "log": "WARN",
+  "oidc": {
+    "clientId": "a6859a12-5e6e-4f64-96bb-cc8577706bee",
+    "discoveryEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "org.forgerock.demo://oauth2redirect",
+    "signOutRedirectUri": "org.forgerock.demo://signout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "test-state",
+    "nonce": "test-nonce",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level2",
+    "par": true,
+    "additionalParameters": {
+      "max_age": "3600",
+      "custom_param": "custom_value"
+    },
+    "openId": {
+      "deviceAuthorizationEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/device_authorization",
+      "authorizationEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/authorize",
+      "tokenEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/token",
+      "userInfoEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/userinfo",
+      "endSessionEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/signoff",
+      "revocationEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/revoke"
+    }
+  }
+}

--- a/davinci/src/androidTest/assets/minimal-davinci.json
+++ b/davinci/src/androidTest/assets/minimal-davinci.json
@@ -1,0 +1,8 @@
+{
+  "oidc": {
+    "clientId": "a6859a12-5e6e-4f64-96bb-cc8577706bee",
+    "discoveryEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "org.forgerock.demo://oauth2redirect"
+  }
+}

--- a/davinci/src/androidTest/assets/minimal-oidc-deviceclient.json
+++ b/davinci/src/androidTest/assets/minimal-oidc-deviceclient.json
@@ -1,0 +1,7 @@
+{
+  "oidc": {
+    "clientId": "a6859a12-5e6e-4f64-96bb-cc8577706bee",
+    "discoveryEndpoint": "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"]
+  }
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/JsonConfigTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/JsonConfigTest.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import androidx.test.filters.SmallTest
+import com.pingidentity.android.ContextProvider
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.None
+import com.pingidentity.logger.WARN
+import com.pingidentity.oidc.JsonConfigError
+import com.pingidentity.oidc.OidcClientConfig
+import com.pingidentity.oidc.OpenIdConfiguration
+import com.pingidentity.oidc.module.Oidc
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@SmallTest
+class JsonConfigTest {
+
+    @Test
+    fun loadMinimalDaVinciConfigFromJsonFile() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-davinci.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val result = DaVinci(json)
+
+        assertTrue(result.isSuccess, "DaVinci(json) should succeed but failed: ${result.exceptionOrNull()?.message}")
+
+        val daVinci = result.getOrThrow()
+        val oidcConfig = daVinci.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        assertEquals("a6859a12-5e6e-4f64-96bb-cc8577706bee", oidcConfig.clientId)
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("org.forgerock.demo://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid", "profile", "email"), oidcConfig.scopes)
+    }
+
+    @Test
+    fun daVinciDefaultValues() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-davinci.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val daVinci = DaVinci(json).getOrThrow()
+        val oidcConfig = daVinci.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        // WorkflowConfig defaults
+        assertEquals(15_000L, daVinci.config.timeout)
+        assertIs<None>(daVinci.config.logger)
+
+        // OidcClientConfig optional field defaults
+        assertNull(oidcConfig.signOutRedirectUri)
+        assertEquals(0L, oidcConfig.refreshThreshold)
+        assertNull(oidcConfig.loginHint)
+        assertNull(oidcConfig.state)
+        assertNull(oidcConfig.nonce)
+        assertNull(oidcConfig.display)
+        assertNull(oidcConfig.prompt)
+        assertNull(oidcConfig.uiLocales)
+        assertNull(oidcConfig.acrValues)
+        assertFalse(oidcConfig.par)
+        assertEquals(emptyMap<String, String>(), oidcConfig.additionalParameters)
+        assertNull(oidcConfig.openIdOverride)
+    }
+
+    @Test
+    fun daVinciFullConfig() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("full-davinci-config.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val daVinci = DaVinci(json).getOrThrow()
+        val oidcConfig = daVinci.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        // WorkflowConfig
+        assertEquals(30_000L, daVinci.config.timeout)
+        assertSame(Logger.WARN, daVinci.config.logger)
+
+        // Required OIDC fields
+        assertEquals("a6859a12-5e6e-4f64-96bb-cc8577706bee", oidcConfig.clientId)
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("org.forgerock.demo://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid", "profile", "email"), oidcConfig.scopes)
+
+        // Optional OIDC fields
+        assertEquals("org.forgerock.demo://signout", oidcConfig.signOutRedirectUri)
+        assertEquals(60L, oidcConfig.refreshThreshold)
+        assertEquals("user@example.com", oidcConfig.loginHint)
+        assertEquals("test-state", oidcConfig.state)
+        assertEquals("test-nonce", oidcConfig.nonce)
+        assertEquals("page", oidcConfig.display)
+        assertEquals("login", oidcConfig.prompt)
+        assertEquals("en-US", oidcConfig.uiLocales)
+        assertEquals("Level2", oidcConfig.acrValues)
+        assertEquals(true, oidcConfig.par)
+        assertEquals(mapOf("max_age" to "3600", "custom_param" to "custom_value"), oidcConfig.additionalParameters)
+        assertNotNull(oidcConfig.openIdOverride)
+    }
+
+    @Test
+    fun daVinciMissingRequiredFieldReturnsError() {
+        val base = buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", "a6859a12-5e6e-4f64-96bb-cc8577706bee")
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", "openid")
+                put("redirectUri", "org.forgerock.demo://oauth2redirect")
+            })
+        }
+
+        fun withoutOidcField(field: String): JsonObject = buildJsonObject {
+            put("oidc", buildJsonObject {
+                base["oidc"]!!.jsonObject.forEach { (k, v) -> if (k != field) put(k, v) }
+            })
+        }
+
+        // Missing oidc.clientId
+        DaVinci(withoutOidcField("clientId")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.discoveryEndpoint
+        DaVinci(withoutOidcField("discoveryEndpoint")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("discoveryEndpoint", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.scopes
+        DaVinci(withoutOidcField("scopes")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.redirectUri
+        DaVinci(withoutOidcField("redirectUri")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("redirectUri", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc block entirely
+        DaVinci(buildJsonObject {}).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("oidc", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+    }
+
+    @Test
+    fun daVinciOpenIdEndpointsAreLoaded() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("full-davinci-config.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val daVinci = DaVinci(json).getOrThrow()
+        val oidcConfig = daVinci.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        val override = oidcConfig.openIdOverride
+        assertNotNull(override, "openIdOverride should be set when openId block is present")
+
+        val openId = OpenIdConfiguration().apply { override() }
+
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/authorize",
+            openId.authorizationEndpoint,
+        )
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/token",
+            openId.tokenEndpoint,
+        )
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/userinfo",
+            openId.userinfoEndpoint,
+        )
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/signoff",
+            openId.endSessionEndpoint,
+        )
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/revoke",
+            openId.revocationEndpoint,
+        )
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/device_authorization",
+            openId.deviceAuthorizationEndpoint,
+        )
+    }
+
+    @Test
+    fun daVinciUnknownFieldsAreIgnored() {
+        val json = buildJsonObject {
+            put("unknownTopLevel", "should-be-ignored")
+            put("extraFlag", true)
+            put("oidc", buildJsonObject {
+                put("clientId", "a6859a12-5e6e-4f64-96bb-cc8577706bee")
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "org.forgerock.demo://oauth2redirect")
+                put("unknownOidcField", "also-ignored")
+                put("extraOidcObject", buildJsonObject { put("nested", "value") })
+            })
+        }
+
+        val result = DaVinci(json)
+
+        assertTrue(result.isSuccess, "DaVinci(json) should succeed with unknown fields but failed: ${result.exceptionOrNull()?.message}")
+
+        val daVinci = result.getOrThrow()
+        val oidcConfig = daVinci.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        assertEquals("a6859a12-5e6e-4f64-96bb-cc8577706bee", oidcConfig.clientId)
+        assertEquals(
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("org.forgerock.demo://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid"), oidcConfig.scopes)
+    }
+
+    @Test
+    fun daVinciWrongFieldTypeReturnsError() {
+        fun validOidc(overrides: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit) = buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", "a6859a12-5e6e-4f64-96bb-cc8577706bee")
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "org.forgerock.demo://oauth2redirect")
+                overrides()
+            })
+        }
+
+        // timeout as a non-numeric string instead of a number
+        DaVinci(buildJsonObject {
+            put("timeout", "not-a-number")
+            put("oidc", validOidc {}["oidc"]!!)
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("timeout", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.clientId as an object instead of a string
+        DaVinci(buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", buildJsonObject {})
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "org.forgerock.demo://oauth2redirect")
+            })
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.scopes as a number instead of string or array
+        DaVinci(validOidc { put("scopes", 123) }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.refreshThreshold as a non-numeric string instead of a number
+        DaVinci(validOidc { put("refreshThreshold", "not-a-number") }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("refreshThreshold", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+    }
+}

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/OidcDeviceClientJsonConfigTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/OidcDeviceClientJsonConfigTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import androidx.test.filters.SmallTest
+import com.pingidentity.android.ContextProvider
+import com.pingidentity.oidc.JsonConfigError
+import com.pingidentity.oidc.OidcDeviceClient
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@SmallTest
+class OidcDeviceClientJsonConfigTest {
+
+    @Test
+    fun oidcDeviceClientSucceedsWithMinimalJsonFile() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-oidc-deviceclient.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val result = OidcDeviceClient(json)
+
+        assertTrue(result.isSuccess, "OidcDeviceClient(json) should succeed but failed: ${result.exceptionOrNull()?.message}")
+    }
+
+    @Test
+    fun oidcDeviceClientSucceedsWithFullJsonFile() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("full-oidc-deviceclient.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val result = OidcDeviceClient(json)
+
+        assertTrue(result.isSuccess, "OidcDeviceClient(json) should succeed with all optional fields but failed: ${result.exceptionOrNull()?.message}")
+    }
+
+    @Test
+    fun oidcDeviceClientMissingRequiredFieldReturnsError() {
+        val validOidc = buildJsonObject {
+            put("clientId", "a6859a12-5e6e-4f64-96bb-cc8577706bee")
+            put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+            put("scopes", "openid")
+        }
+
+        fun withoutOidcField(field: String): JsonObject = buildJsonObject {
+            put("oidc", buildJsonObject {
+                validOidc.forEach { (k, v) -> if (k != field) put(k, v) }
+            })
+        }
+
+        // redirectUri is intentionally absent: OidcDeviceClient does not require it
+        // (device flow uses a device code exchange, not a redirect callback)
+
+        // Missing oidc block entirely
+        OidcDeviceClient(buildJsonObject {}).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("oidc", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.clientId
+        OidcDeviceClient(withoutOidcField("clientId")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.discoveryEndpoint
+        OidcDeviceClient(withoutOidcField("discoveryEndpoint")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("discoveryEndpoint", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.scopes
+        OidcDeviceClient(withoutOidcField("scopes")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+    }
+
+    @Test
+    fun oidcDeviceClientUnknownFieldsAreIgnored() {
+        val json = buildJsonObject {
+            put("unknownTopLevel", "should-be-ignored")
+            put("extraFlag", true)
+            put("oidc", buildJsonObject {
+                put("clientId", "a6859a12-5e6e-4f64-96bb-cc8577706bee")
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("unknownOidcField", "also-ignored")
+                put("extraOidcObject", buildJsonObject { put("nested", "value") })
+            })
+        }
+
+        val result = OidcDeviceClient(json)
+
+        assertTrue(result.isSuccess, "OidcDeviceClient(json) should succeed with unknown fields but failed: ${result.exceptionOrNull()?.message}")
+    }
+
+    @Test
+    fun oidcDeviceClientWrongFieldTypeReturnsError() {
+        fun validOidc(overrides: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {}) = buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", "a6859a12-5e6e-4f64-96bb-cc8577706bee")
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                overrides()
+            })
+        }
+
+        // Note: `timeout` is not tested here. OidcDeviceClient uses OidcClientConfig (not
+        // WorkflowConfig) so `timeout` is never read by the factory and is silently ignored.
+
+        // oidc.clientId as an object instead of a string
+        OidcDeviceClient(buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", buildJsonObject {})
+                put("discoveryEndpoint", "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+            })
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.scopes as a number instead of string or array
+        OidcDeviceClient(validOidc { put("scopes", 123) }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.refreshThreshold as a non-numeric string instead of a number
+        OidcDeviceClient(validOidc { put("refreshThreshold", "not-a-number") }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("refreshThreshold", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+    }
+}

--- a/journey/build.gradle.kts
+++ b/journey/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     androidTestImplementation(project(":protect"))
     androidTestImplementation(project(":foundation:device:device-profile"))
     androidTestImplementation(project(":foundation:device:device-id"))
+    androidTestImplementation(project(":foundation:browser"))
     androidTestImplementation(project(":recaptcha-enterprise"))
     androidTestImplementation(project(":mfa:binding"))
     androidTestImplementation(libs.bcpkix.jdk18on)

--- a/journey/src/androidTest/assets/full-journey-config.json
+++ b/journey/src/androidTest/assets/full-journey-config.json
@@ -1,0 +1,32 @@
+{
+  "timeout": 30000,
+  "log": "WARN",
+  "journey": {
+    "serverUrl": "https://openam-sdks.forgeblocks.com/am",
+    "realm": "alpha",
+    "cookieName": "iPlanetDirectoryPro"
+  },
+  "oidc": {
+    "clientId": "AndroidTest",
+    "discoveryEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "frauth://oauth2redirect",
+    "signOutRedirectUri": "frauth://signout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "test-state",
+    "nonce": "test-nonce",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level2",
+    "par": true,
+    "additionalParameters": {
+      "max_age": "3600",
+      "custom_param": "custom_value"
+    },
+    "openId": {
+      "deviceAuthorizationEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/realms/root/realms/alpha/device/code"
+    }
+  }
+}

--- a/journey/src/androidTest/assets/full-oidc-webclient.json
+++ b/journey/src/androidTest/assets/full-oidc-webclient.json
@@ -1,0 +1,31 @@
+{
+  "timeout": 30000,
+  "log": "WARN",
+  "oidc": {
+    "clientId": "AndroidTest",
+    "discoveryEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "frauth://oauth2redirect",
+    "signOutRedirectUri": "frauth://signout",
+    "refreshThreshold": 60,
+    "loginHint": "user@example.com",
+    "state": "test-state",
+    "nonce": "test-nonce",
+    "display": "page",
+    "prompt": "login",
+    "uiLocales": "en-US",
+    "acrValues": "Level2",
+    "par": true,
+    "additionalParameters": {
+      "max_age": "3600",
+      "custom_param": "custom_value"
+    },
+    "openId": {
+      "authorizationEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/authorize",
+      "tokenEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/access_token",
+      "userInfoEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/userinfo",
+      "endSessionEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/connect/endSession",
+      "revocationEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/token/revoke"
+    }
+  }
+}

--- a/journey/src/androidTest/assets/minimal-journey.json
+++ b/journey/src/androidTest/assets/minimal-journey.json
@@ -1,0 +1,11 @@
+{
+  "journey": {
+    "serverUrl": "https://openam-sdks.forgeblocks.com/am"
+  },
+  "oidc": {
+    "clientId": "AndroidTest",
+    "discoveryEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "frauth://oauth2redirect"
+  }
+}

--- a/journey/src/androidTest/assets/minimal-oidc-webclient.json
+++ b/journey/src/androidTest/assets/minimal-oidc-webclient.json
@@ -1,0 +1,8 @@
+{
+  "oidc": {
+    "clientId": "AndroidTest",
+    "discoveryEndpoint": "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+    "scopes": ["openid", "profile", "email"],
+    "redirectUri": "frauth://oauth2redirect"
+  }
+}

--- a/journey/src/androidTest/kotlin/com/pingidentity/journey/JsonConfigTest.kt
+++ b/journey/src/androidTest/kotlin/com/pingidentity/journey/JsonConfigTest.kt
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.journey
+
+import androidx.test.filters.SmallTest
+import com.pingidentity.android.ContextProvider
+import com.pingidentity.journey.module.Oidc
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.None
+import com.pingidentity.logger.WARN
+import com.pingidentity.oidc.JsonConfigError
+import com.pingidentity.oidc.OidcClientConfig
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@SmallTest
+class JsonConfigTest {
+
+    @Test
+    fun loadMinimalJourneyConfigFromJsonFile() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-journey.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val result = Journey(json)
+
+        assertTrue(result.isSuccess, "Journey(json) should succeed but failed: ${result.exceptionOrNull()?.message}")
+
+        val journey = result.getOrThrow()
+        val journeyConfig = journey.config as JourneyConfig
+        val oidcConfig = journey.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        assertEquals("https://openam-sdks.forgeblocks.com/am", journeyConfig.serverUrl)
+        assertEquals("AndroidTest", oidcConfig.clientId)
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("frauth://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid", "profile", "email"), oidcConfig.scopes)
+    }
+
+    @Test
+    fun journeyDefaultValues() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-journey.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val journey = Journey(json).getOrThrow()
+        val journeyConfig = journey.config as JourneyConfig
+        val oidcConfig = journey.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        // WorkflowConfig defaults
+        assertEquals(15_000L, journey.config.timeout)
+        assertIs<None>(journey.config.logger)
+
+        // Journey-specific defaults (omitted from minimal JSON)
+        assertEquals("root", journeyConfig.realm)
+        assertEquals("iPlanetDirectoryPro", journeyConfig.cookie)
+
+        // OidcClientConfig optional field defaults
+        assertNull(oidcConfig.signOutRedirectUri)
+        assertEquals(0L, oidcConfig.refreshThreshold)
+        assertNull(oidcConfig.loginHint)
+        assertNull(oidcConfig.state)
+        assertNull(oidcConfig.nonce)
+        assertNull(oidcConfig.display)
+        assertNull(oidcConfig.prompt)
+        assertNull(oidcConfig.uiLocales)
+        assertNull(oidcConfig.acrValues)
+        assertFalse(oidcConfig.par)
+        assertEquals(emptyMap<String, String>(), oidcConfig.additionalParameters)
+        assertNull(oidcConfig.openIdOverride)
+    }
+
+    @Test
+    fun journeyFullConfig() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("full-journey-config.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val journey = Journey(json).getOrThrow()
+        val journeyConfig = journey.config as JourneyConfig
+        val oidcConfig = journey.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        // WorkflowConfig
+        assertEquals(30_000L, journey.config.timeout)
+        assertSame(Logger.WARN, journey.config.logger)
+
+        // Journey-specific fields
+        assertEquals("https://openam-sdks.forgeblocks.com/am", journeyConfig.serverUrl)
+        assertEquals("alpha", journeyConfig.realm)
+        assertEquals("iPlanetDirectoryPro", journeyConfig.cookie)
+
+        // Required OIDC fields
+        assertEquals("AndroidTest", oidcConfig.clientId)
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("frauth://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid", "profile", "email"), oidcConfig.scopes)
+
+        // Optional OIDC fields
+        assertEquals("frauth://signout", oidcConfig.signOutRedirectUri)
+        assertEquals(60L, oidcConfig.refreshThreshold)
+        assertEquals("user@example.com", oidcConfig.loginHint)
+        assertEquals("test-state", oidcConfig.state)
+        assertEquals("test-nonce", oidcConfig.nonce)
+        assertEquals("page", oidcConfig.display)
+        assertEquals("login", oidcConfig.prompt)
+        assertEquals("en-US", oidcConfig.uiLocales)
+        assertEquals("Level2", oidcConfig.acrValues)
+        assertEquals(true, oidcConfig.par)
+        assertEquals(mapOf("max_age" to "3600", "custom_param" to "custom_value"), oidcConfig.additionalParameters)
+        assertNotNull(oidcConfig.openIdOverride)
+    }
+
+    @Test
+    fun journeyMissingRequiredFieldReturnsError() {
+        val base = buildJsonObject {
+            put("journey", buildJsonObject {
+                put("serverUrl", "https://openam-sdks.forgeblocks.com/am")
+            })
+            put("oidc", buildJsonObject {
+                put("clientId", "AndroidTest")
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", "openid")
+                put("redirectUri", "frauth://oauth2redirect")
+            })
+        }
+
+        fun withoutOidcField(field: String): JsonObject = buildJsonObject {
+            put("journey", base["journey"]!!)
+            put("oidc", buildJsonObject {
+                base["oidc"]!!.jsonObject.forEach { (k, v) -> if (k != field) put(k, v) }
+            })
+        }
+
+        // Missing journey.serverUrl
+        Journey(buildJsonObject {
+            put("journey", buildJsonObject {})
+            put("oidc", base["oidc"]!!)
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("serverUrl", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing journey block entirely
+        Journey(buildJsonObject { put("oidc", base["oidc"]!!) }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("journey", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.clientId
+        Journey(withoutOidcField("clientId")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.discoveryEndpoint
+        Journey(withoutOidcField("discoveryEndpoint")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("discoveryEndpoint", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.scopes
+        Journey(withoutOidcField("scopes")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.redirectUri
+        Journey(withoutOidcField("redirectUri")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("redirectUri", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc block entirely
+        Journey(buildJsonObject { put("journey", base["journey"]!!) }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("oidc", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+    }
+
+    @Test
+    fun journeyUnknownFieldsAreIgnored() {
+        val json = buildJsonObject {
+            put("unknownTopLevel", "should-be-ignored")
+            put("extraFlag", true)
+            put("journey", buildJsonObject {
+                put("serverUrl", "https://openam-sdks.forgeblocks.com/am")
+                put("unknownJourneyField", "also-ignored")
+            })
+            put("oidc", buildJsonObject {
+                put("clientId", "AndroidTest")
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+                put("unknownOidcField", "also-ignored")
+                put("extraOidcObject", buildJsonObject { put("nested", "value") })
+            })
+        }
+
+        val result = Journey(json)
+
+        assertTrue(result.isSuccess, "Journey(json) should succeed with unknown fields but failed: ${result.exceptionOrNull()?.message}")
+
+        val journey = result.getOrThrow()
+        val journeyConfig = journey.config as JourneyConfig
+        val oidcConfig = journey.config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+        assertEquals("https://openam-sdks.forgeblocks.com/am", journeyConfig.serverUrl)
+        assertEquals("AndroidTest", oidcConfig.clientId)
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("frauth://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid"), oidcConfig.scopes)
+    }
+
+    @Test
+    fun journeyWrongFieldTypeReturnsError() {
+        val validJourney = buildJsonObject { put("serverUrl", "https://openam-sdks.forgeblocks.com/am") }
+
+        fun validOidc(overrides: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit) = buildJsonObject {
+            put("journey", validJourney)
+            put("oidc", buildJsonObject {
+                put("clientId", "AndroidTest")
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+                overrides()
+            })
+        }
+
+        // timeout as a non-numeric string instead of a number
+        Journey(buildJsonObject {
+            put("timeout", "not-a-number")
+            put("journey", validJourney)
+            put("oidc", validOidc {}["oidc"]!!)
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("timeout", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.clientId as an object instead of a string
+        Journey(buildJsonObject {
+            put("journey", validJourney)
+            put("oidc", buildJsonObject {
+                put("clientId", buildJsonObject {})
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+            })
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.scopes as a number instead of string or array
+        Journey(validOidc { put("scopes", 123) }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.refreshThreshold as a non-numeric string instead of a number
+        Journey(validOidc { put("refreshThreshold", "not-a-number") }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("refreshThreshold", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // journey.cookieName as a number instead of a string (gap #8 from spec review)
+        Journey(buildJsonObject {
+            put("journey", buildJsonObject {
+                put("serverUrl", "https://openam-sdks.forgeblocks.com/am")
+                put("cookieName", 42)
+            })
+            put("oidc", validOidc {}["oidc"]!!)
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("cookieName", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+    }
+
+    // Non-default cookieName supplied in the JSON is propagated to JourneyConfig
+    @Test
+    fun journeyCustomCookieName() {
+        val json = buildJsonObject {
+            put("journey", buildJsonObject {
+                put("serverUrl", "https://openam-sdks.forgeblocks.com/am")
+                put("cookieName", "MyCustomCookie")
+            })
+            put("oidc", buildJsonObject {
+                put("clientId", "AndroidTest")
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+            })
+        }
+
+        val journey = Journey(json).getOrThrow()
+        val journeyConfig = journey.config as JourneyConfig
+
+        assertEquals("MyCustomCookie", journeyConfig.cookie)
+    }
+}

--- a/journey/src/androidTest/kotlin/com/pingidentity/journey/OidcWebClientJsonConfigTest.kt
+++ b/journey/src/androidTest/kotlin/com/pingidentity/journey/OidcWebClientJsonConfigTest.kt
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.journey
+
+import androidx.test.filters.SmallTest
+import com.pingidentity.android.ContextProvider
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.None
+import com.pingidentity.logger.WARN
+import com.pingidentity.oidc.JsonConfigError
+import com.pingidentity.oidc.OidcClientConfig
+import com.pingidentity.oidc.OidcWebClient
+import com.pingidentity.oidc.OpenIdConfiguration
+import com.pingidentity.oidc.module.Oidc
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+@SmallTest
+class OidcWebClientJsonConfigTest {
+
+    private fun OidcWebClient.oidcConfig(): OidcClientConfig =
+        config.modules.first { it.module == Oidc }.config as OidcClientConfig
+
+    @Test
+    fun loadMinimalOidcWebClientConfigFromJsonFile() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-oidc-webclient.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val result = OidcWebClient(json)
+
+        assertTrue(result.isSuccess, "OidcWebClient(json) should succeed but failed: ${result.exceptionOrNull()?.message}")
+
+        val client = result.getOrThrow()
+        val oidcConfig = client.oidcConfig()
+
+        assertEquals("AndroidTest", oidcConfig.clientId)
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("frauth://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid", "profile", "email"), oidcConfig.scopes)
+    }
+
+    @Test
+    fun oidcWebClientDefaultValues() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("minimal-oidc-webclient.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val client = OidcWebClient(json).getOrThrow()
+        val oidcConfig = client.oidcConfig()
+
+        assertEquals(15_000L, client.config.timeout)
+        assertIs<None>(client.config.logger)
+
+        assertNull(oidcConfig.signOutRedirectUri)
+        assertEquals(0L, oidcConfig.refreshThreshold)
+        assertNull(oidcConfig.loginHint)
+        assertNull(oidcConfig.state)
+        assertNull(oidcConfig.nonce)
+        assertNull(oidcConfig.display)
+        assertNull(oidcConfig.prompt)
+        assertNull(oidcConfig.uiLocales)
+        assertNull(oidcConfig.acrValues)
+        assertFalse(oidcConfig.par)
+        assertEquals(emptyMap<String, String>(), oidcConfig.additionalParameters)
+        assertNull(oidcConfig.openIdOverride)
+    }
+
+    @Test
+    fun oidcWebClientFullConfig() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("full-oidc-webclient.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val client = OidcWebClient(json).getOrThrow()
+        val oidcConfig = client.oidcConfig()
+
+        assertEquals(30_000L, client.config.timeout)
+        assertSame(Logger.WARN, client.config.logger)
+
+        assertEquals("AndroidTest", oidcConfig.clientId)
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration",
+            oidcConfig.discoveryEndpoint,
+        )
+        assertEquals("frauth://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid", "profile", "email"), oidcConfig.scopes)
+        assertEquals("frauth://signout", oidcConfig.signOutRedirectUri)
+        assertEquals(60L, oidcConfig.refreshThreshold)
+        assertEquals("user@example.com", oidcConfig.loginHint)
+        assertEquals("test-state", oidcConfig.state)
+        assertEquals("test-nonce", oidcConfig.nonce)
+        assertEquals("page", oidcConfig.display)
+        assertEquals("login", oidcConfig.prompt)
+        assertEquals("en-US", oidcConfig.uiLocales)
+        assertEquals("Level2", oidcConfig.acrValues)
+        assertTrue(oidcConfig.par)
+        assertEquals(mapOf("max_age" to "3600", "custom_param" to "custom_value"), oidcConfig.additionalParameters)
+        assertNotNull(oidcConfig.openIdOverride)
+    }
+
+    @Test
+    fun oidcWebClientOpenIdEndpointsAreLoaded() {
+        val json: JsonObject = ContextProvider.context.assets
+            .open("full-oidc-webclient.json")
+            .bufferedReader()
+            .use { Json.parseToJsonElement(it.readText()).jsonObject }
+
+        val client = OidcWebClient(json).getOrThrow()
+        val oidcConfig = client.oidcConfig()
+
+        val override = oidcConfig.openIdOverride
+        assertNotNull(override, "openIdOverride should be set when openId block is present")
+
+        val openId = OpenIdConfiguration().apply { override() }
+
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/authorize",
+            openId.authorizationEndpoint,
+        )
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/access_token",
+            openId.tokenEndpoint,
+        )
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/userinfo",
+            openId.userinfoEndpoint,
+        )
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/connect/endSession",
+            openId.endSessionEndpoint,
+        )
+        assertEquals(
+            "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/token/revoke",
+            openId.revocationEndpoint,
+        )
+    }
+
+    @Test
+    fun oidcWebClientMissingRequiredFieldReturnsError() {
+        val validOidc = buildJsonObject {
+            put("clientId", "AndroidTest")
+            put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+            put("scopes", "openid")
+            put("redirectUri", "frauth://oauth2redirect")
+        }
+
+        fun withoutOidcField(field: String): JsonObject = buildJsonObject {
+            put("oidc", buildJsonObject {
+                validOidc.forEach { (k, v) -> if (k != field) put(k, v) }
+            })
+        }
+
+        // Missing oidc block entirely
+        OidcWebClient(buildJsonObject {}).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("oidc", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.clientId
+        OidcWebClient(withoutOidcField("clientId")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.discoveryEndpoint
+        OidcWebClient(withoutOidcField("discoveryEndpoint")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("discoveryEndpoint", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.scopes
+        OidcWebClient(withoutOidcField("scopes")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+
+        // Missing oidc.redirectUri
+        OidcWebClient(withoutOidcField("redirectUri")).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.MissingRequiredField>(result.exceptionOrNull())
+            assertEquals("redirectUri", (result.exceptionOrNull() as JsonConfigError.MissingRequiredField).field)
+        }
+    }
+
+    @Test
+    fun oidcWebClientUnknownFieldsAreIgnored() {
+        val json = buildJsonObject {
+            put("unknownTopLevel", "should-be-ignored")
+            put("extraFlag", true)
+            put("oidc", buildJsonObject {
+                put("clientId", "AndroidTest")
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+                put("unknownOidcField", "also-ignored")
+                put("extraOidcObject", buildJsonObject { put("nested", "value") })
+            })
+        }
+
+        val result = OidcWebClient(json)
+
+        assertTrue(result.isSuccess, "OidcWebClient(json) should succeed with unknown fields but failed: ${result.exceptionOrNull()?.message}")
+
+        val client = result.getOrThrow()
+        val oidcConfig = client.oidcConfig()
+
+        assertEquals("AndroidTest", oidcConfig.clientId)
+        assertEquals("frauth://oauth2redirect", oidcConfig.redirectUri)
+        assertEquals(setOf("openid"), oidcConfig.scopes)
+    }
+
+    @Test
+    fun oidcWebClientWrongFieldTypeReturnsError() {
+        // Note: `par` wrong-type is not tested. kotlinx.serialization coerces JSON string "true"
+        // to Boolean without error, so the parser cannot distinguish the type mismatch.
+        fun validOidc(overrides: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit = {}) = buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", "AndroidTest")
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+                overrides()
+            })
+        }
+
+        // timeout as a non-numeric string instead of a number
+        OidcWebClient(buildJsonObject {
+            put("timeout", "not-a-number")
+            put("oidc", validOidc {}["oidc"]!!)
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("timeout", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.clientId as an object instead of a string
+        OidcWebClient(buildJsonObject {
+            put("oidc", buildJsonObject {
+                put("clientId", buildJsonObject {})
+                put("discoveryEndpoint", "https://openam-sdks.forgeblocks.com/am/oauth2/alpha/.well-known/openid-configuration")
+                put("scopes", buildJsonArray { add("openid") })
+                put("redirectUri", "frauth://oauth2redirect")
+            })
+        }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("clientId", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.scopes as a number instead of string or array
+        OidcWebClient(validOidc { put("scopes", 123) }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("scopes", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+
+        // oidc.refreshThreshold as a non-numeric string instead of a number
+        OidcWebClient(validOidc { put("refreshThreshold", "not-a-number") }).let { result ->
+            assertTrue(result.isFailure)
+            assertIs<JsonConfigError.InvalidType>(result.exceptionOrNull())
+            assertEquals("refreshThreshold", (result.exceptionOrNull() as JsonConfigError.InvalidType).field)
+        }
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5068](https://pingidentity.atlassian.net/browse/SDKS-5068) [QA] Standardize SDK Configuration

# Description

Added instrumented test coverage for the JSON configuration factory functions `DaVinci(json)`, `Journey(json)`, `OidcWebClient(json)`, `OidcDeviceClient(json)`. 
All tests live in the existing `davinci` and `journey` androidTest modules.

## New test files
  - davinci/…/JsonConfigTest.kt — DaVinci(json) happy path (minimal + full fixture), default values for all optional fields, missing required field errors, unknown field tolerance, and wrong-type errors for timeout, clientId, scopes, and refreshThreshold
  - davinci/…/OidcDeviceClientJsonConfigTest.kt — OidcDeviceClient(json) success smoke tests (minimal + full fixture), missing required field, errors, unknown field tolerance, and wrong-type errors;
  - journey/…/JsonConfigTest.kt — Journey(json) happy path (minimal + full fixture), default values including par, Journey-specific defaults (realm, cookieName), custom cookieName round-trip, missing required field errors (including journey block), unknown field tolerance, and wrong-type errors for timeout, clientId, scopes, refreshThreshold, and cookieName
  - journey/…/OidcWebClientJsonConfigTest.kt — OidcWebClient(json) happy path (minimal + full fixture), default values including par = false, full optional field round-trip, openId endpoint override verification, missing required field errors, unknown field tolerance, and wrong-type errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suites for JSON configuration parsing and validation across multiple modules.
  * Validates successful loading of minimal and full configurations with appropriate default value handling when optional fields are omitted.
  * Confirms error detection for missing required fields and invalid field types.
  * Validates handling of unknown configuration fields and endpoint override scenarios.
  * Added test configuration assets supporting multiple deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->