### PR TITLE
Surface FIDO2 credential errors as DaVinci action events

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Collectors.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/Collectors.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -8,6 +8,7 @@
 package com.pingidentity.davinci.collector
 
 import com.pingidentity.davinci.plugin.Collectors
+import com.pingidentity.davinci.plugin.Failable
 import com.pingidentity.davinci.plugin.Submittable
 import com.pingidentity.orchestrate.FlowContext
 import com.pingidentity.orchestrate.RequestInterceptor
@@ -23,7 +24,7 @@ internal fun Collectors.eventType(): String? {
         when (it) {
             is Submittable -> {
                 val eventType = it.eventType()
-                it.payload()?.let {
+                if (it.payload() != null || (it is Failable && it.error() != null)) {
                     return eventType
                 }
             }
@@ -64,6 +65,9 @@ internal fun Collectors.asJson(): JsonObject {
                     put("actionKey", it.id())
                 }
             } else {
+                if (it is Failable && it.error() != null) {
+                    put("actionKey", it.error())
+                }
                 it.payload()?.let { payload ->
                     map[it.id()] = payload
                 }

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/collector/CollectorsTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/collector/CollectorsTest.kt
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.collector
+
+import com.pingidentity.davinci.plugin.Collector
+import com.pingidentity.davinci.plugin.Collectors
+import com.pingidentity.davinci.plugin.Failable
+import com.pingidentity.davinci.plugin.Submittable
+import com.pingidentity.orchestrate.FlowContext
+import com.pingidentity.orchestrate.RequestInterceptor
+import io.mockk.mockk
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import com.pingidentity.network.HttpRequest as Request
+
+class CollectorsTest {
+
+    // Test implementation of Submittable collector
+    private class TestSubmittableCollector(
+        private val collectorId: String,
+        private val collectorPayload: JsonObject?,
+        private val collectorEventType: String = "submit"
+    ) : Collector<JsonObject>, Submittable {
+        override fun id(): String = collectorId
+        override fun eventType(): String = collectorEventType
+        override fun payload(): JsonObject? = collectorPayload
+        override fun init(input: JsonObject): Collector<JsonObject> = this
+    }
+
+    // Test implementation of Submittable and Failable collector
+    private class TestFailableCollector(
+        private val collectorId: String,
+        private val collectorPayload: JsonObject?,
+        private val collectorError: String?,
+        private val collectorEventType: String = "action"
+    ) : Collector<JsonObject>, Submittable, Failable {
+        override fun id(): String = collectorId
+        override fun eventType(): String = collectorEventType
+        override fun payload(): JsonObject? = collectorPayload
+        override fun error(): String? = collectorError
+        override fun init(input: JsonObject): Collector<JsonObject> = this
+    }
+
+    // Test implementation of RequestInterceptor collector
+    private class TestRequestInterceptorCollector(
+        private val collectorId: String,
+        private val interceptedRequest: Request
+    ) : Collector<JsonObject>, RequestInterceptor {
+        override fun id(): String = collectorId
+        override fun payload(): JsonObject? = null
+        override fun init(input: JsonObject): Collector<JsonObject> = this
+        override var intercept: FlowContext.(Request) -> Request = { interceptedRequest }
+    }
+
+    // Test implementation of regular collector
+    private class TestRegularCollector(
+        private val collectorId: String,
+        private val collectorPayload: JsonObject?
+    ) : Collector<JsonObject> {
+        override fun id(): String = collectorId
+        override fun payload(): JsonObject? = collectorPayload
+        override fun init(input: JsonObject): Collector<JsonObject> = this
+    }
+
+    @Test
+    fun `eventType should return null for empty collectors list`() {
+        val collectors: Collectors = emptyList()
+        assertNull(collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should return null when no submittable collectors`() {
+        val collectors: Collectors = listOf(
+            TestRegularCollector("collector1", buildJsonObject { put("key", JsonPrimitive("value")) })
+        )
+        assertNull(collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should return null when submittable has no payload and no error`() {
+        val collectors: Collectors = listOf(
+            TestSubmittableCollector("submit1", null, "submit")
+        )
+        assertNull(collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should return submit when submittable has payload`() {
+        val payload = buildJsonObject { put("key", JsonPrimitive("value")) }
+        val collectors: Collectors = listOf(
+            TestSubmittableCollector("submit1", payload, "submit")
+        )
+        assertEquals("submit", collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should return action when failable has error`() {
+        val collectors: Collectors = listOf(
+            TestFailableCollector("failable1", null, "NotAllowedError", "action")
+        )
+        assertEquals("action", collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should return submit when failable has payload but no error`() {
+        val payload = buildJsonObject { put("key", JsonPrimitive("value")) }
+        val collectors: Collectors = listOf(
+            TestFailableCollector("failable1", payload, null, "submit")
+        )
+        assertEquals("submit", collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should return first matching event type`() {
+        val payload1 = buildJsonObject { put("key1", JsonPrimitive("value1")) }
+        val payload2 = buildJsonObject { put("key2", JsonPrimitive("value2")) }
+        val collectors: Collectors = listOf(
+            TestSubmittableCollector("submit1", payload1, "submit"),
+            TestSubmittableCollector("submit2", payload2, "continue")
+        )
+        assertEquals("submit", collectors.eventType())
+    }
+
+    @Test
+    fun `eventType should skip non-submittable collectors`() {
+        val payload = buildJsonObject { put("key", JsonPrimitive("value")) }
+        val collectors: Collectors = listOf(
+            TestRegularCollector("regular1", buildJsonObject { put("key", JsonPrimitive("value")) }),
+            TestSubmittableCollector("submit1", payload, "submit")
+        )
+        assertEquals("submit", collectors.eventType())
+    }
+
+    @Test
+    fun `request should return original request when no interceptors`() {
+        val context = mockk<FlowContext>()
+        val originalRequest = mockk<Request>()
+        val collectors: Collectors = listOf(
+            TestRegularCollector("collector1", null)
+        )
+
+        val result = collectors.request(context, originalRequest)
+
+        assertEquals(originalRequest, result)
+    }
+
+    @Test
+    fun `request should apply single interceptor`() {
+        val context = mockk<FlowContext>()
+        val originalRequest = mockk<Request>()
+        val interceptedRequest = mockk<Request>()
+        val collectors: Collectors = listOf(
+            TestRequestInterceptorCollector("interceptor1", interceptedRequest)
+        )
+
+        val result = collectors.request(context, originalRequest)
+
+        assertEquals(interceptedRequest, result)
+    }
+
+    @Test
+    fun `request should apply multiple interceptors in order`() {
+        val context = mockk<FlowContext>()
+        val originalRequest = mockk<Request>()
+        val interceptedRequest1 = mockk<Request>()
+        val interceptedRequest2 = mockk<Request>()
+
+        val interceptor1 = TestRequestInterceptorCollector("interceptor1", interceptedRequest1)
+        val interceptor2 = TestRequestInterceptorCollector("interceptor2", interceptedRequest2)
+
+        val collectors: Collectors = listOf(interceptor1, interceptor2)
+
+        val result = collectors.request(context, originalRequest)
+
+        // The second interceptor should receive the result from the first
+        assertEquals(interceptedRequest2, result)
+    }
+
+    @Test
+    fun `asJson should return empty formData for empty collectors`() {
+        val collectors: Collectors = emptyList()
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        assertEquals(0, formData?.size)
+    }
+
+    @Test
+    fun `asJson should set actionKey for SubmitCollector with payload`() {
+        val payload = JsonPrimitive("test")
+        val init = buildJsonObject { put("key", JsonPrimitive("submitKey")) }
+        val submitCollector = SubmitCollector()
+        submitCollector.init(init)
+        submitCollector.init(payload)
+
+        val collectors: Collectors = listOf(submitCollector)
+
+        val result = collectors.asJson()
+
+        assertEquals("submitKey", result["actionKey"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should set actionKey for FlowCollector with payload`() {
+        val flowCollector = FlowCollector()
+        flowCollector.init(buildJsonObject { put("key", JsonPrimitive("flowKey")) })
+        flowCollector.init(JsonPrimitive("true"))
+
+        val collectors: Collectors = listOf(flowCollector)
+
+
+        val result = collectors.asJson()
+
+        assertEquals("flowKey", result["actionKey"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should set actionKey to error for Failable with error`() {
+        val collectors: Collectors = listOf(
+            TestFailableCollector("failable1", null, "NotAllowedError", "action")
+        )
+
+        val result = collectors.asJson()
+
+        assertEquals("NotAllowedError", result["actionKey"]?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should add regular collector payload to formData`() {
+        val payload = buildJsonObject { put("username", JsonPrimitive("john.doe")) }
+        val collectors: Collectors = listOf(
+            TestRegularCollector("usernameField", payload)
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        val usernameField = formData?.get("usernameField")?.jsonObject
+        assertEquals("john.doe", usernameField?.get("username")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should add failable collector payload to formData when no error`() {
+        val payload = buildJsonObject { put("data", JsonPrimitive("test")) }
+        val collectors: Collectors = listOf(
+            TestFailableCollector("failable1", payload, null, "submit")
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        val failableField = formData?.get("failable1")?.jsonObject
+        assertEquals("test", failableField?.get("data")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should not add regular collector without payload to formData`() {
+        val collectors: Collectors = listOf(
+            TestRegularCollector("emptyField", null)
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        assertEquals(0, formData?.size)
+    }
+
+    @Test
+    fun `asJson should handle multiple collectors`() {
+        val payload1 = buildJsonObject { put("field1", JsonPrimitive("value1")) }
+        val payload2 = buildJsonObject { put("field2", JsonPrimitive("value2")) }
+
+        val submitCollector = SubmitCollector()
+        submitCollector.init(buildJsonObject { put("key", JsonPrimitive("submitButton")) })
+        submitCollector.init(JsonPrimitive("true"))
+
+        val collectors: Collectors = listOf(
+            TestRegularCollector("collector1", payload1),
+            TestRegularCollector("collector2", payload2),
+            submitCollector
+        )
+
+        val result = collectors.asJson()
+
+        assertEquals("submitButton", result["actionKey"]?.jsonPrimitive?.content)
+
+        val formData = result["formData"]?.jsonObject
+        assertEquals("value1", formData?.get("collector1")?.jsonObject?.get("field1")?.jsonPrimitive?.content)
+        assertEquals("value2", formData?.get("collector2")?.jsonObject?.get("field2")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should handle nested maps in payload`() {
+        val payload = buildJsonObject {
+            put("nested", buildJsonObject {
+                put("key", JsonPrimitive("value"))
+            })
+        }
+        val collectors: Collectors = listOf(
+            TestRegularCollector("nestedField", payload)
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        val nestedField = formData?.get("nestedField")?.jsonObject
+        val nested = nestedField?.get("nested")?.jsonObject
+        assertEquals("value", nested?.get("key")?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should handle arrays in payload`() {
+        val payload = buildJsonObject {
+            put("items", JsonArray(listOf(
+                JsonPrimitive("item1"),
+                JsonPrimitive("item2"),
+                JsonPrimitive("item3")
+            )))
+        }
+        val collectors: Collectors = listOf(
+            TestRegularCollector("arrayField", payload)
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        val arrayField = formData?.get("arrayField")?.jsonObject
+        val items = arrayField?.get("items")?.jsonArray
+        assertEquals(3, items?.size)
+        assertEquals("item1", items?.get(0)?.jsonPrimitive?.content)
+    }
+
+    @Test
+    fun `asJson should handle boolean values in payload`() {
+        val payload = buildJsonObject {
+            put("enabled", JsonPrimitive(true))
+            put("disabled", JsonPrimitive(false))
+        }
+        val collectors: Collectors = listOf(
+            TestRegularCollector("booleanField", payload)
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        val booleanField = formData?.get("booleanField")?.jsonObject
+        assertEquals(true, booleanField?.get("enabled")?.jsonPrimitive?.content?.toBoolean())
+        assertEquals(false, booleanField?.get("disabled")?.jsonPrimitive?.content?.toBoolean())
+    }
+
+    @Test
+    fun `asJson should handle number values in payload`() {
+        val payload = buildJsonObject {
+            put("count", JsonPrimitive(42))
+            put("price", JsonPrimitive(19.99))
+        }
+        val collectors: Collectors = listOf(
+            TestRegularCollector("numberField", payload)
+        )
+
+        val result = collectors.asJson()
+
+        val formData = result["formData"]?.jsonObject
+        val numberField = formData?.get("numberField")?.jsonObject
+        assertEquals("42", numberField?.get("count")?.jsonPrimitive?.content)
+        assertEquals("19.99", numberField?.get("price")?.jsonPrimitive?.content)
+    }
+}
+
+
+

--- a/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/Failable.kt
+++ b/foundation/davinci-plugin/src/main/kotlin/com/pingidentity/davinci/plugin/Failable.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+
+package com.pingidentity.davinci.plugin
+
+interface Failable {
+    fun error(): String?
+}

--- a/mfa/fido/src/main/kotlin/com/pingidentity/fido/Constants.kt
+++ b/mfa/fido/src/main/kotlin/com/pingidentity/fido/Constants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -17,6 +17,7 @@ object Constants {
 
     // Event Types
     const val EVENT_TYPE_SUBMIT = "submit"
+    const val EVENT_TYPE_ACTION = "action"
 
     // JSON Fields
     const val FIELD_KEY = "key"

--- a/mfa/fido/src/main/kotlin/com/pingidentity/fido/davinci/AbstractFidoCollector.kt
+++ b/mfa/fido/src/main/kotlin/com/pingidentity/fido/davinci/AbstractFidoCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -7,9 +7,19 @@
 
 package com.pingidentity.fido.davinci
 
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialUnsupportedException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
+import androidx.credentials.exceptions.domerrors.NotAllowedError
+import androidx.credentials.exceptions.domerrors.NotSupportedError
+import androidx.credentials.exceptions.domerrors.UnknownError
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
 import com.pingidentity.davinci.plugin.Collector
 import com.pingidentity.davinci.plugin.DaVinci
 import com.pingidentity.davinci.plugin.DaVinciAware
+import com.pingidentity.davinci.plugin.Failable
 import com.pingidentity.davinci.plugin.Submittable
 import com.pingidentity.fido.Constants
 import com.pingidentity.logger.Logger
@@ -29,7 +39,7 @@ import kotlinx.serialization.json.jsonPrimitive
  * @property trigger The trigger event that activates this collector
  * @property required Whether the collector is mandatory for the workflow
  */
-abstract class AbstractFidoCollector : Collector<JsonObject>, DaVinciAware, Submittable {
+abstract class AbstractFidoCollector : Collector<JsonObject>, DaVinciAware, Submittable, Failable {
     /**
      * The DaVinci workflow instance that this collector is associated with.
      * This is automatically injected by the DaVinci framework.
@@ -53,12 +63,17 @@ abstract class AbstractFidoCollector : Collector<JsonObject>, DaVinciAware, Subm
     var required = false
         private set
 
+
+    var error: String? = null
+
     /**
      * Returns the event type that this collector handles.
      *
      * @return The event type string, always "submit" for FIDO2 collectors
      */
-    override fun eventType(): String = Constants.EVENT_TYPE_SUBMIT
+    override fun eventType(): String {
+        return if (error == null) Constants.EVENT_TYPE_SUBMIT else Constants.EVENT_TYPE_ACTION
+    }
 
     /**
      * Returns the unique identifier for this collector instance.
@@ -68,6 +83,8 @@ abstract class AbstractFidoCollector : Collector<JsonObject>, DaVinciAware, Subm
     override fun id(): String {
         return key
     }
+
+    override fun error(): String? = error
 
     /**
      * Initializes the collector with the provided input data.
@@ -85,5 +102,57 @@ abstract class AbstractFidoCollector : Collector<JsonObject>, DaVinciAware, Subm
         trigger = input[Constants.FIELD_TRIGGER]?.jsonPrimitive?.content ?: ""
         required = input[Constants.FIELD_REQUIRED]?.jsonPrimitive?.boolean ?: false
         return this
+    }
+
+
+    /**
+     * Handles errors that occur during FIDO2 operations.
+     *
+     * This method converts various types of credential exceptions into appropriate
+     * error messages that the Journey server can understand and process.
+     *
+     * @param exception The throwable error to handle and convert
+     */
+    fun handleError(exception: Throwable) {
+        logger.e(
+            "Handling FIDO2 error: ${exception::class.simpleName} - ${exception.message}",
+            exception
+        )
+        when (exception) {
+            is CreateCredentialUnsupportedException -> {
+                logger.d("Credential creation unsupported")
+                error = NotSupportedError::class.simpleName
+            }
+
+            is GetCredentialUnsupportedException -> {
+                logger.d("Get Credential unsupported")
+                error = NotSupportedError::class.simpleName
+            }
+
+            is CreateCredentialCancellationException -> {
+                logger.d("Credential creation cancelled")
+                error = NotAllowedError::class.simpleName
+            }
+
+            is GetCredentialCancellationException -> {
+                logger.d("Get Credential cancelled")
+                error = NotAllowedError::class.simpleName
+            }
+
+            is CreatePublicKeyCredentialDomException -> {
+                logger.d("DOM exception occurred: ${exception.domError::class.simpleName}")
+                error = exception.domError::class.simpleName
+            }
+
+            is GetPublicKeyCredentialDomException -> {
+                logger.d("DOM exception occurred: ${exception.domError::class.simpleName}")
+                error = exception.domError::class.simpleName
+            }
+
+            else -> {
+                logger.d("Unknown error occurred")
+                error = UnknownError::class.simpleName
+            }
+        }
     }
 }

--- a/mfa/fido/src/main/kotlin/com/pingidentity/fido/davinci/FidoAuthenticationCollector.kt
+++ b/mfa/fido/src/main/kotlin/com/pingidentity/fido/davinci/FidoAuthenticationCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -95,6 +95,7 @@ class FidoAuthenticationCollector : AbstractFidoCollector(), Closeable {
     suspend fun authenticate(
         block: FidoAuthenticateCustomizer.() -> Unit = {}
     ): Result<JsonObject> {
+        error = null
         logger.d("Starting FIDO2 authentication")
         return FidoClient { logger = this@FidoAuthenticationCollector.logger }.authenticate(
             publicKeyCredentialRequestOptions, block
@@ -102,6 +103,7 @@ class FidoAuthenticationCollector : AbstractFidoCollector(), Closeable {
             logger.d("FIDO2 authentication successful")
             assertionValue = it
         }.onFailure { exception ->
+            handleError(exception)
             logger.e("FIDO2 authentication failed", exception)
         }
     }

--- a/mfa/fido/src/main/kotlin/com/pingidentity/fido/davinci/FidoRegistrationCollector.kt
+++ b/mfa/fido/src/main/kotlin/com/pingidentity/fido/davinci/FidoRegistrationCollector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -69,12 +69,14 @@ class FidoRegistrationCollector : AbstractFidoCollector(), Closeable {
         block: FidoRegistrationCustomizer.() -> Unit = {}
     ): Result<JsonObject> {
         logger.d("Starting FIDO2 registration")
+        error = null
         return FidoClient {
             logger = this@FidoRegistrationCollector.logger
         }.register(publicKeyCredentialCreationOptions, block).onSuccess {
             logger.d("FIDO2 registration successful")
             attestationValue = it
         }.onFailure { exception ->
+            handleError(exception)
             logger.e("FIDO2 registration failed", exception)
         }
     }

--- a/mfa/fido/src/test/kotlin/com/pingidentity/fido/davinci/AbstractFidoCollectorTest.kt
+++ b/mfa/fido/src/test/kotlin/com/pingidentity/fido/davinci/AbstractFidoCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -92,6 +92,159 @@ class AbstractFidoCollectorTest {
         // Access the logger property to ensure it's properly initialized
         val logger = collector.logger
         assertEquals(Logger.CONSOLE, logger)
+    }
+
+    @Test
+    fun `error should return null by default`() {
+        assertEquals(null, collector.error())
+    }
+
+    @Test
+    fun `error should return error message when set`() {
+        collector.error = "Test error message"
+        assertEquals("Test error message", collector.error())
+    }
+
+    @Test
+    fun `error should be mutable`() {
+        // Initially null
+        assertEquals(null, collector.error())
+
+        // Set error
+        collector.error = "First error"
+        assertEquals("First error", collector.error())
+
+        // Update error
+        collector.error = "Second error"
+        assertEquals("Second error", collector.error())
+
+        // Clear error
+        collector.error = null
+        assertEquals(null, collector.error())
+    }
+
+    @Test
+    fun `eventType should return submit when error is null`() {
+        collector.error = null
+        assertEquals(Constants.EVENT_TYPE_SUBMIT, collector.eventType())
+    }
+
+    @Test
+    fun `eventType should return action when error is set`() {
+        collector.error = "Some error occurred"
+        assertEquals("action", collector.eventType())
+    }
+
+    @Test
+    fun `eventType should return action when error is empty string`() {
+        collector.error = ""
+        assertEquals("action", collector.eventType())
+    }
+
+    @Test
+    fun `handleError should set NotSupportedError for CreateCredentialUnsupportedException`() {
+        val exception = mockk<androidx.credentials.exceptions.CreateCredentialUnsupportedException>(relaxed = true)
+        every { exception.message } returns "Create credential not supported"
+
+        collector.handleError(exception)
+
+        assertEquals("NotSupportedError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set NotSupportedError for GetCredentialUnsupportedException`() {
+        val exception = mockk<androidx.credentials.exceptions.GetCredentialUnsupportedException>(relaxed = true)
+        every { exception.message } returns "Get credential not supported"
+
+        collector.handleError(exception)
+
+        assertEquals("NotSupportedError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set NotAllowedError for CreateCredentialCancellationException`() {
+        val exception = mockk<androidx.credentials.exceptions.CreateCredentialCancellationException>(relaxed = true)
+        every { exception.message } returns "User cancelled creation"
+
+        collector.handleError(exception)
+
+        assertEquals("NotAllowedError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set NotAllowedError for GetCredentialCancellationException`() {
+        val exception = mockk<androidx.credentials.exceptions.GetCredentialCancellationException>(relaxed = true)
+        every { exception.message } returns "User cancelled get"
+
+        collector.handleError(exception)
+
+        assertEquals("NotAllowedError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set DOM error name for CreatePublicKeyCredentialDomException`() {
+        val domError = mockk<androidx.credentials.exceptions.domerrors.NotAllowedError>(relaxed = true)
+        val exception = mockk<androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException>(relaxed = true)
+        every { exception.domError } returns domError
+        every { exception.message } returns "DOM error occurred"
+
+        collector.handleError(exception)
+
+        assertEquals("NotAllowedError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set DOM error name for GetPublicKeyCredentialDomException`() {
+        val domError = mockk<androidx.credentials.exceptions.domerrors.NotSupportedError>(relaxed = true)
+        val exception = mockk<androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException>(relaxed = true)
+        every { exception.domError } returns domError
+        every { exception.message } returns "DOM error occurred"
+
+        collector.handleError(exception)
+
+        assertEquals("NotSupportedError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set UnknownError for unknown exception types`() {
+        val exception = RuntimeException("Some random error")
+
+        collector.handleError(exception)
+
+        assertEquals("UnknownError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set UnknownError for generic Exception`() {
+        val exception = Exception("Generic exception")
+
+        collector.handleError(exception)
+
+        assertEquals("UnknownError", collector.error)
+    }
+
+    @Test
+    fun `handleError should set UnknownError for IllegalStateException`() {
+        val exception = IllegalStateException("Invalid state")
+
+        collector.handleError(exception)
+
+        assertEquals("UnknownError", collector.error)
+    }
+
+    @Test
+    fun `handleError should override previous error`() {
+        // Set an initial error
+        collector.error = "PreviousError"
+        assertEquals("PreviousError", collector.error)
+
+        // Handle a new error
+        val exception = mockk<androidx.credentials.exceptions.CreateCredentialCancellationException>(relaxed = true)
+        every { exception.message } returns "User cancelled"
+        collector.handleError(exception)
+
+        // Verify the error was updated
+        assertEquals("NotAllowedError", collector.error)
     }
 
     // Test implementation of AbstractFido2Collector for testing purposes

--- a/mfa/fido/src/test/kotlin/com/pingidentity/fido/davinci/FidoAuthenticationCollectorTest.kt
+++ b/mfa/fido/src/test/kotlin/com/pingidentity/fido/davinci/FidoAuthenticationCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -171,6 +171,19 @@ class FidoAuthenticationCollectorTest {
         val payload2 = collector.payload()
         assertNotNull(payload2)
         assertEquals(assertion2, payload2?.get(Constants.FIELD_ASSERTION_VALUE)?.jsonObject)
+    }
+
+    @Test
+    fun `authenticate should call handleError and set error on failure`() = runTest {
+        collector.init(getInput())
+        val exception = mockk<androidx.credentials.exceptions.GetCredentialCancellationException>(relaxed = true)
+        every { exception.message } returns "User cancelled"
+        coEvery { mockFidoClient.authenticate(any(), any()) } returns Result.failure(exception)
+
+        val result = collector.authenticate()
+
+        assertTrue(result.isFailure)
+        assertEquals("NotAllowedError", collector.error)
     }
 }
 

--- a/mfa/fido/src/test/kotlin/com/pingidentity/fido/davinci/FidoRegistrationCollectorTest.kt
+++ b/mfa/fido/src/test/kotlin/com/pingidentity/fido/davinci/FidoRegistrationCollectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2025 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -435,4 +435,18 @@ class FidoRegistrationCollectorTest {
         assertEquals("usb", transports[0].jsonPrimitive.content)
         assertEquals("nfc", transports[1].jsonPrimitive.content)
     }
+
+    @Test
+    fun `register should call handleError and set error on failure`() = runTest {
+        collector.init(getRegistrationInput())
+        val exception = mockk<androidx.credentials.exceptions.CreateCredentialCancellationException>(relaxed = true)
+        every { exception.message } returns "User cancelled"
+        coEvery { mockFidoClient.register(any(), any()) } returns Result.failure(exception)
+
+        val result = collector.register()
+
+        assertTrue(result.isFailure)
+        assertEquals("NotAllowedError", collector.error)
+    }
+
 }


### PR DESCRIPTION
  Add a Failable interface so collectors can report a DOM/credential
  error alongside their payload. AbstractFidoCollector now maps
  CreateCredential/GetCredential exceptions (cancellation, unsupported,
  DOM errors) to their corresponding error names and switches its event
  type from "submit" to "action" when an error is present, allowing the
  Journey server to handle FIDO2 failures without treating them as a
  generic submit failure.

# JIRA Ticket

Please link jira ticket here

# Description

Briefly describe the change and any information that would help speedup the review and testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standardized error reporting for FIDO authentication and registration failures.
  - FIDO failures now produce actionable event responses with specific error types, including unsupported, not-allowed, and unknown errors.
  - Cleared previous errors before starting new FIDO operations.

- **Bug Fixes**
  - FIDO failures are now correctly reflected in emitted event data instead of being omitted.

- **Tests**
  - Added comprehensive coverage for collector serialization, request interception, event handling, and FIDO error mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->