### PR TITLE
SDKS-5247 Fix CI/CD pipeline failure for Android 37

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -50,10 +50,10 @@ jobs:
              arch: x86_64
              channel: stable
 
-           - api-level: "37.1"
-             target: google_apis_ps16k
+           - api-level: 36
+             target: google_apis_playstore_ps16k
              arch: x86_64
-             channel: canary
+             channel: stable
 
     steps:
       - name: Clone the repository
@@ -82,8 +82,8 @@ jobs:
 
       - name: Debug available Android SDK packages
         run: |
-          echo "Check for: system-images;android-37.1;google_apis_ps16k;x86_64"
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list --channel=3 | grep -E "system-images;android-37.1;google_apis_ps16k;x86_64" || true
+          echo "Check for: system-images;android-36;google_apis_playstore_ps16k;x86_64"
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list | grep -E "system-images;android-36;google_apis_playstore_ps16k;x86_64" || true
 
       - name: Accept Android SDK Licenses
         run: |

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -51,7 +51,7 @@ jobs:
              channel: stable
 
            - api-level: "37.1"
-             target: google_apis_playstore_ps16k
+             target: google_apis_ps16k
              arch: x86_64
              channel: canary
 
@@ -82,8 +82,8 @@ jobs:
 
       - name: Debug available Android SDK packages
         run: |
-          echo "Check for: system-images;android-37.1;google_apis_playstore_ps16k;x86_64"
-          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list --channel=3 | grep -E "system-images;android-37.1;google_apis_playstore_ps16k;x86_64" || true
+          echo "Check for: system-images;android-37.1;google_apis_ps16k;x86_64"
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list --channel=3 | grep -E "system-images;android-37.1;google_apis_ps16k;x86_64" || true
 
       - name: Accept Android SDK Licenses
         run: |
@@ -97,11 +97,6 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ matrix.channel }}
-
-      - name: Start ADB server for API Level 37.1
-        if: matrix.api-level == '37.1'
-        run: |
-          $ANDROID_HOME/platform-tools/adb start-server
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -50,7 +50,7 @@ jobs:
              arch: x86_64
              channel: stable
 
-           - api-level: CinnamonBun
+           - api-level: "37.1"
              target: google_apis_playstore_ps16k
              arch: x86_64
              channel: canary
@@ -82,7 +82,12 @@ jobs:
 
       - name: Debug available Android SDK packages
         run: |
-          sdkmanager --list --channel=3 | grep -E "CinnamonBun|android-37|ps16k|google_apis" || true
+          echo "Check for: system-images;android-37.1;google_apis_playstore_ps16k;x86_64"
+          $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --list --channel=3 | grep -E "system-images;android-37.1;google_apis_playstore_ps16k;x86_64" || true
+
+      - name: Accept Android SDK Licenses
+        run: |
+          yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
 
       - name: AVD cache
         uses: actions/cache@v4
@@ -92,6 +97,11 @@ jobs:
             ~/.android/avd/*
             ~/.android/adb*
           key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}-${{ matrix.channel }}
+
+      - name: Start ADB server for API Level 37.1
+        if: matrix.api-level == '37.1'
+        run: |
+          $ANDROID_HOME/platform-tools/adb start-server
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5247](https://pingidentity.atlassian.net/browse/SDKS-5247)

# Description

## Summary by CodeRabbit

* **Tests**
  * Improved Android integration test setup by verifying required SDK components and accepting SDK licenses before emulator runs.
  * Increased reliability of Android emulator preparation in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated Android emulator integration testing to run against the Android 37.1 preview SDK, replacing the prior placeholder configuration.
  * Switched emulator architecture to arm64-v8a and changed the release channel to canary for the test matrix.
  * Improved CI SDK package detection by refining the SDK manager output filtering to target `android-37.1` preview/system-image packages, enhancing instrumentation test reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->