### PR TITLE
SDKS-5169 Add Image component for DaVinci

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -19,6 +19,7 @@ import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
+import com.pingidentity.davinci.collector.ImageCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -63,5 +64,6 @@ internal class CollectorRegistry : ModuleInitializer() {
         CollectorFactory.register("READ_ONLY_TEXT", ::ReadOnlyTextCollector)
         CollectorFactory.register("POLLING", ::PollingCollector)
         CollectorFactory.register("QR_CODE", ::QRCodeCollector)
+        CollectorFactory.register("IMAGE", ::ImageCollector)
     }
 }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ImageCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/ImageCollector.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import com.pingidentity.davinci.plugin.Collector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * A display-only [Collector] that surfaces an image in a DaVinci authentication flow.
+ * It carries no user input — [id] returns [key] and the collector never contributes
+ * a value to the form submission.
+ *
+ * ```json
+ * {
+ *     "type": "IMAGE",
+ *     "key": "heroImage",
+ *     "description": "Alt text",
+ *     "imageUrl": "https://cdn.example.com/image.png",
+ *     "hyperlinkUrl": "https://example.com/install"
+ * }
+ * ```
+ */
+class ImageCollector : Collector<Nothing> {
+
+    /** Unique field identifier within the form. */
+    var key = ""
+        private set
+
+    /** Accessibility / alt text for the image. */
+    var description: String = ""
+        private set
+
+    /** URL of the image to display. */
+    var imageUrl: String = ""
+        private set
+
+    /** Optional URL to open when the image is tapped. `null` when not provided. */
+    var hyperlinkUrl: String? = null
+        private set
+
+    /**
+     * Helper function to safely extract a string from a [JsonObject] by key,
+     * returning `null` if the key is absent or not a string.
+     * @param field The key to look up in the [JsonObject].
+     * @return The string value associated with the key, or `null` if not present or not a string.
+     */
+    fun JsonObject.stringOrNull(field: String): String? =
+        (this[field] as? JsonPrimitive)?.contentOrNull
+
+    override fun init(input: JsonObject): ImageCollector {
+        key = input.stringOrNull("key") ?: ""
+        description = input.stringOrNull("description") ?: ""
+        imageUrl = input.stringOrNull("imageUrl") ?: ""
+        hyperlinkUrl = input.stringOrNull("hyperlinkUrl")
+        return this
+    }
+
+    override fun id(): String = key
+}

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/ImageCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/ImageCollectorTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.ImageCollector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ImageCollectorTest {
+
+    private fun buildFullImageJson(): JsonObject = buildJsonObject {
+        put("type", "IMAGE")
+        put("key", "image")
+        put("description", "New Image")
+        put("imageUrl", "https://travel.destinationcanada.com/_next/image?url=https%3A%2F%2Fadmin.destinationcanada.com%2Fsites%2Fdefault%2Ffiles%2F2023-06%2FQC-Montreal-Skyline_hero.jpg&w=1920&q=75")
+        put("hyperlinkUrl", "https://www.pingidentity.com/en.html")
+    }
+
+    @Test
+    fun initializesKeyFromJson() {
+        val collector = ImageCollector().apply { init(buildFullImageJson()) }
+        assertEquals("image", collector.key)
+    }
+
+    @Test
+    fun initializesDescriptionFromJson() {
+        val collector = ImageCollector().apply { init(buildFullImageJson()) }
+        assertEquals("New Image", collector.description)
+    }
+
+    @Test
+    fun initializesImageUrlFromJson() {
+        val collector = ImageCollector().apply { init(buildFullImageJson()) }
+        assertEquals(
+            "https://travel.destinationcanada.com/_next/image?url=https%3A%2F%2Fadmin.destinationcanada.com%2Fsites%2Fdefault%2Ffiles%2F2023-06%2FQC-Montreal-Skyline_hero.jpg&w=1920&q=75",
+            collector.imageUrl
+        )
+    }
+
+    @Test
+    fun initializesHyperlinkUrlFromJson() {
+        val collector = ImageCollector().apply { init(buildFullImageJson()) }
+        assertEquals("https://www.pingidentity.com/en.html", collector.hyperlinkUrl)
+    }
+
+    @Test
+    fun idReturnsKey() {
+        val collector = ImageCollector().apply { init(buildFullImageJson()) }
+        assertEquals("image", collector.id())
+    }
+
+    @Test
+    fun initReturnsCollectorInstanceForMethodChaining() {
+        val collector = ImageCollector()
+        val result = collector.init(buildFullImageJson())
+        assertEquals(collector, result)
+    }
+
+    @Test
+    fun hyperlinkUrlIsNullWhenAbsent() {
+        val input = buildJsonObject {
+            put("type", "IMAGE")
+            put("key", "image")
+            put("description", "No link")
+            put("imageUrl", "https://example.com/image.png")
+        }
+        val collector = ImageCollector().apply { init(input) }
+        assertNull(collector.hyperlinkUrl)
+    }
+
+    @Test
+    fun initializesWithDefaultsWhenJsonIsEmpty() {
+        val collector = ImageCollector().apply { init(JsonObject(emptyMap())) }
+        assertEquals("", collector.key)
+        assertEquals("", collector.description)
+        assertEquals("", collector.imageUrl)
+        assertNull(collector.hyperlinkUrl)
+    }
+
+    @Test
+    fun idReturnsEmptyStringWhenKeyAbsent() {
+        val collector = ImageCollector().apply { init(JsonObject(emptyMap())) }
+        assertEquals("", collector.id())
+    }
+
+    @Test
+    fun initializesWithEmptyImageUrlWhenImageUrlAbsent() {
+        val input = buildJsonObject {
+            put("key", "image")
+            put("description", "Missing imageUrl")
+        }
+        val collector = ImageCollector().apply { init(input) }
+        assertEquals("", collector.imageUrl)
+    }
+}

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
@@ -33,6 +33,7 @@ import com.pingidentity.davinci.collector.ReadOnlyTextCollector
 import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
+import com.pingidentity.davinci.collector.ImageCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -128,6 +129,7 @@ fun DaVinciContinueNode(
                 is QRCodeCollector -> QRCode(it)
 
                 is BooleanCollector -> SingleCheckbox(it, onNodeUpdated)
+                is ImageCollector -> Image(it)
             }
             if (it is Submittable) {
                 hasAction = true

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Image.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Image.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import android.content.Intent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Image
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.min
+import androidx.core.net.toUri
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import coil.compose.AsyncImagePainter
+import coil.decode.SvgDecoder
+import com.pingidentity.android.ContextProvider
+import com.pingidentity.davinci.collector.ImageCollector
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun Image(field: ImageCollector) {
+    ImageCard(
+        imageUrl = field.imageUrl,
+        description = field.description,
+        hyperlinkUrl = field.hyperlinkUrl,
+    )
+}
+
+@Composable
+fun ImageCard(
+    imageUrl: String,
+    description: String,
+    hyperlinkUrl: String?,
+) {
+    val context = LocalContext.current
+    val outlineColor = MaterialTheme.colorScheme.outline
+    val density = LocalDensity.current
+
+    // Track component width so the placeholder icon can scale up to 48 dp max
+    var componentWidthDp by remember { mutableStateOf(0.dp) }
+    val placeholderSize: Dp = min(componentWidthDp, 48.dp)
+
+    val safeHyperlinkUri = hyperlinkUrl
+        ?.takeIf { it.isNotBlank() }
+        ?.toUri()
+        ?.takeIf { it.scheme == "http" || it.scheme == "https" }
+
+    val borderModifier = Modifier.border(
+        width = 1.dp,
+        color = outlineColor,
+        shape = RoundedCornerShape(4.dp),
+    )
+
+    Column(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+            .then(borderModifier)
+            .padding(8.dp)
+            .then(
+                if (safeHyperlinkUri != null) {
+                    Modifier.clickable {
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, safeHyperlinkUri)
+                        )
+                    }
+                } else Modifier
+            ),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        val imageLoader = ImageLoader.Builder(ContextProvider.context)
+            .components { add(SvgDecoder.Factory()) }
+            .build()
+
+        var painterState by remember(imageUrl) {
+            mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty)
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .onSizeChanged { size ->
+                    componentWidthDp = with(density) { size.width.toDp() }
+                },
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = description,
+                imageLoader = imageLoader,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxWidth(),
+                onState = { painterState = it },
+            )
+
+            // Show placeholder icon while loading or if the image fails/is empty
+            if (painterState !is AsyncImagePainter.State.Success) {
+                Icon(
+                    imageVector = Icons.Outlined.Image,
+                    contentDescription = description.ifBlank { "Image placeholder" },
+                    modifier = Modifier.size(placeholderSize),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        if (description.isNotBlank()) {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+        safeHyperlinkUri?.let {
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = safeHyperlinkUri.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5169](https://pingidentity.atlassian.net/browse/SDKS-5169)

# Description
Add ImageCollector to display Image for DaVinci Forms.
<img width="1408" height="2974" alt="image" src="https://github.com/user-attachments/assets/ac2635da-37fc-4a46-9f75-7260ad3a6bd0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image display capabilities to DaVinci authentication flows with support for image URLs, descriptions, and optional hyperlinks.
  * Images render as interactive cards in the sample application.

* **Tests**
  * Added comprehensive test coverage for image collector initialization and field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->