### PR TITLE
SDKS-5191 Downgrade compile SDK from 37 to 36

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added `ReadOnlyTextCollector` for DaVinci forms to support Terms of Service and agreement displays [SDKS-4927]
 - Added support for links in Translatable Rich Text (Forms) [SDKS-4246]
 - Added support for phone number extensions in `PhoneNumberCollector` [SDKS-4669]
-- Added support for Android 17 and updated `compileSdk` to version 37 [SDKS-5191]
+- Support for Android 17 (the SDK has been verified to build and run correctly on Android 17) [SDKS-5191]
 
 #### Fixed
 - Fixed OATH and Push URI parsers to propagate typed `InvalidUriException` for structural URI parse errors [SDKS-5074]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 coilSvg = "2.7.0"
-compileSdk = "37"
+compileSdk = "36"
 targetSdk = "37"
 minSdk = "29"
 jvmTarget = "21"


### PR DESCRIPTION
# JIRA Ticket
[SDKS-5191](https://pingidentity.atlassian.net/browse/SDKS-5191)

# Description
This PR downgrades the Compile SDK version from 37 to 36 to support RN development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted the app’s build SDK level to an earlier, more stable setting to improve build compatibility.
* **Documentation**
  * Updated the changelog entry to reflect that the app was verified to build and run correctly on Android 17.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->