### PR TITLE
SDKS-5060 Release Activities for Ping Orchestration SDK 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,22 @@
-## [Unreleased]
+## [2.1.0]
+
+#### Added
+- Added OAuth 2.0 Device Authorization Grant (RFC 8628) support [SDKS-4784]
+- Added Pushed Authorization Request (PAR) support for OIDC [SDKS-4231]
+- Added standardized JSON configuration support [SDKS-5065] 
+- Added `PollingCollector` for DaVinci flows [SDKS-4681]
+- Added `QrCodeCollector` for DaVinci flows [SDKS-4679]
+- Added `BooleanCollector` to support Checkbox and Switch input types in DaVinci forms [SDKS-4919]
+- Added `ReadOnlyTextCollector` for DaVinci forms to support Terms of Service and agreement displays [SDKS-4927]
+- Added support for links in Translatable Rich Text (Forms) [SDKS-4246]
+- Added support for phone number extensions in `PhoneNumberCollector` [SDKS-4669]
+- Added support for Android 17 and updated `compileSdk` to version 37 [SDKS-5191]
+
 #### Fixed
 - Fixed OATH and Push URI parsers to propagate typed `InvalidUriException` for structural URI parse errors [SDKS-5074]
 - Fixed Ktor CIO engine dropping repeated `Set-Cookie` headers with mixed casing (KTOR-8614 workaround) [SDKS-4742]
+- Fixed Push Number Challenge not surfacing a distinct failure for wrong-number responses [SDKS-5116]
+- Fixed `PasswordCollector` not handling nested Password policies [SDKS-4694]
 
 ## [2.0.1]
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5060](https://pingidentity.atlassian.net/browse/SDKS-5060) Release Activities for Ping Orchestration SDK 2.1.0

# Description

- Updated CHANGELOG.md for the 2.1.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.0 Device Authorization Grant and PAR support.
  * Expanded DaVinci collector/form capabilities, including additional collectors and improved form, link, and phone-format handling.
* **Bug Fixes**
  * Improved robustness for OATH/Push URI parsing and corrected `Set-Cookie` handling.
  * Improved Push Number Challenge handling so wrong-number failures are surfaced properly.
  * Fixed nested password policy handling during password collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->