### PR TITLE
SDKS-5181: Test coverage for PAR

### DIFF
--- a/davinci/build.gradle.kts
+++ b/davinci/build.gradle.kts
@@ -33,6 +33,12 @@ android {
             enableUnitTestCoverage = true
         }
     }
+
+    packaging {
+        resources {
+            excludes += mutableSetOf("META-INF/LICENSE.md", "META-INF/LICENSE-notice.md")
+        }
+    }
 }
 
 dependencies {

--- a/davinci/build.gradle.kts
+++ b/davinci/build.gradle.kts
@@ -60,5 +60,9 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(project(":foundation:testrail"))
     androidTestImplementation(project(":protect"))
+    androidTestImplementation(project(":foundation:browser"))
     androidTestImplementation(libs.zxing.core)
+    androidTestImplementation(libs.ktor.client.core)
+    androidTestImplementation(libs.mockk)
+    androidTestImplementation(libs.mockk.android)
 }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARCentralizedLoginDaVinciE2ETest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARCentralizedLoginDaVinciE2ETest.kt
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import android.net.Uri
+import androidx.test.filters.SmallTest
+import com.pingidentity.browser.BrowserCanceledException
+import com.pingidentity.browser.BrowserLauncher
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.network.ktor.HttpClient
+import com.pingidentity.network.ktor.KtorHttpRequest
+import com.pingidentity.oidc.OidcWebClient
+import com.pingidentity.oidc.exception.AuthorizeException
+import com.pingidentity.oidc.module.Oidc
+import io.ktor.client.request.forms.FormDataContent
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.net.URL
+
+/**
+ * E2E tests for PAR (Pushed Authorization Request) via centralized (browser-based) login
+ * against PingOne.
+ *
+ * Mirrors [PARCentralizedLoginE2ETest] from the journey module but targets the PingOne
+ * environment used by the DaVinci tests.
+ *
+ * [BrowserLauncher] is mocked to cancel immediately after capturing the authorize URL —
+ * this lets us observe the wire shape (PAR POST body, authorize URL params) without ever
+ * opening a browser. The PAR POST completes against the real server before
+ * [BrowserLauncher.launch] is called, so all wire-level assertions are valid.
+ *
+ * Two scenarios are covered:
+ *   1. par = false — standard flow: all authorize params appear inline in the GET /authorize URL.
+ *   2. par = true  — PAR flow: params are POSTed to /par first; GET /authorize carries only
+ *      client_id + request_uri.
+ */
+@SmallTest
+class PARCentralizedLoginDaVinciE2ETest {
+
+    private val recordedRequests = mutableListOf<CentralizedRecordedRequest>()
+
+    companion object {
+        private const val CLIENT_ID = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+        private const val DISCOVERY_ENDPOINT =
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+        private const val REDIRECT_URI = "org.forgerock.demo://oauth2redirect"
+        private const val ACR_VALUES = "4ada23c8f9ae6201ec8116ffbf004595"
+    }
+
+    @Before
+    fun setupMocks() {
+        recordedRequests.clear()
+        mockkObject(BrowserLauncher)
+    }
+
+    @After
+    fun tearDownMocks() {
+        unmockkObject(BrowserLauncher)
+    }
+
+    // -------------------------------------------------------------------------
+    // par = false — standard centralized login
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun centralizedLoginWithoutPAR_noParPostMade() = runTest {
+        coEvery { BrowserLauncher.launch(any<URL>(), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = false).authorize()
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertTrue("Expected zero /par POST calls when par=false", parCalls.isEmpty())
+    }
+
+    @Test
+    fun centralizedLoginWithoutPAR_authorizeUrlContainsAllParams() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = false).authorize()
+
+        assertTrue("Expected browser to be launched", capturedUrl.isCaptured)
+        val query = capturedUrl.captured.query ?: ""
+        for (param in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method",
+        )) {
+            assertTrue("Expected '$param' in /authorize URL when par=false", query.contains(param))
+        }
+        assertFalse(
+            "Did not expect 'request_uri' in /authorize URL when par=false",
+            query.contains("request_uri"),
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithoutPAR_browserLaunchedWithAuthorizeUrl() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        val result = buildWebClient(par = false).authorize()
+
+        assertTrue("Expected browser to be launched when par=false", capturedUrl.isCaptured)
+        assertTrue("Expected authorize() to fail when browser is cancelled", result.isFailure)
+        assertTrue(
+            "Expected BrowserCanceledException, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is BrowserCanceledException,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // par = true — PAR-backed centralized login
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun centralizedLoginWithPAR_exactlyOneParPostMade() = runTest {
+        coEvery { BrowserLauncher.launch(any<URL>(), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertEquals("Expected exactly one POST to /par when par=true", 1, parCalls.size)
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_parPostBodyContainsRequiredFields() = runTest {
+        coEvery { BrowserLauncher.launch(any<URL>(), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        val parRequest = recordedRequests.first { it.url.contains("/par") && it.method == "POST" }
+        val form = parRequest.formFields
+
+        for (field in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method",
+        )) {
+            assertNotNull("PAR POST body missing required field '$field'", form[field])
+        }
+        assertEquals("Expected correct client_id in PAR body", CLIENT_ID, form["client_id"])
+        assertEquals("Expected response_type=code in PAR body", "code", form["response_type"])
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_authorizeUrlContainsOnlyClientIdAndRequestUri() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        assertTrue("Expected browser to be launched after PAR POST", capturedUrl.isCaptured)
+        val query = capturedUrl.captured.query ?: ""
+        assertTrue("Expected 'client_id' in /authorize URL after PAR", query.contains("client_id"))
+        assertTrue("Expected 'request_uri' in /authorize URL after PAR", query.contains("request_uri"))
+        for (forbidden in listOf("scope=", "redirect_uri=", "code_challenge=", "response_type=")) {
+            assertFalse(
+                "Did not expect '$forbidden' in /authorize URL when par=true",
+                query.contains(forbidden),
+            )
+        }
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_requestUriIsNonEmpty() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        assertTrue("Expected browser to be launched", capturedUrl.isCaptured)
+        val requestUri = Uri.parse(capturedUrl.captured.toString()).getQueryParameter("request_uri")
+        assertNotNull("Expected non-null request_uri in /authorize URL", requestUri)
+        assertTrue("Expected non-empty request_uri", requireNotNull(requestUri).isNotEmpty())
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_browserLaunchedAfterSuccessfulParPost() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        val result = buildWebClient(par = true).authorize()
+
+        assertTrue("Expected browser to be launched after successful PAR POST", capturedUrl.isCaptured)
+        assertTrue("Expected failure due to browser cancellation (not a PAR error)", result.isFailure)
+        assertTrue(
+            "Expected BrowserCanceledException, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is BrowserCanceledException,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // par = true — PAR failure scenarios
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun centralizedLoginWithPAR_wrongClientId_returnsFailureWithAuthorizeException() = runTest {
+        val result = buildWebClient(par = true, clientId = "invalid-client-id-xyz").authorize()
+
+        assertTrue("Expected authorize() to fail when client_id is invalid", result.isFailure)
+        assertTrue(
+            "Expected AuthorizeException for rejected PAR, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is AuthorizeException,
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_wrongClientId_browserNeverLaunched() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true, clientId = "invalid-client-id-xyz").authorize()
+
+        assertFalse(
+            "Expected browser NOT to be launched when PAR is rejected due to invalid client_id",
+            capturedUrl.isCaptured,
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_wrongRedirectUri_returnsFailureWithAuthorizeException() = runTest {
+        val result = buildWebClient(par = true, redirectUri = "https://invalid.example.com/callback").authorize()
+
+        assertTrue("Expected authorize() to fail when redirect_uri is not registered", result.isFailure)
+        assertTrue(
+            "Expected AuthorizeException for rejected PAR, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is AuthorizeException,
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_wrongRedirectUri_browserNeverLaunched() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true, redirectUri = "https://invalid.example.com/callback").authorize()
+
+        assertFalse(
+            "Expected browser NOT to be launched when PAR is rejected due to unregistered redirect_uri",
+            capturedUrl.isCaptured,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds an [OidcWebClient] pointed at the PingOne test server. All outgoing HTTP requests
+     * are recorded into [recordedRequests] via an onRequest interceptor, including the PAR POST
+     * body fields for form-encoded requests.
+     */
+    private fun buildWebClient(
+        par: Boolean,
+        clientId: String = CLIENT_ID,
+        redirectUri: String = REDIRECT_URI,
+    ): OidcWebClient {
+        val sharedHttpClient = HttpClient {
+            logger = Logger.STANDARD
+            onRequest {
+                val formFields: Map<String, String> = try {
+                    // KtorHttpRequest.builder is internal to foundation:network, but ktor.client.core
+                    // is on the androidTest classpath so the cast is safe here. The outer try/catch
+                    // handles any non-form-encoded requests (GET, JSON body, etc.) gracefully.
+                    val formData = (this as? KtorHttpRequest)?.builder?.body as? FormDataContent
+                    formData?.formData?.entries()
+                        ?.associate { (k, values) -> k to (values.firstOrNull() ?: "") }
+                        ?: emptyMap()
+                } catch (_: Exception) {
+                    emptyMap()
+                }
+                recordedRequests.add(
+                    CentralizedRecordedRequest(url = url, method = method(), formFields = formFields),
+                )
+            }
+        }
+
+        return OidcWebClient {
+            httpClient = sharedHttpClient
+            logger = Logger.STANDARD
+            module(Oidc) {
+                this.clientId = clientId
+                this.redirectUri = redirectUri
+                scopes = mutableSetOf("openid", "profile", "email")
+                discoveryEndpoint = DISCOVERY_ENDPOINT
+                acrValues = ACR_VALUES
+                this.par = par
+            }
+        }
+    }
+}
+
+private data class CentralizedRecordedRequest(
+    val url: String,
+    val method: String,
+    val formFields: Map<String, String>,
+)

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARDaVinciE2ETest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARDaVinciE2ETest.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import android.net.Uri
+import androidx.test.filters.SmallTest
+import com.pingidentity.davinci.module.Oidc
+import com.pingidentity.davinci.plugin.DaVinci as DaVinciFlow
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.network.ktor.HttpClient
+import com.pingidentity.oidc.exception.AuthorizeException
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.FailureNode
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * E2E tests for PAR (Pushed Authorization Request, RFC 9126) in the DaVinci / PingOne flow.
+ *
+ * Two scenarios are covered:
+ *  1. par = false (default) — standard OIDC flow; all authorize params appear inline in the
+ *     GET /authorize URL (sent as the DaVinci start request), no POST to /par is made.
+ *  2. par = true             — PAR flow; params are POSTed to /par first, then only
+ *     client_id + request_uri appear in the GET /authorize URL.
+ *
+ * Unlike the centralized-login tests, DaVinci does NOT use BrowserLauncher. The authorize URL is
+ * sent as a regular HTTP GET that returns JSON (DaVinci form). Wire-shape is verified by recording
+ * every outgoing HTTP request through an onRequest interceptor on the shared HttpClient.
+ *
+ * Test server: auth.pingone.ca (PingOne)
+ */
+@SmallTest
+class PARDaVinciE2ETest {
+
+    private val recordedRequests = mutableListOf<RecordedRequest>()
+
+    companion object {
+        private const val CLIENT_ID = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
+        private const val DISCOVERY_ENDPOINT =
+            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
+        private const val REDIRECT_URI = "org.forgerock.demo://oauth2redirect"
+        private const val ACR_VALUES = "4ada23c8f9ae6201ec8116ffbf004595"
+    }
+
+    @Before
+    fun setup() {
+        recordedRequests.clear()
+    }
+
+    // ---------------------------------------------------------------------------
+    // par = false — standard flow
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun daVinciWithoutPAR_noParPostMade() = runTest {
+        buildDaVinci(par = false).start()
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertTrue("Expected zero /par POST calls when par=false", parCalls.isEmpty())
+    }
+
+    @Test
+    fun daVinciWithoutPAR_authorizeUrlContainsAllParams() = runTest {
+        buildDaVinci(par = false).start()
+
+        val authorizeRequest = recordedRequests.firstOrNull { it.url.contains("/authorize") }
+        assertNotNull("Expected an /authorize request when par=false", authorizeRequest)
+        val queryParams = Uri.parse(requireNotNull(authorizeRequest).url).queryParameterNames
+
+        for (expected in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method",
+        )) {
+            assertTrue(
+                "Expected '$expected' in /authorize URL when par=false",
+                queryParams.contains(expected),
+            )
+        }
+        assertFalse(
+            "Did not expect 'request_uri' in /authorize URL when par=false",
+            queryParams.contains("request_uri"),
+        )
+    }
+
+    @Test
+    fun daVinciWithoutPAR_startReturnsContinueNode() = runTest {
+        val node = buildDaVinci(par = false).start()
+        assertTrue(
+            "Expected ContinueNode (DaVinci first form) when par=false, got ${node::class.simpleName}",
+            node is ContinueNode,
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // par = true — PAR flow
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun daVinciWithPAR_exactlyOneParPostMade() = runTest {
+        buildDaVinci(par = true).start()
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertEquals("Expected exactly one POST to /par when par=true", 1, parCalls.size)
+    }
+
+    @Test
+    fun daVinciWithPAR_authorizeUrlContainsOnlyClientIdAndRequestUri() = runTest {
+        buildDaVinci(par = true).start()
+
+        val authorizeRequest = recordedRequests.firstOrNull { it.url.contains("/authorize") }
+        assertNotNull("Expected an /authorize request after PAR POST", authorizeRequest)
+        val queryParams = Uri.parse(requireNotNull(authorizeRequest).url).queryParameterNames
+
+        assertTrue(
+            "Expected 'client_id' in /authorize URL after PAR",
+            queryParams.contains("client_id"),
+        )
+        assertTrue(
+            "Expected 'request_uri' in /authorize URL after PAR",
+            queryParams.contains("request_uri"),
+        )
+
+        // Full OIDC params must be absent — they were pushed to /par, not the URL
+        for (forbidden in listOf(
+            "scope", "redirect_uri", "code_challenge",
+            "code_challenge_method", "response_type",
+        )) {
+            assertFalse(
+                "Did not expect '$forbidden' in /authorize URL when par=true",
+                queryParams.contains(forbidden),
+            )
+        }
+    }
+
+    @Test
+    fun daVinciWithPAR_requestUriPropagatedToAuthorize() = runTest {
+        buildDaVinci(par = true).start()
+
+        val authorizeRequest = requireNotNull(recordedRequests.firstOrNull { it.url.contains("/authorize") })
+        val requestUri = Uri.parse(authorizeRequest.url).getQueryParameter("request_uri")
+        assertNotNull("Expected non-null request_uri in /authorize URL", requestUri)
+        assertTrue("Expected non-empty request_uri", requireNotNull(requestUri).isNotEmpty())
+    }
+
+    @Test
+    fun daVinciWithPAR_startReturnsContinueNode() = runTest {
+        val node = buildDaVinci(par = true).start()
+        assertTrue(
+            "Expected ContinueNode (DaVinci first form) after PAR flow, got ${node::class.simpleName}",
+            node is ContinueNode,
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // par = true — PAR failure scenarios
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun daVinciWithPAR_wrongClientId_returnsFailureNode() = runTest {
+        val node = buildDaVinci(par = true, clientId = "invalid-client-id-xyz").start()
+
+        assertTrue(
+            "Expected FailureNode when client_id is invalid, got ${node::class.simpleName}",
+            node is FailureNode,
+        )
+        assertTrue(
+            "Expected AuthorizeException for rejected PAR, got ${(node as FailureNode).cause::class.simpleName}",
+            node.cause is AuthorizeException,
+        )
+    }
+
+    @Test
+    fun daVinciWithPAR_wrongClientId_noAuthorizeRequestMade() = runTest {
+        buildDaVinci(par = true, clientId = "invalid-client-id-xyz").start()
+
+        val authorizeCalls = recordedRequests.filter { it.url.contains("/authorize") }
+        assertTrue(
+            "Expected no /authorize request when PAR is rejected due to invalid client_id",
+            authorizeCalls.isEmpty(),
+        )
+    }
+
+    @Test
+    fun daVinciWithPAR_wrongRedirectUri_returnsFailureNode() = runTest {
+        val node = buildDaVinci(par = true, redirectUri = "https://invalid.example.com/callback").start()
+
+        assertTrue(
+            "Expected FailureNode when redirect_uri is not registered, got ${node::class.simpleName}",
+            node is FailureNode,
+        )
+        assertTrue(
+            "Expected AuthorizeException for rejected PAR, got ${(node as FailureNode).cause::class.simpleName}",
+            node.cause is AuthorizeException,
+        )
+    }
+
+    @Test
+    fun daVinciWithPAR_wrongRedirectUri_noAuthorizeRequestMade() = runTest {
+        buildDaVinci(par = true, redirectUri = "https://invalid.example.com/callback").start()
+
+        val authorizeCalls = recordedRequests.filter { it.url.contains("/authorize") }
+        assertTrue(
+            "Expected no /authorize request when PAR is rejected due to unregistered redirect_uri",
+            authorizeCalls.isEmpty(),
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Builds a [DaVinciFlow] pointed at the PingOne test server with an onRequest interceptor
+     * that records every outgoing HTTP request into [recordedRequests].
+     *
+     * [httpClient] is set at the workflow level (not inside [Oidc]) so that it is shared by
+     * every module in the pipeline — including the PAR POST made by the Oidc module's start
+     * hook — ensuring all requests are captured.
+     */
+    private fun buildDaVinci(
+        par: Boolean,
+        clientId: String = CLIENT_ID,
+        redirectUri: String = REDIRECT_URI,
+    ): DaVinciFlow {
+        val sharedHttpClient = HttpClient {
+            logger = Logger.STANDARD
+            onRequest {
+                recordedRequests.add(RecordedRequest(url = url, method = method()))
+            }
+        }
+
+        return DaVinci {
+            logger = Logger.STANDARD
+            this.httpClient = sharedHttpClient
+            module(Oidc) {
+                this.clientId = clientId
+                this.redirectUri = redirectUri
+                scopes = mutableSetOf("openid", "profile", "email")
+                discoveryEndpoint = DISCOVERY_ENDPOINT
+                acrValues = ACR_VALUES
+                this.par = par
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RecordedRequest — immutable snapshot of a dispatched HTTP request
+// ---------------------------------------------------------------------------
+
+private data class RecordedRequest(
+    val url: String,
+    val method: String,
+)

--- a/journey/src/androidTest/kotlin/com/pingidentity/journey/PARCentralizedLoginE2ETest.kt
+++ b/journey/src/androidTest/kotlin/com/pingidentity/journey/PARCentralizedLoginE2ETest.kt
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.journey
+
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.test.filters.SmallTest
+import com.pingidentity.browser.BrowserCanceledException
+import com.pingidentity.browser.BrowserLauncher
+import com.pingidentity.oidc.exception.AuthorizeException
+import com.pingidentity.oidc.module.Oidc
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.network.ktor.HttpClient
+import com.pingidentity.network.ktor.KtorHttpRequest
+import com.pingidentity.oidc.OidcWebClient
+import io.ktor.client.request.forms.FormDataContent
+import io.mockk.coEvery
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.net.URL
+
+/**
+ * E2E tests for PAR (Pushed Authorization Request) via centralized (browser-based) login.
+ *
+ * These tests use [OidcWebClient] backed by the live AIC server. [BrowserLauncher] is mocked
+ * to cancel immediately after capturing the authorize URL — this lets us observe:
+ *   - Whether a /par POST was made (and its body fields)
+ *   - The exact URL that would be launched in the browser
+ *
+ * The browser is never opened; the PAR POST completes against the real server before
+ * [BrowserLauncher.launch] is called, so the wire shape is fully observable.
+ *
+ * Two scenarios are covered:
+ *   1. par = false — standard flow: all authorize params appear inline in the GET /authorize URL.
+ *   2. par = true  — PAR flow: params are POSTed to /par first; GET /authorize carries only
+ *      client_id + request_uri.
+ *
+ * Outgoing HTTP requests are recorded via a Ktor onRequest interceptor.
+ */
+@SmallTest
+class PARCentralizedLoginE2ETest : BaseJourneyTest() {
+
+    private val recordedRequests = mutableListOf<RecordedRequest>()
+
+    @Before
+    fun setupMocks() {
+        recordedRequests.clear()
+        mockkObject(BrowserLauncher)
+    }
+
+    @After
+    fun tearDownMocks() {
+        unmockkObject(BrowserLauncher)
+    }
+
+    // -------------------------------------------------------------------------
+    // par = false — standard centralized login
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun centralizedLoginWithoutPAR_noParPostMade() = runTest {
+        coEvery { BrowserLauncher.launch(any<URL>(), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = false).authorize()
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertTrue("Expected zero /par POST calls when par=false", parCalls.isEmpty())
+    }
+
+    @Test
+    fun centralizedLoginWithoutPAR_authorizeUrlContainsAllParams() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = false).authorize()
+
+        assertTrue("Expected browser to be launched", capturedUrl.isCaptured)
+        val query = capturedUrl.captured.query ?: ""
+        for (param in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method",
+        )) {
+            assertTrue("Expected '$param' in /authorize URL when par=false", query.contains(param))
+        }
+        assertFalse(
+            "Did not expect 'request_uri' in /authorize URL when par=false",
+            query.contains("request_uri"),
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithoutPAR_browserLaunchedWithAuthorizeUrl() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        val result = buildWebClient(par = false).authorize()
+
+        assertTrue("Expected browser to be launched when par=false", capturedUrl.isCaptured)
+        assertTrue("Expected authorize() to fail when browser is cancelled", result.isFailure)
+        assertTrue(
+            "Expected BrowserCanceledException, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is BrowserCanceledException,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // par = true — PAR-backed centralized login
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun centralizedLoginWithPAR_exactlyOneParPostMade() = runTest {
+        coEvery { BrowserLauncher.launch(any<URL>(), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertEquals("Expected exactly one POST to /par when par=true", 1, parCalls.size)
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_parPostBodyContainsRequiredFields() = runTest {
+        coEvery { BrowserLauncher.launch(any<URL>(), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        val parRequest = recordedRequests.first { it.url.contains("/par") && it.method == "POST" }
+        val form = parRequest.formFields
+
+        for (field in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method",
+        )) {
+            assertNotNull("PAR POST body missing required field '$field'", form[field])
+        }
+        assertEquals("Expected correct client_id in PAR body", CLIENT_ID, form["client_id"])
+        assertEquals("Expected response_type=code in PAR body", "code", form["response_type"])
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_authorizeUrlContainsOnlyClientIdAndRequestUri() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        assertTrue("Expected browser to be launched after PAR POST", capturedUrl.isCaptured)
+        val query = capturedUrl.captured.query ?: ""
+        assertTrue("Expected 'client_id' in /authorize URL after PAR", query.contains("client_id"))
+        assertTrue("Expected 'request_uri' in /authorize URL after PAR", query.contains("request_uri"))
+        for (forbidden in listOf("scope=", "redirect_uri=", "code_challenge=", "response_type=")) {
+            assertFalse(
+                "Did not expect '$forbidden' in /authorize URL when par=true",
+                query.contains(forbidden),
+            )
+        }
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_requestUriIsNonEmpty() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true).authorize()
+
+        assertTrue("Expected browser to be launched", capturedUrl.isCaptured)
+        val requestUri = capturedUrl.captured.toString().toUri().getQueryParameter("request_uri")
+        assertNotNull("Expected non-null request_uri in /authorize URL", requestUri)
+        assertTrue("Expected non-empty request_uri", requireNotNull(requestUri).isNotEmpty())
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_browserLaunchedAfterSuccessfulParPost() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        val result = buildWebClient(par = true).authorize()
+
+        assertTrue("Expected browser to be launched after successful PAR POST", capturedUrl.isCaptured)
+        assertTrue("Expected failure due to browser cancellation (not a PAR error)", result.isFailure)
+        assertTrue(
+            "Expected BrowserCanceledException, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is BrowserCanceledException,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // par = true — PAR failure scenarios
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun centralizedLoginWithPAR_wrongClientId_returnsFailureWithAuthorizeException() = runTest {
+        val result = buildWebClient(par = true, clientId = "invalid-client-id-xyz").authorize()
+
+        assertTrue("Expected authorize() to fail when client_id is invalid", result.isFailure)
+        assertTrue(
+            "Expected AuthorizeException for rejected PAR, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is AuthorizeException,
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_wrongClientId_browserNeverLaunched() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true, clientId = "invalid-client-id-xyz").authorize()
+
+        assertFalse(
+            "Expected browser NOT to be launched when PAR is rejected due to invalid client_id",
+            capturedUrl.isCaptured,
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_wrongRedirectUri_returnsFailureWithAuthorizeException() = runTest {
+        val result = buildWebClient(par = true, redirectUri = "https://invalid.example.com/callback").authorize()
+
+        assertTrue("Expected authorize() to fail when redirect_uri is not registered", result.isFailure)
+        assertTrue(
+            "Expected AuthorizeException for rejected PAR, got ${result.exceptionOrNull()?.javaClass?.simpleName}",
+            result.exceptionOrNull() is AuthorizeException,
+        )
+    }
+
+    @Test
+    fun centralizedLoginWithPAR_wrongRedirectUri_browserNeverLaunched() = runTest {
+        val capturedUrl = slot<URL>()
+        coEvery { BrowserLauncher.launch(capture(capturedUrl), any<Uri>()) } returns
+            Result.failure(BrowserCanceledException())
+        buildWebClient(par = true, redirectUri = "https://invalid.example.com/callback").authorize()
+
+        assertFalse(
+            "Expected browser NOT to be launched when PAR is rejected due to unregistered redirect_uri",
+            capturedUrl.isCaptured,
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds an [OidcWebClient] pointed at the AIC test server. All outgoing HTTP requests are
+     * recorded into [recordedRequests] via an onRequest interceptor, including the PAR POST body
+     * fields for form-encoded requests.
+     */
+    private fun buildWebClient(
+        par: Boolean,
+        clientId: String = CLIENT_ID,
+        redirectUri: String = REDIRECT_URI,
+    ): OidcWebClient {
+        val sharedHttpClient = HttpClient {
+            logger = Logger.STANDARD
+            onRequest {
+                val formFields: Map<String, String> = try {
+                    // KtorHttpRequest.builder is internal to foundation:network, but ktor.client.core
+                    // is on the androidTest classpath so the cast is safe here. The outer try/catch
+                    // handles any non-form-encoded requests (GET, JSON body, etc.) gracefully.
+                    val formData = (this as? KtorHttpRequest)?.builder?.body as? FormDataContent
+                    formData?.formData?.entries()
+                        ?.associate { (k, values) -> k to (values.firstOrNull() ?: "") }
+                        ?: emptyMap()
+                } catch (_: Exception) {
+                    emptyMap()
+                }
+                recordedRequests.add(RecordedRequest(url = url, method = method(), formFields = formFields))
+            }
+        }
+
+        return OidcWebClient {
+            httpClient = sharedHttpClient
+            logger = Logger.STANDARD
+            module(Oidc) {
+                this.clientId = clientId
+                this.redirectUri = redirectUri
+                scopes = mutableSetOf("openid", "email", "address", "profile", "phone")
+                discoveryEndpoint = DISCOVERY_ENDPOINT
+                this.par = par
+            }
+        }
+    }
+}

--- a/journey/src/androidTest/kotlin/com/pingidentity/journey/PARJourneyE2ETest.kt
+++ b/journey/src/androidTest/kotlin/com/pingidentity/journey/PARJourneyE2ETest.kt
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.journey
+
+import androidx.core.net.toUri
+import androidx.test.filters.SmallTest
+import com.pingidentity.journey.module.Oidc
+import com.pingidentity.logger.Logger
+import com.pingidentity.logger.STANDARD
+import com.pingidentity.network.ktor.HttpClient
+import com.pingidentity.network.ktor.KtorHttpRequest
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.SuccessNode
+import com.pingidentity.utils.Result
+import io.ktor.client.request.forms.FormDataContent
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * E2E tests for PAR (Pushed Authorization Request, RFC 9126) in the Journey / AIC flow.
+ *
+ * Two scenarios are covered:
+ *  1. par = false (default) — standard OIDC flow; all authorize params appear inline in the
+ *     GET /authorize URL, no POST to /par is made.
+ *  2. par = true             — PAR flow; params are POSTed to /par first, then only
+ *     client_id + request_uri appear in the GET /authorize URL.
+ *
+ * Wire-shape is verified by recording every outgoing HTTP request through a Ktor
+ * onRequest interceptor that captures the URL, method, and form fields of each request.
+ *
+ * Test server: openam-sdks.forgeblocks.com (AIC)
+ */
+@SmallTest
+class PARJourneyE2ETest : BaseJourneyTest() {
+
+    private val recordedRequests = mutableListOf<RecordedRequest>()
+
+    @Before
+    fun setupTree() = runTest {
+        tree = "Login"
+        recordedRequests.clear()
+    }
+
+    // ---------------------------------------------------------------------------
+    // par = false — standard flow
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun journeyLoginWithoutPAR_noParCallMade() = runTest {
+        val journey = buildJourney(par = false)
+        loginSuccessfully(journey)
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertTrue("Expected zero /par POST calls when par=false", parCalls.isEmpty())
+    }
+
+    @Test
+    fun journeyLoginWithoutPAR_authorizeUrlContainsAllParams() = runTest {
+        val journey = buildJourney(par = false)
+        loginSuccessfully(journey)
+
+        val authorizeRequest = recordedRequests.firstOrNull { it.url.contains("/authorize") }
+        assertNotNull("Expected an /authorize request when par=false", authorizeRequest)
+        val queryParams = requireNotNull(authorizeRequest).url.toUri().queryParameterNames
+
+        for (expected in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method"
+        )) {
+            assertTrue(
+                "Expected '$expected' in /authorize URL when par=false",
+                queryParams.contains(expected)
+            )
+        }
+
+        assertTrue(
+            "Did not expect 'request_uri' in /authorize URL when par=false",
+            !queryParams.contains("request_uri")
+        )
+    }
+
+    @Test
+    fun journeyLoginWithoutPAR_tokenObtainedSuccessfully() = runTest {
+        val journey = buildJourney(par = false)
+        loginSuccessfully(journey)
+
+        val tokenResult = journey.user()?.token()
+        assertTrue("Expected successful token after standard flow", tokenResult is Result.Success)
+        assertTrue(
+            "Expected non-empty access token",
+            (tokenResult as Result.Success).value.accessToken.isNotEmpty()
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // par = true — PAR flow
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun journeyLoginWithPAR_exactlyOneParPostMade() = runTest {
+        val journey = buildJourney(par = true)
+        loginSuccessfully(journey)
+
+        val parCalls = recordedRequests.filter { it.url.contains("/par") && it.method == "POST" }
+        assertEquals("Expected exactly one POST to /par when par=true", 1, parCalls.size)
+    }
+
+    @Test
+    fun journeyLoginWithPAR_parPostBodyContainsRequiredFields() = runTest {
+        val journey = buildJourney(par = true)
+        loginSuccessfully(journey)
+
+        val parRequest = recordedRequests.first { it.url.contains("/par") && it.method == "POST" }
+        val formFields = parRequest.formFields
+
+        for (field in listOf(
+            "client_id", "response_type", "scope",
+            "redirect_uri", "code_challenge", "code_challenge_method"
+        )) {
+            assertNotNull("PAR POST body missing required field '$field'", formFields[field])
+        }
+        assertEquals("Expected correct client_id in PAR body", CLIENT_ID, formFields["client_id"])
+        assertEquals("Expected response_type=code in PAR body", "code", formFields["response_type"])
+    }
+
+    @Test
+    fun journeyLoginWithPAR_authorizeUrlContainsOnlyClientIdAndRequestUri() = runTest {
+        val journey = buildJourney(par = true)
+        loginSuccessfully(journey)
+
+        val authorizeRequest = recordedRequests.firstOrNull { it.url.contains("/authorize") }
+        assertNotNull("Expected an /authorize request after PAR POST", authorizeRequest)
+        val queryParams = requireNotNull(authorizeRequest).url.toUri().queryParameterNames
+
+        assertTrue(
+            "Expected 'client_id' in /authorize URL after PAR",
+            queryParams.contains("client_id")
+        )
+        assertTrue(
+            "Expected 'request_uri' in /authorize URL after PAR",
+            queryParams.contains("request_uri")
+        )
+
+        // Full OIDC params must be absent — they were pushed to /par, not the URL
+        for (forbidden in listOf(
+            "scope", "redirect_uri", "code_challenge",
+            "code_challenge_method", "response_type"
+        )) {
+            assertTrue(
+                "Did not expect '$forbidden' in /authorize URL when par=true",
+                !queryParams.contains(forbidden)
+            )
+        }
+    }
+
+    @Test
+    fun journeyLoginWithPAR_requestUriPropagatedToAuthorize() = runTest {
+        val journey = buildJourney(par = true)
+        loginSuccessfully(journey)
+
+        val authorizeRequest = requireNotNull(recordedRequests.firstOrNull { it.url.contains("/authorize") })
+        val requestUri = authorizeRequest.url.toUri().getQueryParameter("request_uri")
+        assertNotNull("Expected non-null request_uri in /authorize URL", requestUri)
+        assertTrue("Expected non-empty request_uri", requireNotNull(requestUri).isNotEmpty())
+    }
+
+    @Test
+    fun journeyLoginWithPAR_tokenObtainedSuccessfully() = runTest {
+        val journey = buildJourney(par = true)
+        loginSuccessfully(journey)
+
+        val tokenResult = journey.user()?.token()
+        assertTrue("Expected successful token after PAR flow", tokenResult is Result.Success)
+        assertTrue(
+            "Expected non-empty access token after PAR",
+            (tokenResult as Result.Success).value.accessToken.isNotEmpty()
+        )
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Builds a [Journey] pointed at the AIC test server with an onRequest interceptor that
+     * records every outgoing HTTP request into [recordedRequests].
+     *
+     * [httpClient] is set at the workflow level so it is shared across all modules — including
+     * the Oidc module's start hook that performs the PAR POST — ensuring all requests are captured.
+     */
+    private fun buildJourney(par: Boolean): Journey {
+        return Journey {
+            logger = Logger.STANDARD
+            serverUrl = SERVER_URL
+            realm = REALM
+            cookie = COOKIE
+            httpClient = HttpClient {
+                logger = Logger.STANDARD
+                onRequest {
+                    val formFields: Map<String, String> = try {
+                        // KtorHttpRequest.builder is internal to foundation:network, but ktor.client.core
+                        // is on the androidTest classpath so the cast is safe here. The outer try/catch
+                        // handles any non-form-encoded requests (GET, JSON body, etc.) gracefully.
+                        val formData = (this as? KtorHttpRequest)?.builder?.body as? FormDataContent
+                        formData?.formData?.entries()
+                            ?.associate { (k, values) -> k to (values.firstOrNull() ?: "") }
+                            ?: emptyMap()
+                    } catch (_: Exception) {
+                        emptyMap()
+                    }
+                    recordedRequests.add(
+                        RecordedRequest(
+                            url = url,
+                            method = method(),
+                            formFields = formFields,
+                        )
+                    )
+                }
+            }
+            module(Oidc) {
+                clientId = CLIENT_ID
+                redirectUri = REDIRECT_URI
+                scopes = mutableSetOf("openid", "email", "address", "profile", "phone")
+                discoveryEndpoint = DISCOVERY_ENDPOINT
+                this.par = par
+            }
+        }
+    }
+
+    private suspend fun loginSuccessfully(journey: Journey) {
+        val node = journey.start(tree) as ContinueNode
+        node.handleLoginCallbacks(USERNAME, PASSWORD)
+        val result = node.next()
+        assertTrue(
+            "Expected SuccessNode after login, got ${result::class.simpleName}",
+            result is SuccessNode
+        )
+        // Trigger the OIDC authorize redirect (and PAR POST if par=true).
+        // In the Journey SDK, this happens lazily on the first token() call.
+        journey.user()?.token()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RecordedRequest — immutable snapshot of a dispatched HTTP request
+// ---------------------------------------------------------------------------
+
+/**
+ * Immutable snapshot of an outgoing HTTP request captured by the onRequest interceptor.
+ *
+ * @property url        Full request URL including query parameters.
+ * @property method     HTTP method ("GET", "POST", etc.).
+ * @property formFields Decoded form-urlencoded body fields, or empty map if not a form POST.
+ */
+data class RecordedRequest(
+    val url: String,
+    val method: String,
+    val formFields: Map<String, String>,
+)

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/config/EnvViewModel.kt
@@ -55,6 +55,7 @@ data class JourneyConfigState(
     val scopes: String = "",
     val redirectUri: String = "",
     val display: String = "",
+    val par: Boolean = false,
 )
 
 data class OidcConfigState(
@@ -63,7 +64,8 @@ data class OidcConfigState(
     val scopes: String = "",
     val redirectUri: String = "",
     val display: String = "",
-    val arcValue: String = ""
+    val arcValue: String = "",
+    val par: Boolean = false,
 )
 
 data class DeviceAuthConfigState(
@@ -156,6 +158,7 @@ internal fun loadAssetConfigs(): AssetConfigs {
                 scopes = scopes,
                 redirectUri = redirectUri,
                 display = displayName,
+                par = oidc["par"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false,
             ))
             if (openIdObj != null || isDaVinci) deviceAuth.add(DeviceAuthConfigState(
                 clientId = clientId,
@@ -185,6 +188,8 @@ internal fun loadAssetConfigs(): AssetConfigs {
                 scopes = scopes,
                 redirectUri = redirectUri,
                 display = displayName,
+                arcValue = oidc.str("acrValues"),
+                par = oidc["par"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false,
             ))
         }
     }
@@ -224,6 +229,7 @@ internal fun buildJourney(config: JourneyConfigState) {
                 put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
                 put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
                 put(JsonConfigKey.DISPLAY, config.display)
+                put(JsonConfigKey.PAR, config.par)
             })
         }
     ).onSuccess { journey = it }
@@ -278,6 +284,8 @@ internal fun buildWeb(config: OidcConfigState) {
                 put(JsonConfigKey.SCOPES, config.scopes.toScopesJsonArray())
                 put(JsonConfigKey.REDIRECT_URI, config.redirectUri)
                 put(JsonConfigKey.DISPLAY, config.display)
+                if (config.arcValue.isNotBlank()) put(JsonConfigKey.ACR_VALUES, config.arcValue)
+                put(JsonConfigKey.PAR, config.par)
             })
         }
     ).onSuccess { web = it }
@@ -354,6 +362,7 @@ suspend fun initConfigs() {
             scopes = prefs[stringPreferencesKey("j_scopes")] ?: "",
             redirectUri = prefs[stringPreferencesKey("j_redirectUri")] ?: "",
             display = prefs[stringPreferencesKey("j_display")] ?: "",
+            par = prefs[stringPreferencesKey("j_par")]?.toBooleanStrictOrNull() ?: false,
         )
     }
 
@@ -375,6 +384,8 @@ suspend fun initConfigs() {
             scopes = prefs[stringPreferencesKey("w_scopes")] ?: "",
             redirectUri = prefs[stringPreferencesKey("w_redirectUri")] ?: "",
             display = prefs[stringPreferencesKey("w_display")] ?: "",
+            arcValue = prefs[stringPreferencesKey("w_arcValue")] ?: "",
+            par = prefs[stringPreferencesKey("w_par")]?.toBooleanStrictOrNull() ?: false,
         )
     }
 
@@ -635,6 +646,7 @@ class EnvViewModel : ViewModel() {
             scopes = prefs[stringPreferencesKey("j_scopes")] ?: "",
             redirectUri = prefs[stringPreferencesKey("j_redirectUri")] ?: "",
             display = prefs[stringPreferencesKey("j_display")] ?: "",
+            par = prefs[stringPreferencesKey("j_par")]?.toBooleanStrictOrNull() ?: false,
         )
     }
 
@@ -660,6 +672,8 @@ class EnvViewModel : ViewModel() {
             scopes = prefs[stringPreferencesKey("w_scopes")] ?: "",
             redirectUri = prefs[stringPreferencesKey("w_redirectUri")] ?: "",
             display = prefs[stringPreferencesKey("w_display")] ?: "",
+            arcValue = prefs[stringPreferencesKey("w_arcValue")] ?: "",
+            par = prefs[stringPreferencesKey("w_par")]?.toBooleanStrictOrNull() ?: false,
         )
     }
 
@@ -719,6 +733,7 @@ class EnvViewModel : ViewModel() {
             prefs[stringPreferencesKey("j_scopes")] = config.scopes
             prefs[stringPreferencesKey("j_redirectUri")] = config.redirectUri
             prefs[stringPreferencesKey("j_display")] = config.display
+            prefs[stringPreferencesKey("j_par")] = config.par.toString()
         }
     }
 
@@ -740,6 +755,8 @@ class EnvViewModel : ViewModel() {
             prefs[stringPreferencesKey("w_scopes")] = config.scopes
             prefs[stringPreferencesKey("w_redirectUri")] = config.redirectUri
             prefs[stringPreferencesKey("w_display")] = config.display
+            prefs[stringPreferencesKey("w_arcValue")] = config.arcValue
+            prefs[stringPreferencesKey("w_par")] = config.par.toString()
         }
     }
 
@@ -794,6 +811,7 @@ class EnvViewModel : ViewModel() {
                     put("serverUrl", c.serverUrl); put("realm", c.realm); put("cookie", c.cookie)
                     put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
                     put("scopes", c.scopes); put("redirectUri", c.redirectUri); put("display", c.display)
+                    put("par", c.par)
                 })
             }
         }.toString()
@@ -806,6 +824,7 @@ class EnvViewModel : ViewModel() {
                 serverUrl = str("serverUrl"), realm = str("realm"), cookie = str("cookie"),
                 clientId = str("clientId"), discoveryEndpoint = str("discoveryEndpoint"),
                 scopes = str("scopes"), redirectUri = str("redirectUri"), display = str("display"),
+                par = o["par"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false,
             )
         }
     }.getOrDefault(emptyList())
@@ -817,6 +836,7 @@ class EnvViewModel : ViewModel() {
                     put("clientId", c.clientId); put("discoveryEndpoint", c.discoveryEndpoint)
                     put("scopes", c.scopes); put("redirectUri", c.redirectUri)
                     put("display", c.display); put("arcValue", c.arcValue)
+                    put("par", c.par)
                 })
             }
         }.toString()
@@ -829,6 +849,7 @@ class EnvViewModel : ViewModel() {
                 clientId = str("clientId"), discoveryEndpoint = str("discoveryEndpoint"),
                 scopes = str("scopes"), redirectUri = str("redirectUri"),
                 display = str("display"), arcValue = str("arcValue"),
+                par = o["par"]?.jsonPrimitive?.content?.toBooleanStrictOrNull() ?: false,
             )
         }
     }.getOrDefault(emptyList())


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5181](https://pingidentity.atlassian.net/browse/SDKS-5181) [QA][Android] PAR

# Description
Adds E2E test coverage for the PAR (Pushed Authorization Request, RFC 9126) feature across all SDK flows, and fixes two bugs in the sample app where `par` and `acrValues` were not being propagated through the config pipeline.

##  New test files
- **journey/PARCentralizedLoginE2ETest** — PAR via browser-based (OidcWebClient) login against AIC.
  BrowserLauncher is mocked to cancel immediately after capturing the authorize URL, allowing wire-shape assertions without opening a browser. Covers:
  - par=false: no /par POST made; all OIDC params appear inline in the /authorize URL
  - par=true: exactly one /par POST made with required form fields; /authorize carries only client_id + request_uri; browser is launched after a successful PAR exchange
  - Failure scenarios: invalid client_id / unregistered redirect_uri → Result.failure(AuthorizeException); browser is never launched

- **journey/PARJourneyE2ETest** — PAR via Journey tree-based login against AIC. Outgoing HTTP requests are recorded via a Ktor onRequestinterceptor. 
**Covers:**
  - **par=false**: no /par POST; all OIDC params inline in /authorize; token obtained successfully
  - **par=true**: exactly one /par POST with required fields; /authorize carries only client_id + request_uri; request_uri is non empty; token obtained successfully.

- **davinci/PARCentralizedLoginDaVinciE2ETest** — PAR via OidcWebClient against PingOne. Same approach and coverage as **PARCentralizedLoginE2ETest**, targeting the PingOne environment.

- **davinci/PARDaVinciE2ETest** — PAR via DaVinci form-based flow against PingOne. Unlike the centralized tests, DaVinci sends the authorize URL as a plain HTTP GET (no BrowserLauncher). 
**Covers:**
  - **par=false**: no /par POST; all OIDC params inline in /authorize; start() returns ContinueNode
  - **par=true**: exactly one /par POST; /authorize carries only client_id + request_uri; start() returns ContinueNode
  - **Failure scenarios**: invalid client_id / unregistered redirect_uri → FailureNode(AuthorizeException); no /authorize request made

- **Bug fixes** (samples/pingsampleapp/EnvViewModel)
  - `par` was not read from JSON asset configs for either the Journey or web (OidcWebClient) flow
  - `acrValues` was not read from JSON asset configs for the web flow
  - Both fields were missing from the DataStore persist/load path and the in-memory serialization round-trip, meaning they were lost on app restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added PAR (Pushed Authorization Requests) configuration support for Journey and Web login flows in the sample app.
  * PAR settings are now persisted and restored alongside other configuration options.
* **Tests**
  * Added new Android end-to-end test coverage for PAR behavior across Journey, DaVinci, and centralized (browser-based) login flows, including success and validation/error scenarios.
* **Chores**
  * Improved Android packaging to exclude unnecessary license files from packaged resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->