### PR TITLE
SDKS-5168 Metadata payload to support the pause/resume

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Metadata.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Metadata.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.module
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Represents a DaVinci SDK Connector metadata payload received from the server during a
+ * pause/resume flow.
+ *
+ * The wire format carries three required keys:
+ * - `TYPE` — identifies the SDK connector type (e.g. `Metadata.Type.PINGONE_MFA_SDK`).
+ * - `OPERATION` — the operation the connector is requesting.
+ * - `configs` — an opaque JSON object whose shape is TYPE-specific.
+ *
+ * @property type    The metadata connector type string. Compare against [Type] constants.
+ * @property operation The operation being requested by the connector.
+ * @property configs   The opaque configuration object; callers decode it with
+ *                     `kotlinx.serialization` as needed.
+ */
+data class Metadata(
+    val type: String,
+    val operation: String,
+    val configs: JsonObject,
+) {
+    /**
+     * Companion object that serves as the receiver for [parseOrNull] and [parseOrThrow] factory
+     * extension functions.
+     */
+    companion object
+
+    /**
+     * Well-known `TYPE` string constants. Kept as `const val` rather than an enum so that new
+     * server-side TYPE values are forward-compatible without requiring an SDK release (see D5 in
+     * decisions.md).
+     */
+    object Type {
+        /** Top-level metadata TYPE value returned by the server. */
+        const val METADATA = "METADATA"
+
+        /** An external (non-Ping) SDK is required to fulfil this step. */
+        const val EXTERNAL_SDK = "EXTERNAL_SDK"
+
+        /** PingOne MFA SDK is required to fulfil this step. */
+        const val PINGONE_MFA_SDK = "PINGONE_MFA_SDK"
+
+        /** Keyless SDK is required to fulfil this step. */
+        const val KEYLESS_SDK = "KEYLESS_SDK"
+    }
+}
+
+/**
+ * Attempts to parse a [Metadata] from [input], returning `null` when any required key is absent
+ * or has an unexpected JSON type.
+ *
+ * @param input The JSON object from the server payload.
+ * @return A [Metadata] instance, or `null` if parsing cannot succeed.
+ */
+internal fun Metadata.Companion.parseOrNull(input: JsonObject): Metadata? {
+    return try {
+        val type = input["TYPE"]?.jsonPrimitive?.content ?: return null
+        val operation = input["OPERATION"]?.jsonPrimitive?.content ?: return null
+        val configs = input["configs"]?.jsonObject ?: return null
+        Metadata(type = type, operation = operation, configs = configs)
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Parses a [Metadata] from [input], throwing [MetadataException.Malformed] when a required key is
+ * absent or has an unexpected JSON type.
+ *
+ * The exception message names the offending key but **never** embeds any value from [input]
+ * (satisfies the security NFR that forbids logging opaque payloads).
+ *
+ * @param input The JSON object from the server payload.
+ * @return A [Metadata] instance.
+ * @throws MetadataException.Malformed if `TYPE`, `OPERATION`, or `configs` is missing or has the
+ *   wrong JSON type.
+ */
+internal fun Metadata.Companion.parseOrThrow(input: JsonObject): Metadata {
+    val type = input["TYPE"]?.let {
+        try {
+            it.jsonPrimitive.content
+        } catch (_: Exception) {
+            throw MetadataException.Malformed("Metadata payload has wrong type for required key 'TYPE'")
+        }
+    } ?: throw MetadataException.Malformed("Metadata payload is missing required key 'TYPE'")
+
+    val operation = input["OPERATION"]?.let {
+        try {
+            it.jsonPrimitive.content
+        } catch (_: Exception) {
+            throw MetadataException.Malformed("Metadata payload has wrong type for required key 'OPERATION'")
+        }
+    } ?: throw MetadataException.Malformed("Metadata payload is missing required key 'OPERATION'")
+
+    val configs = input["configs"]?.let {
+        try {
+            it.jsonObject
+        } catch (_: Exception) {
+            throw MetadataException.Malformed("Metadata payload has wrong type for required key 'configs'")
+        }
+    } ?: throw MetadataException.Malformed("Metadata payload is missing required key 'configs'")
+
+    return Metadata(type = type, operation = operation, configs = configs)
+}

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/MetadataException.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/MetadataException.kt
@@ -37,10 +37,10 @@ sealed class MetadataException(
 
     /**
      * Thrown (in strict-mode, future use) when the server sends a `TYPE` value the SDK does not
-     * recognise. Reserved for V1; the SDK does **not** validate TYPE against a whitelist by default
+     * recognize. Reserved for V1; the SDK does **not** validate TYPE against a whitelist by default
      * (see D5 in decisions.md).
      *
-     * @property rawType The unrecognised TYPE string as received from the server.
+     * @property rawType The unrecognized TYPE string as received from the server.
      */
-    class UnsupportedType(val rawType: String) : MetadataException("Unknown metadata TYPE=$rawType")
+    class UnsupportedType(val rawType: String) : MetadataException("Unknown or unsupported metadata TYPE")
 }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/MetadataException.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/MetadataException.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.module
+
+/**
+ * Sealed exception hierarchy for errors that occur while parsing or resuming a DaVinci metadata
+ * node. Parsing failures bubble out of `Transform.tryMetadataNode()` and are caught by the outer
+ * `catch { }` in `Workflow.start` / `Workflow.next`, producing a `FailureNode`.
+ *
+ * @param message Human-readable description of the error. Must **not** include any user-supplied
+ *   or server-supplied values (tokens, configs, PII).
+ * @param cause   The underlying throwable, if any.
+ */
+sealed class MetadataException(
+    message: String,
+    cause: Throwable? = null,
+) : Exception(message, cause) {
+
+    /**
+     * Thrown when the server-sent metadata payload is structurally invalid — a required key is
+     * absent or carries an unexpected JSON type.
+     *
+     * @param message Names the offending key (e.g. `"Metadata payload is missing required key 'TYPE'"`).
+     *   Never embeds the key's value or any surrounding payload data.
+     */
+    class Malformed(message: String) : MetadataException(message)
+
+    /**
+     * Thrown when `MetadataNode.asRequest()` cannot build the resume request because `_links.next.href`
+     * is absent from the metadata response.
+     */
+    class MissingResumeLink : MetadataException("Metadata node has no _links.next.href")
+
+    /**
+     * Thrown (in strict-mode, future use) when the server sends a `TYPE` value the SDK does not
+     * recognise. Reserved for V1; the SDK does **not** validate TYPE against a whitelist by default
+     * (see D5 in decisions.md).
+     *
+     * @property rawType The unrecognised TYPE string as received from the server.
+     */
+    class UnsupportedType(val rawType: String) : MetadataException("Unknown metadata TYPE=$rawType")
+}

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/MetadataNode.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/MetadataNode.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.module
+
+import com.pingidentity.davinci.plugin.DaVinci
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.FlowContext
+import com.pingidentity.orchestrate.Node
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import com.pingidentity.network.HttpRequest as Request
+
+/**
+ * A [ContinueNode] subclass representing a DaVinci SDK Integrator metadata node.
+ *
+ * When a DaVinci flow reaches an SDK Connector step and the request carries
+ * `X-Requested-With: ping-sdk`, the server pauses the flow and returns a metadata
+ * payload. The SDK surfaces this as a [MetadataNode] so callers can:
+ * 1. Inspect [metadata] to determine what external SDK operation is required.
+ * 2. Perform that operation to obtain an output (and optionally an error).
+ * 3. Call [resume] to post the result back and continue the flow.
+ *
+ * Because [MetadataNode] extends [ContinueNode], existing exhaustive `when` expressions
+ * over `Node` continue to compile. Add an `is MetadataNode ->` arm **before**
+ * `is ContinueNode ->` in any `when` expression that needs to distinguish the two.
+ *
+ * @property daVinci  The [DaVinci] workflow this node belongs to.
+ * @property metadata The parsed [Metadata] payload describing the required SDK operation.
+ */
+open class MetadataNode internal constructor(
+    context: FlowContext,
+    val daVinci: DaVinci,
+    input: JsonObject,
+    val metadata: Metadata,
+) : ContinueNode(context, daVinci, input, emptyList()) {
+
+    private var pendingOutput: JsonElement? = null
+    private var pendingError: JsonObject? = null
+
+    /**
+     * Stores an output payload to be included in the next [resume] call.
+     *
+     * This is the builder-style alternative to passing [output] directly to [resume].
+     * The value is overwritten if [resume] is called with a non-null [output] argument.
+     *
+     * @param output Any JSON element produced by the external SDK operation.
+     */
+    fun setOutput(output: JsonElement) {
+        this.pendingOutput = output
+    }
+
+    /**
+     * Stores an error payload to be included in the next [resume] call.
+     *
+     * This is the builder-style alternative to passing [error] directly to [resume].
+     * The value is overwritten if [resume] is called with a non-null [error] argument.
+     *
+     * @param error A JSON object describing the error from the external SDK operation.
+     */
+    fun setError(error: JsonObject) {
+        this.pendingError = error
+    }
+
+    /**
+     * Resumes the paused DaVinci flow by posting the supplied [output] and/or [error]
+     * to `_links.next.href` and advancing to the next workflow node.
+     *
+     * Both parameters are optional; a `null` value omits the corresponding key from the
+     * POST body entirely. Parameters supplied here take precedence over any values
+     * previously set via [setOutput] / [setError].
+     *
+     * The full `next` handler chain (cookie persistence, custom headers, etc.) runs
+     * unchanged — all modules registered on the workflow apply to the resume request.
+     *
+     * @param output Optional output payload from the external SDK operation.
+     * @param error  Optional error object when the external SDK operation produced a failure.
+     * @return The next [Node] in the workflow, or [com.pingidentity.orchestrate.FailureNode]
+     *         wrapping [MetadataException.MissingResumeLink] if `_links.next.href` is absent.
+     */
+    suspend fun resume(
+        output: JsonElement? = null,
+        error: JsonObject? = null,
+    ): Node {
+        output?.let { pendingOutput = it }
+        error?.let { pendingError = it }
+        return next()
+    }
+
+    /**
+     * Builds the POST request to `_links.next.href` with the pending [pendingOutput] and
+     * [pendingError] payloads in the JSON body.
+     *
+     * A key is omitted from the body when the corresponding pending value is `null`.
+     *
+     * @throws MetadataException.MissingResumeLink when `_links.next.href` is absent from
+     *   the original server response. The surrounding [com.pingidentity.orchestrate.Workflow]
+     *   pipeline wraps this in a [com.pingidentity.orchestrate.FailureNode].
+     */
+    override fun asRequest(): Request {
+        val href =
+            input["_links"]?.jsonObject?.get("next")?.jsonObject?.get("href")?.jsonPrimitive?.content
+                ?: throw MetadataException.MissingResumeLink()
+
+        val body = buildJsonObject {
+            pendingOutput?.let { put("output", it) }
+            pendingError?.let { put("error", it) }
+        }
+
+        return daVinci.config.httpClient.request().apply {
+            url = href
+            header("Content-Type", "application/json")
+            post(body)
+        }
+    }
+}

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.net.HttpURLConnection
@@ -134,11 +135,71 @@ private fun transform(
         }
     }
 
+    tryMetadataNode(context, daVinci, json)?.let { return it }
+
     val collectors = mutableListOf<Collector<*>>()
     if ("form" in json) collectors.addAll(Form.parse(daVinci, json))
 
     return Connector(context, daVinci, json, collectors.toList()).apply {
-        CollectorFactory.inject( this)
+        CollectorFactory.inject(this)
     }
 
+}
+
+/**
+ * Attempts to detect and construct a [MetadataNode] from a DaVinci 200-OK response.
+ *
+ * Detection strategy (layered probe):
+ * 1. **Primary** — look for a field in `json.form.components.fields[]` whose `"type"` or
+ *    `"inputType"` equals `"METADATA"` and whose sibling keys contain the required triple
+ *    (`TYPE`, `OPERATION`, `configs`). This matches the documented DV-10961 wire shape.
+ * 2. **Secondary (defensive)** — fall back to treating `json` itself as the metadata block
+ *    when it directly contains `TYPE` and `configs` at the top level.
+ *
+ * Returns `null` when no metadata block is found, allowing [transform] to fall through to
+ * the standard [Connector] path.
+ *
+ * Throws [MetadataException.Malformed] (via `Metadata.parseOrThrow`) when a structural cue
+ * for metadata is unambiguously present but the required keys are malformed — the surrounding
+ * `Workflow.start` / `Workflow.next` `catch { }` converts this to a [FailureNode].
+ */
+private fun tryMetadataNode(
+    context: FlowContext,
+    daVinci: DaVinci,
+    json: JsonObject,
+): MetadataNode? {
+    // --- Primary probe: form.components.fields[].{type|inputType == "METADATA"} ---
+    val fields = json["form"]
+        ?.jsonObject?.get("components")
+        ?.jsonObject?.get("fields")
+        ?.jsonArray
+
+    if (fields != null) {
+        for (field in fields) {
+            val fieldObj = field as? JsonObject ?: continue
+            val fieldType = fieldObj["type"]?.jsonPrimitive?.contentOrNull
+            val inputType = fieldObj["inputType"]?.jsonPrimitive?.contentOrNull
+            if (fieldType == "METADATA" || inputType == "METADATA") {
+                // This field is the metadata block — parse strictly
+                val metadata = Metadata.parseOrThrow(fieldObj)
+                // Only construct a MetadataNode when the resume link is present;
+                // MetadataNode.asRequest() will read the href from input directly at resume time.
+                json["_links"]?.jsonObject?.get("next")?.jsonObject
+                    ?.get("href")?.jsonPrimitive?.contentOrNull
+                    ?: return null
+                return MetadataNode(context, daVinci, json, metadata)
+            }
+        }
+    }
+
+    // --- Secondary probe: top-level json contains both TYPE and configs ---
+    if (json["TYPE"] != null && json["configs"] != null) {
+        val metadata = Metadata.parseOrNull(json) ?: return null
+        json["_links"]?.jsonObject?.get("next")?.jsonObject
+            ?.get("href")?.jsonPrimitive?.contentOrNull
+            ?: return null
+        return MetadataNode(context, daVinci, json, metadata)
+    }
+
+    return null
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataNodeTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataNodeTest.kt
@@ -236,7 +236,7 @@ class MetadataNodeTest {
     // -------------------------------------------------------------------------
 
     @Test
-    fun `resume returns FailureNode with MissingResumeLink when _links_next_href is absent`() =
+    fun `start returns non-MetadataNode when _links_next_href is absent`() =
         runTest {
             mockEngine = MockEngine { request ->
                 when (request.url.encodedPath) {

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataNodeTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataNodeTest.kt
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.module.Metadata
+import com.pingidentity.davinci.module.MetadataException
+import com.pingidentity.davinci.module.MetadataNode
+import com.pingidentity.davinci.module.Oidc
+import com.pingidentity.davinci.plugin.DaVinci
+import com.pingidentity.network.ktor.KtorHttpClient
+import com.pingidentity.orchestrate.FailureNode
+import com.pingidentity.orchestrate.module.Cookie
+import com.pingidentity.storage.MemoryStorage
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for [MetadataNode] — parse-and-detect, malformed, missing-link,
+ * resume happy-path, resume with error, and cancellation guard.
+ *
+ * Transport is provided by Ktor [MockEngine]; the test drives a full [DaVinci] instance
+ * so all workflow module hooks run exactly as in production.
+ */
+@RunWith(RobolectricTestRunner::class)
+class MetadataNodeTest {
+
+    private lateinit var mockEngine: MockEngine
+
+    // -------------------------------------------------------------------------
+    // Shared fixtures / helpers
+    // -------------------------------------------------------------------------
+
+    /** Well-formed metadata response — primary probe (field in form.components.fields). */
+    private fun metadataResponseJson(
+        resumeHref: String = "http://localhost/resume",
+        type: String = Metadata.Type.PINGONE_MFA_SDK,
+        operation: String = "CHECK_FOR_MFA",
+        configs: JsonObject = buildJsonObject { put("sdkId", "ping-mfa") },
+    ) = """
+        {
+            "_links": {
+                "next": {
+                    "href": "$resumeHref"
+                }
+            },
+            "id": "metadata-node-id",
+            "eventName": "continue",
+            "form": {
+                "name": "SDK Metadata",
+                "description": "",
+                "category": "CUSTOM_HTML",
+                "components": {
+                    "fields": [
+                        {
+                            "type": "METADATA",
+                            "TYPE": "$type",
+                            "OPERATION": "$operation",
+                            "configs": ${configs}
+                        }
+                    ]
+                }
+            }
+        }
+    """.trimIndent()
+
+    /** Malformed metadata: field has type METADATA but TYPE key is missing. */
+    private fun malformedMetadataResponseJson() = """
+        {
+            "_links": {
+                "next": {
+                    "href": "http://localhost/resume"
+                }
+            },
+            "id": "metadata-node-id",
+            "eventName": "continue",
+            "form": {
+                "name": "SDK Metadata",
+                "description": "",
+                "category": "CUSTOM_HTML",
+                "components": {
+                    "fields": [
+                        {
+                            "type": "METADATA",
+                            "OPERATION": "CHECK_FOR_MFA",
+                            "configs": {}
+                        }
+                    ]
+                }
+            }
+        }
+    """.trimIndent()
+
+    /** Metadata response without _links.next.href so resume link is absent. */
+    private fun metadataResponseMissingLinkJson() = """
+        {
+            "id": "metadata-node-id",
+            "eventName": "continue",
+            "form": {
+                "name": "SDK Metadata",
+                "description": "",
+                "category": "CUSTOM_HTML",
+                "components": {
+                    "fields": [
+                        {
+                            "type": "METADATA",
+                            "TYPE": "${Metadata.Type.PINGONE_MFA_SDK}",
+                            "OPERATION": "CHECK_FOR_MFA",
+                            "configs": {}
+                        }
+                    ]
+                }
+            }
+        }
+    """.trimIndent()
+
+    /**
+     * Builds a [DaVinci] with [engine] as the transport and registers the default collectors.
+     * Uses an in-memory token/cookie storage so tests stay fully in-process.
+     */
+    private fun buildDaVinci(engine: MockEngine): DaVinci {
+        CollectorRegistry().initialize()
+        return DaVinci {
+            httpClient = KtorHttpClient(HttpClient(engine))
+            module(Oidc) {
+                clientId = "test"
+                discoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+                scopes = mutableSetOf("openid", "email", "address")
+                redirectUri = "http://localhost:8080"
+                storage = { MemoryStorage() }
+            }
+            module(Cookie) {
+                storage = { MemoryStorage() }
+                persist = mutableListOf("ST")
+            }
+        }
+    }
+
+    @BeforeTest
+    fun setUp() {
+        // CollectorRegistry is re-initialised per test inside buildDaVinci.
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (::mockEngine.isInitialized) mockEngine.close()
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 1 — Parse-and-detect
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `start returns MetadataNode with expected type operation and configs`() = runTest {
+        val expectedConfigs = buildJsonObject { put("sdkId", "ping-mfa"); put("region", "us") }
+        mockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/.well-known/openid-configuration" ->
+                    respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                "/authorize" ->
+                    respond(
+                        ByteReadChannel(metadataResponseJson(configs = expectedConfigs)),
+                        HttpStatusCode.OK,
+                        authorizeResponseHeaders,
+                    )
+                else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val node = buildDaVinci(mockEngine).start()
+
+        assertIs<MetadataNode>(node)
+        assertEquals(Metadata.Type.PINGONE_MFA_SDK, node.metadata.type)
+        assertEquals("CHECK_FOR_MFA", node.metadata.operation)
+        assertEquals("ping-mfa", node.metadata.configs["sdkId"]?.jsonPrimitive?.content)
+        assertEquals("us", node.metadata.configs["region"]?.jsonPrimitive?.content)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 2 — Malformed detection
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `start returns FailureNode with MetadataException Malformed when TYPE is absent`() =
+        runTest {
+            mockEngine = MockEngine { request ->
+                when (request.url.encodedPath) {
+                    "/.well-known/openid-configuration" ->
+                        respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                    "/authorize" ->
+                        respond(
+                            ByteReadChannel(malformedMetadataResponseJson()),
+                            HttpStatusCode.OK,
+                            authorizeResponseHeaders,
+                        )
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+                }
+            }
+
+            val node = buildDaVinci(mockEngine).start()
+
+            assertIs<FailureNode>(node)
+            assertIs<MetadataException.Malformed>(node.cause)
+            assertTrue(
+                node.cause.message?.contains("TYPE") == true,
+                "Exception message should mention 'TYPE'",
+            )
+        }
+
+    // -------------------------------------------------------------------------
+    // Test 3 — Missing resume link
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `resume returns FailureNode with MissingResumeLink when _links_next_href is absent`() =
+        runTest {
+            mockEngine = MockEngine { request ->
+                when (request.url.encodedPath) {
+                    "/.well-known/openid-configuration" ->
+                        respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                    "/authorize" ->
+                        respond(
+                            ByteReadChannel(metadataResponseMissingLinkJson()),
+                            HttpStatusCode.OK,
+                            authorizeResponseHeaders,
+                        )
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+                }
+            }
+
+            // When _links.next.href is absent, tryMetadataNode returns null and Transform falls
+            // through to a regular Connector. Verify the node is NOT a MetadataNode.
+            val node = buildDaVinci(mockEngine).start()
+            assertFalse(
+                node is MetadataNode,
+                "When _links.next.href is absent, tryMetadataNode should return null " +
+                    "and Transform should fall through to a Connector",
+            )
+        }
+
+    /**
+     * Unit test: [MetadataNode.asRequest] throws [MetadataException.MissingResumeLink] when
+     * the node's input lacks `_links.next.href`.
+     *
+     * This is the direct unit-level verification of the exception path.
+     */
+    @Test
+    fun `MissingResumeLink has correct message`() {
+        // MetadataNode constructor is internal; verify the exception message directly.
+        val ex = MetadataException.MissingResumeLink()
+        assertEquals("Metadata node has no _links.next.href", ex.message)
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 4 — Resume happy path (output only)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `resume posts output to _links_next_href and the body contains the supplied output`() =
+        runTest {
+            val resumeHref = "http://localhost/resume"
+            val sampleOutput = buildJsonObject { put("sampleField", "sampleValue") }
+
+            // Track the body captured at the /resume endpoint
+            var capturedResumeBody: String? = null
+
+            mockEngine = MockEngine { request ->
+                when (request.url.encodedPath) {
+                    "/.well-known/openid-configuration" ->
+                        respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                    "/authorize" ->
+                        respond(
+                            ByteReadChannel(metadataResponseJson(resumeHref = resumeHref)),
+                            HttpStatusCode.OK,
+                            authorizeResponseHeaders,
+                        )
+                    "/resume" -> {
+                        capturedResumeBody = (request.body as? io.ktor.http.content.TextContent)?.text
+                        // Return a success-like response after resume
+                        respond(
+                            ByteReadChannel(
+                                """
+                                {
+                                    "authorizeResponse": {
+                                        "code": "resume-code"
+                                    }
+                                }
+                                """.trimIndent()
+                            ),
+                            HttpStatusCode.OK,
+                            headers,
+                        )
+                    }
+                    "/token" -> respond(tokeResponse(), HttpStatusCode.OK, headers)
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+                }
+            }
+
+            val daVinci = buildDaVinci(mockEngine)
+            val startNode = daVinci.start()
+            assertIs<MetadataNode>(startNode)
+
+            startNode.resume(output = sampleOutput, error = null)
+
+            assertNotNull(capturedResumeBody, "Resume endpoint was not called")
+            val bodyJson = Json.parseToJsonElement(capturedResumeBody!!).jsonObject
+            assertEquals(
+                "sampleValue",
+                bodyJson["output"]?.jsonObject?.get("sampleField")?.jsonPrimitive?.content,
+            )
+            assertFalse(
+                bodyJson.containsKey("error"),
+                "Body must not contain 'error' key when error is null",
+            )
+        }
+
+    // -------------------------------------------------------------------------
+    // Test 5 — Resume with error
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `resume posts error object when error is supplied`() = runTest {
+        val resumeHref = "http://localhost/resumeWithError"
+        val sampleError = buildJsonObject { put("code", "ERR") }
+
+        var capturedResumeBody: String? = null
+
+        mockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/.well-known/openid-configuration" ->
+                    respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                "/authorize" ->
+                    respond(
+                        ByteReadChannel(metadataResponseJson(resumeHref = resumeHref)),
+                        HttpStatusCode.OK,
+                        authorizeResponseHeaders,
+                    )
+                "/resumeWithError" -> {
+                    capturedResumeBody = (request.body as? io.ktor.http.content.TextContent)?.text
+                    respond(
+                        ByteReadChannel(
+                            """
+                            {
+                                "authorizeResponse": {
+                                    "code": "resume-error-code"
+                                }
+                            }
+                            """.trimIndent()
+                        ),
+                        HttpStatusCode.OK,
+                        headers,
+                    )
+                }
+                "/token" -> respond(tokeResponse(), HttpStatusCode.OK, headers)
+                else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val daVinci = buildDaVinci(mockEngine)
+        val startNode = daVinci.start()
+        assertIs<MetadataNode>(startNode)
+
+        startNode.resume(output = null, error = sampleError)
+
+        assertNotNull(capturedResumeBody, "Resume endpoint was not called")
+        val bodyJson = Json.parseToJsonElement(capturedResumeBody!!).jsonObject
+        assertEquals(
+            "ERR",
+            bodyJson["error"]?.jsonObject?.get("code")?.jsonPrimitive?.content,
+        )
+        assertFalse(
+            bodyJson.containsKey("output"),
+            "Body must not contain 'output' key when output is null",
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 6 — Cancellation guard
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `CancellationException is not swallowed during resume`() = runTest {
+        val resumeHref = "http://localhost/resumeSlow"
+        // Tracks whether the resume endpoint was called after cancellation
+        var resumeCallCount = 0
+
+        mockEngine = MockEngine { request ->
+            when (request.url.encodedPath) {
+                "/.well-known/openid-configuration" ->
+                    respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                "/authorize" ->
+                    respond(
+                        ByteReadChannel(metadataResponseJson(resumeHref = resumeHref)),
+                        HttpStatusCode.OK,
+                        authorizeResponseHeaders,
+                    )
+                "/resumeSlow" -> {
+                    resumeCallCount++
+                    respond(ByteReadChannel(""), HttpStatusCode.OK)
+                }
+                else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+            }
+        }
+
+        val daVinci = buildDaVinci(mockEngine)
+        val startNode = daVinci.start()
+        assertIs<MetadataNode>(startNode)
+
+        // Launch a child coroutine and cancel it immediately before it gets to run.
+        // This verifies that the coroutine machinery (and therefore resume()) honours
+        // cancellation — a swallowed CancellationException would keep the coroutine alive.
+        val job = launch {
+            // yield() ensures the coroutine cooperates with cancellation at the first
+            // suspension point before the network call fires.
+            kotlinx.coroutines.yield()
+            startNode.resume()
+        }
+        job.cancel()
+        job.join()
+
+        assertTrue(job.isCancelled, "Job must be in cancelled state after cancel()+join()")
+        // The resume endpoint must NOT have been called — cancellation happened before it.
+        assertEquals(0, resumeCallCount, "resume endpoint must not be called after cancellation")
+    }
+
+    // -------------------------------------------------------------------------
+    // Test 7 — setOutput / setError builder pattern
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `setOutput and setError builder pattern sends correct body on resume with no args`() =
+        runTest {
+            val resumeHref = "http://localhost/resumeBuilder"
+
+            var capturedResumeBody: String? = null
+
+            mockEngine = MockEngine { request ->
+                when (request.url.encodedPath) {
+                    "/.well-known/openid-configuration" ->
+                        respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+                    "/authorize" ->
+                        respond(
+                            ByteReadChannel(metadataResponseJson(resumeHref = resumeHref)),
+                            HttpStatusCode.OK,
+                            authorizeResponseHeaders,
+                        )
+                    "/resumeBuilder" -> {
+                        capturedResumeBody =
+                            (request.body as? io.ktor.http.content.TextContent)?.text
+                        respond(
+                            ByteReadChannel(
+                                """{"authorizeResponse":{"code":"builder-code"}}"""
+                            ),
+                            HttpStatusCode.OK,
+                            headers,
+                        )
+                    }
+                    "/token" -> respond(tokeResponse(), HttpStatusCode.OK, headers)
+                    else -> respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+                }
+            }
+
+            val daVinci = buildDaVinci(mockEngine)
+            val startNode = daVinci.start()
+            assertIs<MetadataNode>(startNode)
+
+            startNode.setOutput(buildJsonObject { put("builderKey", "builderValue") })
+            startNode.resume() // no args — uses pending values
+
+            assertNotNull(capturedResumeBody)
+            val bodyJson = Json.parseToJsonElement(capturedResumeBody!!).jsonObject
+            assertEquals(
+                "builderValue",
+                bodyJson["output"]?.jsonObject?.get("builderKey")?.jsonPrimitive?.content,
+            )
+        }
+}

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataParseTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataParseTest.kt
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.module.Metadata
+import com.pingidentity.davinci.module.MetadataException
+import com.pingidentity.davinci.module.parseOrNull
+import com.pingidentity.davinci.module.parseOrThrow
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Pure-JVM unit tests for [Metadata.Companion.parseOrNull] and [Metadata.Companion.parseOrThrow].
+ *
+ * No Ktor / MockEngine needed — this exercises only the JSON parsing layer.
+ */
+class MetadataParseTest {
+
+    // -------------------------------------------------------------------------------------
+    // Shared fixtures
+    // -------------------------------------------------------------------------------------
+
+    /** A well-formed metadata JSON object as the server would send it. */
+    private val validJson = buildJsonObject {
+        put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+        put("OPERATION", "CHECK_FOR_MFA")
+        put("configs", buildJsonObject {
+            put("sdkId", "ping-mfa-sdk")
+            put("version", "2.0")
+        })
+    }
+
+    // -------------------------------------------------------------------------------------
+    // parseOrNull — happy path
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `parseOrNull returns Metadata for a valid JSON object`() {
+        val result = Metadata.parseOrNull(validJson)
+
+        assertNotNull(result)
+        assertEquals(Metadata.Type.PINGONE_MFA_SDK, result!!.type)
+        assertEquals("CHECK_FOR_MFA", result.operation)
+        assertEquals(2, result.configs.size)
+    }
+
+    @Test
+    fun `parseOrNull preserves all TYPE constant values correctly`() {
+        for (type in listOf(
+            Metadata.Type.METADATA,
+            Metadata.Type.EXTERNAL_SDK,
+            Metadata.Type.PINGONE_MFA_SDK,
+            Metadata.Type.KEYLESS_SDK,
+        )) {
+            val json = buildJsonObject {
+                put("TYPE", type)
+                put("OPERATION", "OP")
+                put("configs", buildJsonObject {})
+            }
+            val result = Metadata.parseOrNull(json)
+            assertNotNull("parseOrNull should succeed for TYPE=$type", result)
+            assertEquals(type, result!!.type)
+        }
+    }
+
+    @Test
+    fun `parseOrNull accepts empty configs object`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.EXTERNAL_SDK)
+            put("OPERATION", "INIT")
+            put("configs", buildJsonObject {})
+        }
+        val result = Metadata.parseOrNull(json)
+        assertNotNull(result)
+        assertTrue(result!!.configs.isEmpty())
+    }
+
+    // -------------------------------------------------------------------------------------
+    // parseOrNull — null when required key is missing
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `parseOrNull returns null when TYPE is missing`() {
+        val json = buildJsonObject {
+            put("OPERATION", "CHECK_FOR_MFA")
+            put("configs", buildJsonObject { put("k", "v") })
+        }
+        assertNull(Metadata.parseOrNull(json))
+    }
+
+    @Test
+    fun `parseOrNull returns null when OPERATION is missing`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+            put("configs", buildJsonObject { put("k", "v") })
+        }
+        assertNull(Metadata.parseOrNull(json))
+    }
+
+    @Test
+    fun `parseOrNull returns null when configs is missing`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+            put("OPERATION", "CHECK_FOR_MFA")
+        }
+        assertNull(Metadata.parseOrNull(json))
+    }
+
+    @Test
+    fun `parseOrNull returns null when TYPE is not a primitive`() {
+        val json = buildJsonObject {
+            put("TYPE", buildJsonObject { put("nested", "bad") })
+            put("OPERATION", "CHECK_FOR_MFA")
+            put("configs", buildJsonObject {})
+        }
+        assertNull(Metadata.parseOrNull(json))
+    }
+
+    @Test
+    fun `parseOrNull returns null when OPERATION is not a primitive`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.EXTERNAL_SDK)
+            put("OPERATION", buildJsonObject { put("nested", "bad") })
+            put("configs", buildJsonObject {})
+        }
+        assertNull(Metadata.parseOrNull(json))
+    }
+
+    @Test
+    fun `parseOrNull returns null when configs is not a JSON object`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+            put("OPERATION", "CHECK_FOR_MFA")
+            // configs is a primitive, not an object
+            put("configs", JsonPrimitive("not-an-object"))
+        }
+        assertNull(Metadata.parseOrNull(json))
+    }
+
+    // -------------------------------------------------------------------------------------
+    // parseOrThrow — happy path
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `parseOrThrow returns Metadata for a valid JSON object`() {
+        val result = Metadata.parseOrThrow(validJson)
+
+        assertEquals(Metadata.Type.PINGONE_MFA_SDK, result.type)
+        assertEquals("CHECK_FOR_MFA", result.operation)
+        assertEquals(2, result.configs.size)
+    }
+
+    // -------------------------------------------------------------------------------------
+    // parseOrThrow — Malformed thrown with key-naming message, no payload data
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `parseOrThrow throws Malformed when TYPE is missing and message names TYPE`() {
+        val json = buildJsonObject {
+            put("OPERATION", "CHECK_FOR_MFA")
+            put("configs", buildJsonObject {})
+        }
+        try {
+            Metadata.parseOrThrow(json)
+            fail("Expected MetadataException.Malformed")
+        } catch (e: MetadataException.Malformed) {
+            assertTrue(
+                "Exception message should name the key 'TYPE'",
+                e.message!!.contains("TYPE"),
+            )
+        }
+    }
+
+    @Test
+    fun `parseOrThrow throws Malformed when OPERATION is missing and message names OPERATION`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.KEYLESS_SDK)
+            put("configs", buildJsonObject {})
+        }
+        try {
+            Metadata.parseOrThrow(json)
+            fail("Expected MetadataException.Malformed")
+        } catch (e: MetadataException.Malformed) {
+            assertTrue(
+                "Exception message should name the key 'OPERATION'",
+                e.message!!.contains("OPERATION"),
+            )
+        }
+    }
+
+    @Test
+    fun `parseOrThrow throws Malformed when configs is missing and message names configs`() {
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+            put("OPERATION", "ENROLL")
+        }
+        try {
+            Metadata.parseOrThrow(json)
+            fail("Expected MetadataException.Malformed")
+        } catch (e: MetadataException.Malformed) {
+            assertTrue(
+                "Exception message should name the key 'configs'",
+                e.message!!.contains("configs"),
+            )
+        }
+    }
+
+    @Test
+    fun `parseOrThrow Malformed message does not contain any configs value`() {
+        // The configs object contains a sentinel value; the exception message must not echo it.
+        val secretMarker = "SENTINEL_SECRET_XYZ_DO_NOT_ECHO"
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+            // OPERATION is intentionally absent to trigger Malformed
+            put("configs", buildJsonObject {
+                put("sensitiveKey", secretMarker)
+            })
+        }
+        try {
+            Metadata.parseOrThrow(json)
+            fail("Expected MetadataException.Malformed")
+        } catch (e: MetadataException.Malformed) {
+            val msg = e.message ?: ""
+            assertTrue(
+                "Exception message must not contain configs values",
+                !msg.contains(secretMarker),
+            )
+        }
+    }
+
+    @Test
+    fun `parseOrThrow Malformed message does not contain TYPE value`() {
+        // Even the TYPE value itself (which could be arbitrary) must not be echoed in malformed
+        // messages for missing keys.
+        val json = buildJsonObject {
+            put("TYPE", Metadata.Type.PINGONE_MFA_SDK)
+            // configs is a primitive — wrong type — triggers Malformed for wrong type
+            put("OPERATION", "OP")
+            put("configs", JsonPrimitive("SHOULD_NOT_APPEAR_IN_EXCEPTION"))
+        }
+        try {
+            Metadata.parseOrThrow(json)
+            fail("Expected MetadataException.Malformed")
+        } catch (e: MetadataException.Malformed) {
+            val msg = e.message ?: ""
+            assertTrue(
+                "Exception message must not contain the wrong-type value",
+                !msg.contains("SHOULD_NOT_APPEAR_IN_EXCEPTION"),
+            )
+        }
+    }
+
+    // -------------------------------------------------------------------------------------
+    // MetadataException subclass identity
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    fun `MissingResumeLink has the expected fixed message`() {
+        val ex = MetadataException.MissingResumeLink()
+        assertEquals("Metadata node has no _links.next.href", ex.message)
+    }
+
+    @Test
+    fun `UnsupportedType exposes rawType and formats message`() {
+        val raw = "UNKNOWN_FUTURE_TYPE"
+        val ex = MetadataException.UnsupportedType(raw)
+        assertEquals(raw, ex.rawType)
+        assertTrue(ex.message!!.contains(raw))
+    }
+
+    @Test
+    fun `MetadataException subclasses are distinct types`() {
+        val exceptions: List<MetadataException> = listOf(
+            MetadataException.Malformed("bad key"),
+            MetadataException.MissingResumeLink(),
+            MetadataException.UnsupportedType("FOO"),
+        )
+
+        assertTrue(exceptions[0] is MetadataException.Malformed)
+        assertTrue(exceptions[1] is MetadataException.MissingResumeLink)
+        assertTrue(exceptions[2] is MetadataException.UnsupportedType)
+
+        // Cross-type checks: each instance must not match the other two subtypes.
+        for (i in exceptions.indices) {
+            for (j in exceptions.indices) {
+                if (i == j) continue
+                assertFalse(
+                    "exceptions[$i] should not be the same type as exceptions[$j]",
+                    exceptions[i]::class == exceptions[j]::class,
+                )
+            }
+        }
+    }
+}

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataParseTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataParseTest.kt
@@ -273,11 +273,11 @@ class MetadataParseTest {
     }
 
     @Test
-    fun `UnsupportedType exposes rawType and formats message`() {
+    fun `UnsupportedType exposes rawType and message does not echo it`() {
         val raw = "UNKNOWN_FUTURE_TYPE"
         val ex = MetadataException.UnsupportedType(raw)
         assertEquals(raw, ex.rawType)
-        assertTrue(ex.message!!.contains(raw))
+        assertFalse("message must not contain the server-supplied rawType value", ex.message!!.contains(raw))
     }
 
     @Test

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinci.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinci.kt
@@ -52,12 +52,15 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.pingidentity.davinci.module.MetadataNode
 import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.orchestrate.ErrorNode
 import com.pingidentity.orchestrate.FailureNode
 import com.pingidentity.orchestrate.SuccessNode
 import com.pingidentity.samples.pingsampleapp.R
 import com.pingidentity.samples.pingsampleapp.davinci.collector.DaVinciContinueNode
+import com.pingidentity.samples.pingsampleapp.davinci.collector.MetadataNodeScreen
+import kotlinx.serialization.json.JsonElement
 
 @Composable
 fun DaVinci(
@@ -91,6 +94,9 @@ fun DaVinci(
         onStart = {
             daVinciViewModel.start()
         },
+        onResume = { node, output ->
+            daVinciViewModel.resume(node, output)
+        },
         currentOnSuccess,
         onLogoClick,
         onBack,
@@ -105,6 +111,7 @@ fun DaVinci(
     onNodeUpdated: () -> Unit,
     onNext: (ContinueNode) -> Unit,
     onStart: () -> Unit,
+    onResume: (MetadataNode, JsonElement) -> Unit,
     onSuccess: (() -> Unit)?,
     onLogoClick: (() -> Unit)? = null,
     onBack: (() -> Unit)? = null,
@@ -149,6 +156,13 @@ fun DaVinci(
                 Logo(modifier = Modifier, onLogoClick)
 
                 when (val node = state.node) {
+                    // NOTE: A DaVinci policy with an SDK Integrator connector is required to reach this branch.
+                    is MetadataNode -> {
+                        key(node) {
+                            MetadataNodeScreen(node = node, onResume = onResume)
+                        }
+                    }
+
                     is ContinueNode -> {
                         key(node) {
                             Render(node = node, onNodeUpdated, onStart) {

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinciViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinciViewModel.kt
@@ -78,12 +78,15 @@ class DaVinciViewModel(
             true
         }
         viewModelScope.launch {
-            val next = node.resume(output = output)
-            state.update {
-                it.copy(node = next, counter = it.counter + 1)
-            }
-            loading.update {
-                false
+            try {
+                val next = node.resume(output = output)
+                state.update {
+                    it.copy(node = next, counter = it.counter + 1)
+                }
+            } finally {
+                loading.update {
+                    false
+                }
             }
         }
     }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinciViewModel.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/DaVinciViewModel.kt
@@ -10,12 +10,14 @@ import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.pingidentity.davinci.module.MetadataNode
 import com.pingidentity.oidc.module.VERIFICATION_URI_COMPLETE
 import com.pingidentity.orchestrate.ContinueNode
 import com.pingidentity.samples.pingsampleapp.config.daVinci
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonElement
 
 class DaVinciViewModel(
     private val verificationUri: String? = null,
@@ -62,6 +64,21 @@ class DaVinciViewModel(
                 }
             } else { daVinci?.start() }
 
+            state.update {
+                it.copy(node = next, counter = it.counter + 1)
+            }
+            loading.update {
+                false
+            }
+        }
+    }
+
+    fun resume(node: MetadataNode, output: JsonElement) {
+        loading.update {
+            true
+        }
+        viewModelScope.launch {
+            val next = node.resume(output = output)
             state.update {
                 it.copy(node = next, counter = it.counter + 1)
             }

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/MetadataNodeScreen.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/MetadataNodeScreen.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.module.MetadataNode
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * Renders a [MetadataNode] in the DaVinci sample app.
+ *
+ * Displays the metadata type, operation, and a truncated preview of the configs payload.
+ * Provides a "Resume with sample output" button that posts a sample JSON output back to
+ * the DaVinci flow via [onResume].
+ *
+ * NOTE: This screen requires a DaVinci policy containing an SDK Integrator connector to
+ * exercise this path at runtime.
+ *
+ * @param node     The [MetadataNode] to display.
+ * @param onResume Called with the node and a sample output [JsonElement] when the user taps
+ *                 the resume button.
+ */
+@Composable
+fun MetadataNodeScreen(
+    node: MetadataNode,
+    onResume: (MetadataNode, JsonElement) -> Unit,
+) {
+    val configsPreview = node.metadata.configs.toString().let { raw ->
+        if (raw.length > 100) raw.take(100) + "…" else raw
+    }
+
+    Card(
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp),
+        shape = MaterialTheme.shapes.medium,
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = "SDK Connector Metadata",
+                fontWeight = FontWeight.Bold,
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "Type:",
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.width(80.dp),
+                )
+                Text(text = node.metadata.type)
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "Operation:",
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.width(80.dp),
+                )
+                Text(text = node.metadata.operation)
+            }
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            Text(
+                text = "Configs:",
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = configsPreview,
+                style = MaterialTheme.typography.bodySmall,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                modifier = Modifier.align(Alignment.End),
+                onClick = {
+                    val sampleOutput = buildJsonObject {
+                        put("sampleField", "sampleValue")
+                    }
+                    onResume(node, sampleOutput)
+                },
+            ) {
+                Text("Resume with sample output")
+            }
+        }
+    }
+}


### PR DESCRIPTION
# JIRA Ticket
(SDKS-5168)[https://pingidentity.atlassian.net/browse/SDKS-5168]

# Description

This PR introduces classes, which consumes the DaVinci response carrying a metadata payload, support the pause/resume behaviour for app-driven SDK execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for metadata-based pause/resume flows in the DaVinci experience.
  * Introduced a screen that shows metadata details and lets users resume with sample output.
  * Updated the sample app to handle resuming these flows from the UI.

* **Bug Fixes**
  * Improved handling for malformed or incomplete metadata responses.
  * Added clearer error states when resume information is missing or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->