### PR TITLE
SDKS-5202 Add optional status code to ErrorNode and deprecate signOutRedirectUri in OidcClientConfig

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/module/Transform.kt
@@ -62,7 +62,12 @@ internal val NodeTransform =
                         }
                     }
                     // If we're still here, we have a 4XX failure that should be recoverable
-                    return@transform ErrorNode(this, jsonResponse, message)
+                    return@transform ErrorNode(
+                        context = this,
+                        input = jsonResponse,
+                        message = message,
+                        status = statusCode,
+                    )
                 }
                 // Handle success (2XX) responses
                 200 -> {

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
@@ -136,7 +136,7 @@ class OidcClientConfig {
      */
     @Deprecated(
         message = "signOutRedirectUri is no longer used by the SDK and will be removed in a future release. " +
-            "Remove this property from your OidcClientConfig — no replacement is needed."
+            "Terminate User Session by ID Token is enabled for your client"
     )
     var signOutRedirectUri: String? = null
 

--- a/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
+++ b/foundation/oidc/src/main/kotlin/com/pingidentity/oidc/OidcClientConfig.kt
@@ -134,6 +134,10 @@ class OidcClientConfig {
     /**
      * Sign-out redirect URI for OIDC.
      */
+    @Deprecated(
+        message = "signOutRedirectUri is no longer used by the SDK and will be removed in a future release. " +
+            "Remove this property from your OidcClientConfig — no replacement is needed."
+    )
     var signOutRedirectUri: String? = null
 
     /**

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Node.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Node.kt
@@ -21,11 +21,13 @@ sealed interface Node
  * Represents a failure node in the workflow.
  * @property input The input JSON object.
  * @property message The failure message.
+ * @property status The optional HTTP status code associated with the failure.
  */
-data class ErrorNode(
+data class ErrorNode @JvmOverloads constructor(
     val context: FlowContext,
     val input: JsonObject = buildJsonObject { },
-    val message: String
+    val message: String,
+    val status: Int? = null
 ) : Node
 
 /**

--- a/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Node.kt
+++ b/foundation/orchestrate/src/main/kotlin/com/pingidentity/orchestrate/Node.kt
@@ -23,7 +23,7 @@ sealed interface Node
  * @property message The failure message.
  * @property status The optional HTTP status code associated with the failure.
  */
-data class ErrorNode @JvmOverloads constructor(
+data class ErrorNode(
     val context: FlowContext,
     val input: JsonObject = buildJsonObject { },
     val message: String,

--- a/foundation/orchestrate/src/test/kotlin/com/pingidentity/orchestrate/NodeTest.kt
+++ b/foundation/orchestrate/src/test/kotlin/com/pingidentity/orchestrate/NodeTest.kt
@@ -19,6 +19,7 @@ import org.junit.Rule
 import org.junit.rules.TestWatcher
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import com.pingidentity.network.HttpRequest as Request
 
@@ -78,5 +79,17 @@ class NodeTest {
 
         connector.close()
         verify { (closeableAction as Closeable).close() }
+    }
+
+    @Test
+    fun `ErrorNode status defaults to null when constructed without status`() {
+        val node = ErrorNode(mockk(), buildJsonObject {}, "error message")
+        assertNull(node.status)
+    }
+
+    @Test
+    fun `ErrorNode status is preserved when provided`() {
+        val node = ErrorNode(mockk(), buildJsonObject {}, "error message", status = 400)
+        assertEquals(400, node.status)
     }
 }

--- a/journey/src/main/kotlin/com/pingidentity/journey/module/Transform.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/module/Transform.kt
@@ -69,7 +69,7 @@ internal val NodeTransform =
                             FailureNode(ApiException(it.status, errorMessage))
                         } else {
                             // API error
-                            error(this, errorBody)
+                            error(this, errorBody, it.status)
                         }
                     }
                 }
@@ -78,7 +78,7 @@ internal val NodeTransform =
                     //For api errors, return ErrorNode
                     // 5XX errors are treated as unrecoverable failures
                     catch {
-                        error(this, it.body().asJson())
+                        error(this, it.body().asJson(), it.status)
                     }
                 }
             }
@@ -89,8 +89,17 @@ private fun String.asJson(): JsonObject {
     return Json.parseToJsonElement(this).jsonObject
 }
 
-private fun error(flowContext: FlowContext, json: JsonObject): ErrorNode {
-    return ErrorNode(flowContext, json, json["message"]?.jsonPrimitive?.content ?: "")
+private fun error(
+    flowContext: FlowContext,
+    json: JsonObject,
+    statusCode: Int?,
+): ErrorNode {
+    return ErrorNode(
+        context = flowContext,
+        input = json,
+        message = json["message"]?.jsonPrimitive?.content ?: "",
+        status = statusCode
+    )
 }
 
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5202](https://pingidentity.atlassian.net/browse/SDKS-5202)

# Description
- ErrorNode now exposes an HTTP status field.
- signOutRedirectUri in OidcClientConfig has been marked deprecated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Error responses can now carry an optional HTTP status code, improving error details throughout the flow.

* **Bug Fixes**
  * DaVinci and Journey error handling now correctly propagates the HTTP status code into the produced error information.

* **Tests**
  * Added unit tests confirming the status defaults to `null` when not provided, and preserves an explicitly supplied value.

* **Deprecations**
  * Deprecated the sign-out redirect URI configuration property, advising removal without a replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->