### PR TITLE
SDKS-5168 Add MetadataCollector and associated UI components

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/CollectorRegistry.kt
@@ -20,6 +20,7 @@ import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.ImageCollector
+import com.pingidentity.davinci.collector.MetadataCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -65,5 +66,6 @@ internal class CollectorRegistry : ModuleInitializer() {
         CollectorFactory.register("POLLING", ::PollingCollector)
         CollectorFactory.register("QR_CODE", ::QRCodeCollector)
         CollectorFactory.register("IMAGE", ::ImageCollector)
+        CollectorFactory.register("METADATA", ::MetadataCollector)
     }
 }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Collectors.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Collectors.kt
@@ -59,13 +59,22 @@ internal fun Collectors.asJson(): JsonObject {
     return buildJsonObject {
         val map = mutableMapOf<String, Any>()
         forEach {
-            if (it is SubmitCollector || it is FlowCollector) {
-                it.payload()?.let { _ ->
-                    put("actionKey", it.id())
+            when {
+                it is MetadataCollector -> {
+                    it.payload()?.let { payload ->
+                        put("actionKey", it.id())
+                        map[it.id()] = payload
+                    }
                 }
-            } else {
-                it.payload()?.let { payload ->
-                    map[it.id()] = payload
+                it is SubmitCollector || it is FlowCollector -> {
+                    it.payload()?.let { _ ->
+                        put("actionKey", it.id())
+                    }
+                }
+                else -> {
+                    it.payload()?.let { payload ->
+                        map[it.id()] = payload
+                    }
                 }
             }
         }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
@@ -6,24 +6,26 @@
 
 package com.pingidentity.davinci.collector
 
+import com.pingidentity.davinci.plugin.Submittable
+import com.pingidentity.orchestrate.Closeable
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.put
 
 /**
  * Collector for a DaVinci form field of type METADATA.
  *
  * When a DaVinci flow reaches an SDK Integrator connector node, the server pauses
  * and returns a form field of type METADATA carrying an arbitrary JSON payload.
- * The integrating app reads [metadata], performs on-device work, then sets either
- * [output] (success path) or [errorPayload] (failure path) before calling [com.pingidentity.orchestrate.ContinueNode.next].
+ * The integrating app reads [metadata], performs on-device work, then calls either
+ * [setResult] (success path) or [setError] (failure path) before calling
+ * [com.pingidentity.orchestrate.ContinueNode.next].
  *
- * **Precedence**: [errorPayload] takes priority over [output]. When [errorPayload] is non-null it is
- * wrapped as `{ "error": { ... } }` in the resume body regardless of whether [output]
- * is also set. If neither is set, [payload] returns `null` and the field is omitted from
- * the form data.
+ * The collector is considered ready to submit once either [setResult] or [setError]
+ * has been called — [validate] returns a [Required] error until then.
  */
-class MetadataCollector : FieldCollector<JsonObject>() {
+class MetadataCollector : FieldCollector<JsonObject>(), Submittable, Closeable {
 
     /**
      * The metadata payload sent by the server — arbitrary JSON the SDK must process.
@@ -31,24 +33,7 @@ class MetadataCollector : FieldCollector<JsonObject>() {
     var metadata: JsonObject = JsonObject(emptyMap())
         private set
 
-    /**
-     * The result to send back to the server on the success path.
-     *
-     * Set this to the JSON object the DaVinci flow expects, then call [com.pingidentity.orchestrate.ContinueNode.next].
-     * Not populated by the SDK — the integrating app is responsible for setting it.
-     * Ignored when [errorPayload] is also set ([errorPayload] takes precedence).
-     */
-    var output: JsonObject? = null
-
-    /**
-     * The error to send back to the server on the failure path.
-     *
-     * When set, [output] is ignored and the resume body wraps this value as
-     * `{ "error": { ... } }` under `formData.<key>`. Set this before calling
-     * [com.pingidentity.orchestrate.ContinueNode.next]. Not populated by the SDK — the integrating app is
-     * responsible for setting it.
-     */
-    var errorPayload: JsonObject? = null
+    private var result: JsonObject? = null
 
     override fun init(input: JsonObject): MetadataCollector {
         super.init(input)
@@ -57,12 +42,44 @@ class MetadataCollector : FieldCollector<JsonObject>() {
     }
 
     /**
-     * Returns the resume payload for the SDK Integrator connector.
+     * Sets the result to POST back to DaVinci on the success path.
      *
-     * [errorPayload] takes priority: when set, returns `{ "error": { ... } }`.
-     * Falls back to [output] when [errorPayload] is null.
-     * Returns `null` when neither is set.
+     * @param result The JSON object representing the SDK's outcome.
      */
-    override fun payload(): JsonObject? =
-        errorPayload?.let { buildJsonObject { put("error", it) } } ?: output
+    fun setResult(result: JsonObject) {
+        this.result = result
+    }
+
+    /**
+     * Signals the connector's client-error branch.
+     *
+     * The resume body will contain `{ "error": { "code": ..., "message": ..., ["isClientError": ...] } }`.
+     *
+     * @param errorCode A short error code string (e.g. `"USER_CANCELLED"`).
+     * @param message A human-readable description of the error.
+     * @param isClientError When provided, included in the error envelope.
+     */
+    fun setError(errorCode: String, message: String, isClientError: Boolean? = null) {
+        result = buildJsonObject {
+            put("error", buildJsonObject {
+                put("code", errorCode)
+                put("message", message)
+                isClientError?.let { put("isClientError", it) }
+            })
+        }
+    }
+
+    /** Returns the resume payload, or `null` if neither [setResult] nor [setError] has been called. */
+    override fun payload(): JsonObject? = result
+
+    /** Always `"action"` — required by the SDK Integrator connector resume contract. */
+    override fun eventType(): String = "action"
+
+    /** Returns [Required] until [setResult] or [setError] has been called, regardless of the field's `required` flag. */
+    override fun validate(): List<ValidationError> = if (result == null) listOf(Required) else emptyList()
+
+    /** Clears the result, returning the collector to its initial unset state. */
+    override fun close() {
+        result = null
+    }
 }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
@@ -53,18 +53,16 @@ class MetadataCollector : FieldCollector<JsonObject>(), Submittable, Closeable {
     /**
      * Signals the connector's client-error branch.
      *
-     * The resume body will contain `{ "error": { "code": ..., "message": ..., ["isClientError": ...] } }`.
+     * The resume body will contain `{ "error": { "code": ..., "message": ... } }`.
      *
      * @param errorCode A short error code string (e.g. `"USER_CANCELLED"`).
      * @param message A human-readable description of the error.
-     * @param isClientError When provided, included in the error envelope.
      */
-    fun setError(errorCode: String, message: String, isClientError: Boolean? = null) {
+    fun setError(errorCode: String, message: String) {
         result = buildJsonObject {
             put("error", buildJsonObject {
                 put("code", errorCode)
                 put("message", message)
-                isClientError?.let { put("isClientError", it) }
             })
         }
     }

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import com.pingidentity.davinci.plugin.Collector
+import com.pingidentity.orchestrate.ContinueNode
+import com.pingidentity.orchestrate.ContinueNodeAware
+import com.pingidentity.orchestrate.FlowContext
+import com.pingidentity.orchestrate.RequestInterceptor
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import com.pingidentity.network.HttpRequest as Request
+
+/**
+ * Collector for a DaVinci form field of type METADATA.
+ *
+ * When a DaVinci flow reaches an SDK Integrator connector node, the server pauses
+ * and returns a form field of type METADATA carrying an arbitrary JSON payload.
+ * The integrating app reads [metadata], performs on-device work, then sets either
+ * [output] (success path) or [error] (failure path) before calling [ContinueNode.next].
+ *
+ * **Precedence**: [error] takes priority over [output]. When [error] is non-null it is
+ * wrapped as `{ "error": { ... } }` in the resume body regardless of whether [output]
+ * is also set. If neither is set, `formData.<key>` is sent as an empty object `{}`.
+ *
+ * On [ContinueNode.next] the [intercept] override replaces the standard form-POST
+ * body with the resume contract expected by the SDK Integrator connector:
+ * ```
+ * {
+ *   "id": "<nodeId>",
+ *   "eventName": "continue",
+ *   "parameters": {
+ *     "eventType": "action",
+ *     "data": {
+ *       "actionKey": "sdkMetadata",
+ *       "formData": {
+ *         "sdkMetadata": { ... }   // output, or { "error": { ... } } when error is set
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ */
+class MetadataCollector : Collector<Nothing>, ContinueNodeAware, RequestInterceptor {
+
+    override lateinit var continueNode: ContinueNode
+
+    /**
+     * The key of this field (typically "sdkMetadata").
+     */
+    var key = ""
+        private set
+
+    /**
+     * The raw type string (always "METADATA").
+     */
+    var type = ""
+        private set
+
+    /**
+     * The metadata payload sent by the server — arbitrary JSON the SDK must process.
+     */
+    var metadata: JsonObject = JsonObject(emptyMap())
+        private set
+
+    /**
+     * The result to send back to the server on the success path.
+     *
+     * Set this to the JSON object the DaVinci flow expects, then call [ContinueNode.next].
+     * Not populated by the SDK — the integrating app is responsible for setting it.
+     * Ignored when [error] is also set ([error] takes precedence).
+     */
+    var output: JsonObject? = null
+
+    /**
+     * The error to send back to the server on the failure path.
+     *
+     * When set, [output] is ignored and the resume body wraps this value as
+     * `{ "error": { ... } }` under `formData.<key>`. Set this before calling
+     * [ContinueNode.next]. Not populated by the SDK — the integrating app is
+     * responsible for setting it.
+     */
+    var error: JsonObject? = null
+
+    override fun init(input: JsonObject): MetadataCollector {
+        key = input["key"]?.jsonPrimitive?.contentOrNull ?: ""
+        type = input["type"]?.jsonPrimitive?.contentOrNull ?: ""
+        metadata = input["payload"]?.jsonObject ?: JsonObject(emptyMap())
+        return this
+    }
+
+    override fun id(): String = key
+
+    override fun payload(): Nothing? = null
+
+    /**
+     * Replaces the standard form-POST body with the SDK Integrator resume contract.
+     */
+    override var intercept: FlowContext.(Request) -> Request = { request ->
+        val id = continueNode.input["id"]?.jsonPrimitive?.contentOrNull ?: ""
+        val sdkMetadata = error?.let { buildJsonObject { put("error", it) } } ?: output ?: JsonObject(emptyMap())
+        val body = buildJsonObject {
+            put("id", id)
+            put("eventName", "continue")
+            put("parameters", buildJsonObject {
+                put("eventType", "action")
+                put("data", buildJsonObject {
+                    put("actionKey", key)
+                    put("formData", buildJsonObject {
+                        put(key, sdkMetadata)
+                    })
+                })
+            })
+        }
+        request.post(body)
+        request
+    }
+}

--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/MetadataCollector.kt
@@ -6,18 +6,9 @@
 
 package com.pingidentity.davinci.collector
 
-import com.pingidentity.davinci.plugin.Collector
-import com.pingidentity.orchestrate.ContinueNode
-import com.pingidentity.orchestrate.ContinueNodeAware
-import com.pingidentity.orchestrate.FlowContext
-import com.pingidentity.orchestrate.RequestInterceptor
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
-import com.pingidentity.network.HttpRequest as Request
 
 /**
  * Collector for a DaVinci form field of type METADATA.
@@ -25,45 +16,14 @@ import com.pingidentity.network.HttpRequest as Request
  * When a DaVinci flow reaches an SDK Integrator connector node, the server pauses
  * and returns a form field of type METADATA carrying an arbitrary JSON payload.
  * The integrating app reads [metadata], performs on-device work, then sets either
- * [output] (success path) or [error] (failure path) before calling [ContinueNode.next].
+ * [output] (success path) or [errorPayload] (failure path) before calling [com.pingidentity.orchestrate.ContinueNode.next].
  *
- * **Precedence**: [error] takes priority over [output]. When [error] is non-null it is
+ * **Precedence**: [errorPayload] takes priority over [output]. When [errorPayload] is non-null it is
  * wrapped as `{ "error": { ... } }` in the resume body regardless of whether [output]
- * is also set. If neither is set, `formData.<key>` is sent as an empty object `{}`.
- *
- * On [ContinueNode.next] the [intercept] override replaces the standard form-POST
- * body with the resume contract expected by the SDK Integrator connector:
- * ```
- * {
- *   "id": "<nodeId>",
- *   "eventName": "continue",
- *   "parameters": {
- *     "eventType": "action",
- *     "data": {
- *       "actionKey": "sdkMetadata",
- *       "formData": {
- *         "sdkMetadata": { ... }   // output, or { "error": { ... } } when error is set
- *       }
- *     }
- *   }
- * }
- * ```
+ * is also set. If neither is set, [payload] returns `null` and the field is omitted from
+ * the form data.
  */
-class MetadataCollector : Collector<Nothing>, ContinueNodeAware, RequestInterceptor {
-
-    override lateinit var continueNode: ContinueNode
-
-    /**
-     * The key of this field (typically "sdkMetadata").
-     */
-    var key = ""
-        private set
-
-    /**
-     * The raw type string (always "METADATA").
-     */
-    var type = ""
-        private set
+class MetadataCollector : FieldCollector<JsonObject>() {
 
     /**
      * The metadata payload sent by the server — arbitrary JSON the SDK must process.
@@ -74,9 +34,9 @@ class MetadataCollector : Collector<Nothing>, ContinueNodeAware, RequestIntercep
     /**
      * The result to send back to the server on the success path.
      *
-     * Set this to the JSON object the DaVinci flow expects, then call [ContinueNode.next].
+     * Set this to the JSON object the DaVinci flow expects, then call [com.pingidentity.orchestrate.ContinueNode.next].
      * Not populated by the SDK — the integrating app is responsible for setting it.
-     * Ignored when [error] is also set ([error] takes precedence).
+     * Ignored when [errorPayload] is also set ([errorPayload] takes precedence).
      */
     var output: JsonObject? = null
 
@@ -85,42 +45,24 @@ class MetadataCollector : Collector<Nothing>, ContinueNodeAware, RequestIntercep
      *
      * When set, [output] is ignored and the resume body wraps this value as
      * `{ "error": { ... } }` under `formData.<key>`. Set this before calling
-     * [ContinueNode.next]. Not populated by the SDK — the integrating app is
+     * [com.pingidentity.orchestrate.ContinueNode.next]. Not populated by the SDK — the integrating app is
      * responsible for setting it.
      */
-    var error: JsonObject? = null
+    var errorPayload: JsonObject? = null
 
     override fun init(input: JsonObject): MetadataCollector {
-        key = input["key"]?.jsonPrimitive?.contentOrNull ?: ""
-        type = input["type"]?.jsonPrimitive?.contentOrNull ?: ""
+        super.init(input)
         metadata = input["payload"]?.jsonObject ?: JsonObject(emptyMap())
         return this
     }
 
-    override fun id(): String = key
-
-    override fun payload(): Nothing? = null
-
     /**
-     * Replaces the standard form-POST body with the SDK Integrator resume contract.
+     * Returns the resume payload for the SDK Integrator connector.
+     *
+     * [errorPayload] takes priority: when set, returns `{ "error": { ... } }`.
+     * Falls back to [output] when [errorPayload] is null.
+     * Returns `null` when neither is set.
      */
-    override var intercept: FlowContext.(Request) -> Request = { request ->
-        val id = continueNode.input["id"]?.jsonPrimitive?.contentOrNull ?: ""
-        val sdkMetadata = error?.let { buildJsonObject { put("error", it) } } ?: output ?: JsonObject(emptyMap())
-        val body = buildJsonObject {
-            put("id", id)
-            put("eventName", "continue")
-            put("parameters", buildJsonObject {
-                put("eventType", "action")
-                put("data", buildJsonObject {
-                    put("actionKey", key)
-                    put("formData", buildJsonObject {
-                        put(key, sdkMetadata)
-                    })
-                })
-            })
-        }
-        request.post(body)
-        request
-    }
+    override fun payload(): JsonObject? =
+        errorPayload?.let { buildJsonObject { put("error", it) } } ?: output
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.Response.kt
@@ -224,3 +224,38 @@ fun tokeErrorResponse() =
                 "  \"error\" : \"Invalid Grant\"\n" +
                 "}",
     )
+
+fun metadataNodeResponse() =
+    ByteReadChannel(
+        """
+        {
+            "_links": {
+                "next": {
+                    "href": "http://auth.test-one-pingone.com/sdkIntegrator"
+                }
+            },
+            "interactionId": "008bccea-914b-49da-b2a1-5cd3f83f4372",
+            "interactionToken": "dummy-interaction-token",
+            "eventName": "continue",
+            "isResponseCompatibleWithMobileAndWebSdks": true,
+            "id": "4r92vx2x9u",
+            "form": {
+                "name": "SDK Integrator Form",
+                "description": "",
+                "category": "CUSTOM_HTML",
+                "components": {
+                    "fields": [
+                        {
+                            "type": "METADATA",
+                            "key": "sdkMetadata",
+                            "payload": {
+                                "sdk": "PROTECT",
+                                "action": "INITIALIZE"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        """
+    )

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/DaVinciTest.kt
@@ -10,6 +10,7 @@ package com.pingidentity.davinci
 import android.net.Uri
 import com.pingidentity.davinci.collector.FlowCollector
 import com.pingidentity.davinci.collector.LabelCollector
+import com.pingidentity.davinci.collector.MetadataCollector
 import com.pingidentity.davinci.collector.MultiSelectCollector
 import com.pingidentity.davinci.collector.PasswordCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
@@ -945,5 +946,95 @@ class DaVinciTest {
         assertNotSame(firstNode, rewindNode)
         assertEquals(firstNode.id, rewindNode.id)
         assertEquals(firstNode.name, rewindNode.name)
+    }
+
+    // -------------------------------------------------------------------------
+    // MetadataCollector — resume envelope (actionKey + eventType)
+    // -------------------------------------------------------------------------
+
+    private fun metadataEngine(successResponse: () -> ByteReadChannel) = MockEngine { request ->
+        when (request.url.encodedPath) {
+            "/.well-known/openid-configuration" ->
+                respond(openIdConfigurationResponse(), HttpStatusCode.OK, headers)
+            "/authorize" ->
+                respond(metadataNodeResponse(), HttpStatusCode.OK, authorizeResponseHeaders)
+            "/sdkIntegrator" ->
+                respond(successResponse(), HttpStatusCode.OK, customHTMLTemplateHeaders)
+            else ->
+                respond(ByteReadChannel(""), HttpStatusCode.InternalServerError)
+        }
+    }
+
+    private fun buildMetadataDaVinci(engine: MockEngine) = DaVinci {
+        httpClient = KtorHttpClient(HttpClient(engine))
+        module(Oidc) {
+            clientId = "test"
+            discoveryEndpoint = "http://localhost/.well-known/openid-configuration"
+            scopes = mutableSetOf("openid", "email", "address")
+            redirectUri = "http://localhost:8080"
+            storage = { MemoryStorage() }
+        }
+        module(Cookie) {
+            storage = { MemoryStorage() }
+            persist = mutableListOf("ST")
+        }
+    }
+
+    @Test
+    fun `MetadataCollector setResult sends correct actionKey eventType and formData`() = runTest {
+        val engine = metadataEngine { customHTMLTemplate() }
+        val daVinci = buildMetadataDaVinci(engine)
+
+        val node = daVinci.start()
+        assertTrue(node is ContinueNode)
+
+        val collector = node.collectors.filterIsInstance<MetadataCollector>().first()
+        assertEquals("sdkMetadata", collector.key)
+        assertEquals("PROTECT", collector.metadata["sdk"]?.jsonPrimitive?.content)
+
+        collector.setResult(buildJsonObject { put("score", 98) })
+        node.next()
+
+        val resumeRequest = engine.requestHistory.last { it.url.encodedPath == "/sdkIntegrator" }
+        val body = Json.parseToJsonElement((resumeRequest.body as TextContent).text).jsonObject
+        val parameters = body["parameters"]?.jsonObject
+        val data = parameters?.get("data")?.jsonObject
+
+        assertEquals("continue", body["eventName"]?.jsonPrimitive?.content)
+        assertEquals("4r92vx2x9u", body["id"]?.jsonPrimitive?.content)
+        assertEquals("action", parameters?.get("eventType")?.jsonPrimitive?.content)
+        assertEquals("sdkMetadata", data?.get("actionKey")?.jsonPrimitive?.content)
+        val sdkMetadata = data?.get("formData")?.jsonObject?.get("sdkMetadata")?.jsonObject
+        assertEquals(98, sdkMetadata?.get("score")?.jsonPrimitive?.content?.toInt())
+
+        engine.close()
+    }
+
+    @Test
+    fun `MetadataCollector setError sends error envelope with correct actionKey and eventType`() = runTest {
+        val engine = metadataEngine { customHTMLTemplate() }
+        val daVinci = buildMetadataDaVinci(engine)
+
+        val node = daVinci.start()
+        assertTrue(node is ContinueNode)
+
+        val collector = node.collectors.filterIsInstance<MetadataCollector>().first()
+        collector.setError(errorCode = "USER_CANCELLED", message = "User cancelled")
+        node.next()
+
+        val resumeRequest = engine.requestHistory.last { it.url.encodedPath == "/sdkIntegrator" }
+        val body = Json.parseToJsonElement((resumeRequest.body as TextContent).text).jsonObject
+        val parameters = body["parameters"]?.jsonObject
+        val data = parameters?.get("data")?.jsonObject
+
+        assertEquals("action", parameters?.get("eventType")?.jsonPrimitive?.content)
+        assertEquals("sdkMetadata", data?.get("actionKey")?.jsonPrimitive?.content)
+        val sdkMetadata = data?.get("formData")?.jsonObject?.get("sdkMetadata")?.jsonObject
+        val error = sdkMetadata?.get("error")?.jsonObject
+        assertNotNull(error)
+        assertEquals("USER_CANCELLED", error["code"]?.jsonPrimitive?.content)
+        assertEquals("User cancelled", error["message"]?.jsonPrimitive?.content)
+
+        engine.close()
     }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci
+
+import com.pingidentity.davinci.collector.MetadataCollector
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class MetadataCollectorTest {
+
+    private fun buildFullMetadataJson(): JsonObject = buildJsonObject {
+        put("type", "METADATA")
+        put("key", "sdkMetadata")
+        put("payload", buildJsonObject {
+            put("testkey", "testValue")
+        })
+    }
+
+    @Test
+    fun initializesKeyFromJson() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertEquals("sdkMetadata", collector.key)
+    }
+
+    @Test
+    fun initializesTypeFromJson() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertEquals("METADATA", collector.type)
+    }
+
+    @Test
+    fun initializesMetadataFromPayloadField() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertEquals("testValue", collector.metadata["testkey"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun idReturnsKey() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertEquals("sdkMetadata", collector.id())
+    }
+
+    @Test
+    fun payloadReturnsNull() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertNull(collector.payload())
+    }
+
+    @Test
+    fun outputIsNullByDefault() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertNull(collector.output)
+    }
+
+    @Test
+    fun errorIsNullByDefault() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertNull(collector.error)
+    }
+
+    @Test
+    fun initReturnsCollectorInstanceForMethodChaining() {
+        val collector = MetadataCollector()
+        val result = collector.init(buildFullMetadataJson())
+        assertEquals(collector, result)
+    }
+
+    @Test
+    fun initializesWithDefaultsWhenJsonIsEmpty() {
+        val collector = MetadataCollector().apply { init(JsonObject(emptyMap())) }
+        assertEquals("", collector.key)
+        assertEquals("", collector.type)
+        assertTrue(collector.metadata.isEmpty())
+    }
+
+    @Test
+    fun idReturnsEmptyStringWhenKeyAbsent() {
+        val collector = MetadataCollector().apply { init(JsonObject(emptyMap())) }
+        assertEquals("", collector.id())
+    }
+
+    @Test
+    fun metadataIsEmptyWhenPayloadAbsent() {
+        val input = buildJsonObject {
+            put("type", "METADATA")
+            put("key", "sdkMetadata")
+        }
+        val collector = MetadataCollector().apply { init(input) }
+        assertTrue(collector.metadata.isEmpty())
+    }
+
+    @Test
+    fun outputCanBeSet() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        val output = buildJsonObject {
+            put("verification", "successful")
+            put("status", true)
+        }
+        collector.output = output
+        assertEquals(output, collector.output)
+        assertNull(collector.error)
+    }
+
+    @Test
+    fun errorCanBeSet() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        val error = buildJsonObject {
+            put("code", "SOME_ERROR_CODE")
+            put("message", "User cancelled the operation")
+        }
+        collector.error = error
+        assertEquals(error, collector.error)
+    }
+
+    @Test
+    fun outputAndErrorCanBeSetIndependently() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        val output = buildJsonObject { put("status", "success") }
+        val error = buildJsonObject {
+            put("code", "SOME_ERROR_CODE")
+            put("message", "User cancelled the operation")
+        }
+
+        collector.output = output
+        collector.error = error
+
+        assertEquals(output, collector.output)
+        assertEquals(error, collector.error)
+    }
+}

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
@@ -9,6 +9,7 @@ package com.pingidentity.davinci
 import com.pingidentity.davinci.collector.MetadataCollector
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
@@ -51,9 +52,36 @@ class MetadataCollectorTest {
     }
 
     @Test
-    fun payloadReturnsNull() {
+    fun payloadReturnsNullWhenNeitherOutputNorErrorIsSet() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
         assertNull(collector.payload())
+    }
+
+    @Test
+    fun payloadReturnsOutputWhenOnlyOutputIsSet() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        val expected = buildJsonObject { put("status", "success") }
+        collector.output = expected
+        assertEquals(expected, collector.payload())
+    }
+
+    @Test
+    fun payloadWrapsErrorPayloadWhenOnlyErrorIsSet() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        val err = buildJsonObject { put("code", "ERR") }
+        collector.errorPayload = err
+        val result = collector.payload()!!
+        assertEquals(err, result["error"]?.jsonObject)
+    }
+
+    @Test
+    fun payloadPrefersErrorPayloadOverOutput() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        collector.output = buildJsonObject { put("status", "success") }
+        val err = buildJsonObject { put("code", "ERR") }
+        collector.errorPayload = err
+        val result = collector.payload()!!
+        assertEquals(err, result["error"]?.jsonObject)
     }
 
     @Test
@@ -63,9 +91,9 @@ class MetadataCollectorTest {
     }
 
     @Test
-    fun errorIsNullByDefault() {
+    fun errorPayloadIsNullByDefault() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        assertNull(collector.error)
+        assertNull(collector.errorPayload)
     }
 
     @Test
@@ -108,33 +136,33 @@ class MetadataCollectorTest {
         }
         collector.output = output
         assertEquals(output, collector.output)
-        assertNull(collector.error)
+        assertNull(collector.errorPayload)
     }
 
     @Test
-    fun errorCanBeSet() {
+    fun errorPayloadCanBeSet() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        val error = buildJsonObject {
+        val err = buildJsonObject {
             put("code", "SOME_ERROR_CODE")
             put("message", "User cancelled the operation")
         }
-        collector.error = error
-        assertEquals(error, collector.error)
+        collector.errorPayload = err
+        assertEquals(err, collector.errorPayload)
     }
 
     @Test
-    fun outputAndErrorCanBeSetIndependently() {
+    fun outputAndErrorPayloadCanBeSetIndependently() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
         val output = buildJsonObject { put("status", "success") }
-        val error = buildJsonObject {
+        val err = buildJsonObject {
             put("code", "SOME_ERROR_CODE")
             put("message", "User cancelled the operation")
         }
 
         collector.output = output
-        collector.error = error
+        collector.errorPayload = err
 
         assertEquals(output, collector.output)
-        assertEquals(error, collector.error)
+        assertEquals(err, collector.errorPayload)
     }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
@@ -7,13 +7,18 @@
 package com.pingidentity.davinci
 
 import com.pingidentity.davinci.collector.MetadataCollector
+import com.pingidentity.davinci.collector.asJson
+import com.pingidentity.davinci.collector.eventType
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -23,98 +28,34 @@ class MetadataCollectorTest {
         put("type", "METADATA")
         put("key", "sdkMetadata")
         put("payload", buildJsonObject {
-            put("testkey", "testValue")
+            put("sdk", "PROTECT")
+            put("action", "INITIALIZE")
         })
     }
 
+    // --- init ---
+
     @Test
-    fun initializesKeyFromJson() {
+    fun initializesKeyTypeAndMetadata() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
         assertEquals("sdkMetadata", collector.key)
-    }
-
-    @Test
-    fun initializesTypeFromJson() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
         assertEquals("METADATA", collector.type)
+        assertEquals("PROTECT", collector.metadata["sdk"]?.jsonPrimitive?.content)
+        assertEquals("INITIALIZE", collector.metadata["action"]?.jsonPrimitive?.content)
     }
 
     @Test
-    fun initializesMetadataFromPayloadField() {
+    fun idEqualsKey() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        assertEquals("testValue", collector.metadata["testkey"]?.jsonPrimitive?.content)
+        assertEquals(collector.key, collector.id())
     }
 
     @Test
-    fun idReturnsKey() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        assertEquals("sdkMetadata", collector.id())
-    }
-
-    @Test
-    fun payloadReturnsNullWhenNeitherOutputNorErrorIsSet() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        assertNull(collector.payload())
-    }
-
-    @Test
-    fun payloadReturnsOutputWhenOnlyOutputIsSet() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        val expected = buildJsonObject { put("status", "success") }
-        collector.output = expected
-        assertEquals(expected, collector.payload())
-    }
-
-    @Test
-    fun payloadWrapsErrorPayloadWhenOnlyErrorIsSet() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        val err = buildJsonObject { put("code", "ERR") }
-        collector.errorPayload = err
-        val result = collector.payload()!!
-        assertEquals(err, result["error"]?.jsonObject)
-    }
-
-    @Test
-    fun payloadPrefersErrorPayloadOverOutput() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        collector.output = buildJsonObject { put("status", "success") }
-        val err = buildJsonObject { put("code", "ERR") }
-        collector.errorPayload = err
-        val result = collector.payload()!!
-        assertEquals(err, result["error"]?.jsonObject)
-    }
-
-    @Test
-    fun outputIsNullByDefault() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        assertNull(collector.output)
-    }
-
-    @Test
-    fun errorPayloadIsNullByDefault() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        assertNull(collector.errorPayload)
-    }
-
-    @Test
-    fun initReturnsCollectorInstanceForMethodChaining() {
-        val collector = MetadataCollector()
-        val result = collector.init(buildFullMetadataJson())
-        assertEquals(collector, result)
-    }
-
-    @Test
-    fun initializesWithDefaultsWhenJsonIsEmpty() {
+    fun defaultsWhenJsonEmpty() {
         val collector = MetadataCollector().apply { init(JsonObject(emptyMap())) }
         assertEquals("", collector.key)
         assertEquals("", collector.type)
         assertTrue(collector.metadata.isEmpty())
-    }
-
-    @Test
-    fun idReturnsEmptyStringWhenKeyAbsent() {
-        val collector = MetadataCollector().apply { init(JsonObject(emptyMap())) }
-        assertEquals("", collector.id())
     }
 
     @Test
@@ -128,41 +69,133 @@ class MetadataCollectorTest {
     }
 
     @Test
-    fun outputCanBeSet() {
+    fun initReturnsInstanceForChaining() {
+        val collector = MetadataCollector()
+        assertEquals(collector, collector.init(buildFullMetadataJson()))
+    }
+
+    // --- payload / setResult ---
+
+    @Test
+    fun payloadIsNullBeforeSetResultOrSetError() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        val output = buildJsonObject {
-            put("verification", "successful")
-            put("status", true)
-        }
-        collector.output = output
-        assertEquals(output, collector.output)
-        assertNull(collector.errorPayload)
+        assertNull(collector.payload())
     }
 
     @Test
-    fun errorPayloadCanBeSet() {
+    fun setResultProducesPayload() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        val err = buildJsonObject {
-            put("code", "SOME_ERROR_CODE")
-            put("message", "User cancelled the operation")
-        }
-        collector.errorPayload = err
-        assertEquals(err, collector.errorPayload)
+        val result = buildJsonObject { put("verified", true) }
+        collector.setResult(result)
+        assertEquals(result, collector.payload())
+    }
+
+    // --- setError ---
+
+    @Test
+    fun setErrorProducesErrorEnvelope() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        collector.setError(errorCode = "USER_CANCELLED", message = "User cancelled the operation")
+
+        val error = collector.payload()!!["error"]?.jsonObject
+        assertNotNull(error)
+        assertEquals("USER_CANCELLED", error["code"]?.jsonPrimitive?.content)
+        assertEquals("User cancelled the operation", error["message"]?.jsonPrimitive?.content)
+        assertNull(error["isClientError"])
     }
 
     @Test
-    fun outputAndErrorPayloadCanBeSetIndependently() {
+    fun setErrorWithIsClientErrorIncludesFlag() {
         val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        val output = buildJsonObject { put("status", "success") }
-        val err = buildJsonObject {
-            put("code", "SOME_ERROR_CODE")
-            put("message", "User cancelled the operation")
+        collector.setError(errorCode = "E1", message = "m", isClientError = true)
+
+        val error = collector.payload()!!["error"]?.jsonObject
+        assertEquals(true, error?.get("isClientError")?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun setErrorWithIsClientErrorFalseIncludesFlag() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        collector.setError(errorCode = "E1", message = "m", isClientError = false)
+
+        val error = collector.payload()!!["error"]?.jsonObject
+        assertFalse(error?.get("isClientError")?.jsonPrimitive?.boolean ?: true)
+    }
+
+    // --- eventType ---
+
+    @Test
+    fun eventTypeIsAction() {
+        assertEquals("action", MetadataCollector().eventType())
+    }
+
+    // --- validate ---
+
+    @Test
+    fun validateRequiresResultBeforeSet() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertTrue(collector.validate().isNotEmpty())
+    }
+
+    @Test
+    fun validatePassesAfterSetResult() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        collector.setResult(buildJsonObject { put("ok", true) })
+        assertTrue(collector.validate().isEmpty())
+    }
+
+    @Test
+    fun validatePassesAfterSetError() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        collector.setError(errorCode = "E", message = "m")
+        assertTrue(collector.validate().isEmpty())
+    }
+
+    // --- close ---
+
+    @Test
+    fun closeClearsResult() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        collector.setResult(buildJsonObject { put("ok", true) })
+        collector.close()
+        assertNull(collector.payload())
+    }
+
+    // --- Collectors pipeline integration ---
+
+    @Test
+    fun collectorsAsJsonSetsActionKeyAndFormDataWhenResultPresent() {
+        val collector = MetadataCollector().apply {
+            init(buildFullMetadataJson())
+            setResult(buildJsonObject { put("verified", true) })
         }
+        val json = listOf(collector).asJson()
+        assertEquals("sdkMetadata", json["actionKey"]?.jsonPrimitive?.content)
+        val sdkMetadata = json["formData"]?.jsonObject?.get("sdkMetadata")?.jsonObject
+        assertNotNull(sdkMetadata)
+        assertEquals(true, sdkMetadata["verified"]?.jsonPrimitive?.boolean)
+    }
 
-        collector.output = output
-        collector.errorPayload = err
+    @Test
+    fun collectorsEventTypeIsActionWhenResultPresent() {
+        val collector = MetadataCollector().apply {
+            init(buildFullMetadataJson())
+            setResult(buildJsonObject { put("ok", true) })
+        }
+        assertEquals("action", listOf(collector).eventType())
+    }
 
-        assertEquals(output, collector.output)
-        assertEquals(err, collector.errorPayload)
+    @Test
+    fun collectorsAsJsonOmitsActionKeyWhenNoResult() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        val json = listOf(collector).asJson()
+        assertNull(json["actionKey"])
+        assertTrue(json["formData"]?.jsonObject?.isEmpty() ?: true)
+    }
+
+    @Test
+    fun collectorsEventTypeIsNullWhenNoResult() {
+        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
+        assertNull(listOf(collector).eventType())
     }
 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/MetadataCollectorTest.kt
@@ -17,7 +17,6 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -101,25 +100,6 @@ class MetadataCollectorTest {
         assertNotNull(error)
         assertEquals("USER_CANCELLED", error["code"]?.jsonPrimitive?.content)
         assertEquals("User cancelled the operation", error["message"]?.jsonPrimitive?.content)
-        assertNull(error["isClientError"])
-    }
-
-    @Test
-    fun setErrorWithIsClientErrorIncludesFlag() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        collector.setError(errorCode = "E1", message = "m", isClientError = true)
-
-        val error = collector.payload()!!["error"]?.jsonObject
-        assertEquals(true, error?.get("isClientError")?.jsonPrimitive?.content?.toBoolean())
-    }
-
-    @Test
-    fun setErrorWithIsClientErrorFalseIncludesFlag() {
-        val collector = MetadataCollector().apply { init(buildFullMetadataJson()) }
-        collector.setError(errorCode = "E1", message = "m", isClientError = false)
-
-        val error = collector.payload()!!["error"]?.jsonObject
-        assertFalse(error?.get("isClientError")?.jsonPrimitive?.boolean ?: true)
     }
 
     // --- eventType ---

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/DaVinciContinueNode.kt
@@ -34,6 +34,7 @@ import com.pingidentity.davinci.collector.PollingCollector
 import com.pingidentity.davinci.collector.QRCodeCollector
 import com.pingidentity.davinci.collector.BooleanCollector
 import com.pingidentity.davinci.collector.ImageCollector
+import com.pingidentity.davinci.collector.MetadataCollector
 import com.pingidentity.davinci.collector.SingleSelectCollector
 import com.pingidentity.davinci.collector.SubmitCollector
 import com.pingidentity.davinci.collector.TextCollector
@@ -130,6 +131,7 @@ fun DaVinciContinueNode(
 
                 is BooleanCollector -> SingleCheckbox(it, onNodeUpdated)
                 is ImageCollector -> Image(it)
+                is MetadataCollector -> Metadata(it, onNext)
             }
             if (it is Submittable) {
                 hasAction = true

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Ping Identity Corporation. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.samples.pingsampleapp.davinci.collector
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.pingidentity.davinci.collector.MetadataCollector
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+@Composable
+fun Metadata(
+    metadataCollector: MetadataCollector,
+    onNext: () -> Unit,
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(12.dp)
+                .fillMaxWidth()
+        ) {
+            Text(
+                text = "SDK Metadata",
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.Bold,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = metadataCollector.metadata.toString(),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Button(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(end = 4.dp),
+                    onClick = {
+                        metadataCollector.output = buildJsonObject { put("status", "success") }
+                        metadataCollector.error = null
+                        onNext()
+                    },
+                ) {
+                    Text("Success")
+                }
+                Button(
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 4.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.error,
+                    ),
+                    onClick = {
+                        metadataCollector.error = buildJsonObject {
+                            put("code", "USER_ERROR")
+                            put("message", "User reported an error")
+                        }
+                        metadataCollector.output = null
+                        onNext()
+                    },
+                ) {
+                    Text("Error")
+                }
+            }
+        }
+    }
+}

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
@@ -60,8 +60,7 @@ fun Metadata(
                         .weight(1f)
                         .padding(end = 4.dp),
                     onClick = {
-                        metadataCollector.output = buildJsonObject { put("status", "success") }
-                        metadataCollector.errorPayload = null
+                        metadataCollector.setResult(buildJsonObject { put("status", "success") })
                         onNext()
                     },
                 ) {
@@ -75,11 +74,11 @@ fun Metadata(
                         containerColor = MaterialTheme.colorScheme.error,
                     ),
                     onClick = {
-                        metadataCollector.errorPayload = buildJsonObject {
-                            put("code", "USER_ERROR")
-                            put("message", "User reported an error")
-                        }
-                        metadataCollector.output = null
+                        metadataCollector.setError(
+                            errorCode = "100",
+                            message = "An error occurred",
+                            isClientError = true,
+                        )
                         onNext()
                     },
                 ) {

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
@@ -77,7 +77,6 @@ fun Metadata(
                         metadataCollector.setError(
                             errorCode = "100",
                             message = "An error occurred",
-                            isClientError = true,
                         )
                         onNext()
                     },

--- a/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
+++ b/samples/pingsampleapp/src/main/java/com/pingidentity/samples/pingsampleapp/davinci/collector/Metadata.kt
@@ -61,7 +61,7 @@ fun Metadata(
                         .padding(end = 4.dp),
                     onClick = {
                         metadataCollector.output = buildJsonObject { put("status", "success") }
-                        metadataCollector.error = null
+                        metadataCollector.errorPayload = null
                         onNext()
                     },
                 ) {
@@ -75,7 +75,7 @@ fun Metadata(
                         containerColor = MaterialTheme.colorScheme.error,
                     ),
                     onClick = {
-                        metadataCollector.error = buildJsonObject {
+                        metadataCollector.errorPayload = buildJsonObject {
                             put("code", "USER_ERROR")
                             put("message", "User reported an error")
                         }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5168](https://pingidentity.atlassian.net/browse/SDKS-5168)

# Description

Add Metadata collector to support DaVinci callbacks.
Success
```json
{
  "id": "4r92vx2x9u",
  "eventName": "continue",
  "parameters": {
    "eventType": "action",
    "data": {
      "actionKey": "sdkMetadata",
      "formData": {
        "sdkMetadata": {
          "status": "success"
        }
      }
    }
  }
}
```

Error
```json
{
  "id": "4r92vx2x9u",
  "eventName": "continue",
  "parameters": {
    "eventType": "action",
    "data": {
      "actionKey": "sdkMetadata",
      "formData": {
        "sdkMetadata": {
          "error": {
            "code": "100",
            "message": "An error occurred"
          }
        }
      }
    }
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “SDK Metadata” collector to capture server-provided metadata and enable success/error resume payloads.
  * Updated the continue-node flow to render the metadata step and proceed immediately after success/error selection.
  * Updated JSON generation for metadata submissions to include both the metadata identifier and its value in `formData`.
* **Tests**
  * Added unit tests covering initialization, result/error payload lifecycle, validation behavior, and JSON/event type integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->