### PR TITLE
SDKS-5251 Switch e2e tests to dedicated DaVinci environment

### DIFF
--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DaVinciTestConfig.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DaVinciTestConfig.kt
@@ -28,14 +28,9 @@ object DaVinciTestConfig {
         private set
     var davinciProtectAcrValues: String = ""
         private set
-    var davinciMfaAcrValues: String = ""
+    var davinciMfaDeviceAcrValues: String = ""
         private set
 
-    // Form field tests (FormFieldsTest, FormFieldValidationTest, PollingCollectorE2ETests)
-    var davinciFormClientId: String = ""
-        private set
-    var davinciFormDiscoveryEndpoint: String = ""
-        private set
     var davinciFormFieldsAcrValues: String = ""
         private set
     var davinciPollingAcrValues: String = ""
@@ -48,9 +43,15 @@ object DaVinciTestConfig {
         private set
     var davinciVerificationCode: String = ""
         private set
-    var davinciProtectUsername: String = ""
+
+    // PAR (PARDaVinciE2ETest, PARCentralizedLoginDaVinciE2ETest)
+    var parClientId: String = ""
         private set
-    var davinciProtectPassword: String = ""
+    var parDiscoveryEndpoint: String = ""
+        private set
+    var parRedirectUri: String = ""
+        private set
+    var parAcrValues: String = ""
         private set
 
     // Device Authorization Grant
@@ -83,18 +84,19 @@ object DaVinciTestConfig {
             davinciDiscoveryEndpoint = properties.getProperty("DAVINCI_DISCOVERY_ENDPOINT", "")
             davinciAcrValues = properties.getProperty("DAVINCI_ACR_VALUES", "")
             davinciProtectAcrValues = properties.getProperty("DAVINCI_PROTECT_ACR_VALUES", "")
-            davinciMfaAcrValues = properties.getProperty("DAVINCI_MFA_ACR_VALUES", "")
+            davinciMfaDeviceAcrValues = properties.getProperty("DAVINCI_MFA_DEVICE_ACR_VALUES", "")
 
-            davinciFormClientId = properties.getProperty("DAVINCI_FORM_CLIENT_ID", "")
-            davinciFormDiscoveryEndpoint = properties.getProperty("DAVINCI_FORM_DISCOVERY_ENDPOINT", "")
             davinciFormFieldsAcrValues = properties.getProperty("DAVINCI_FORM_FIELDS_ACR_VALUES", "")
             davinciPollingAcrValues = properties.getProperty("DAVINCI_POLLING_ACR_VALUES", "")
 
             davinciUsername = properties.getProperty("DAVINCI_USERNAME", "")
             davinciPassword = properties.getProperty("DAVINCI_PASSWORD", "")
             davinciVerificationCode = properties.getProperty("DAVINCI_VERIFICATION_CODE", "")
-            davinciProtectUsername = properties.getProperty("DAVINCI_PROTECT_USERNAME", "")
-            davinciProtectPassword = properties.getProperty("DAVINCI_PROTECT_PASSWORD", "")
+
+            parClientId = properties.getProperty("PAR_CLIENT_ID", "")
+            parDiscoveryEndpoint = properties.getProperty("PAR_DISCOVERY_ENDPOINT", "")
+            parRedirectUri = properties.getProperty("PAR_REDIRECT_URI", "")
+            parAcrValues = properties.getProperty("PAR_ACR_VALUES", "")
 
             deviceClientId = properties.getProperty("DEVICE_CLIENT_ID", "")
             deviceDiscoveryEndpoint = properties.getProperty("DEVICE_DISCOVERY_ENDPOINT", "")

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciProtectTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciProtectTest.kt
@@ -109,7 +109,7 @@ class DavinciProtectTest {
         val score = resultObject.getInt("score")
 
         assertTrue(level in listOf("LOW", "MEDIUM", "HIGH"))
-        assertTrue(score in 1..100)
+        assertTrue(score in 1..1000)
 
         // Assertions for the 'event' object
         val eventObject = rawResponse.getJSONObject("event")
@@ -183,7 +183,7 @@ class DavinciProtectTest {
         val score = resultObject.getInt("score")
 
         assertTrue(level in listOf("LOW", "MEDIUM", "HIGH"))
-        assertTrue(score in 1..100)
+        assertTrue(score in 1..1000)
 
         // Assertions for the 'event' object
         val eventObject = rawResponse.getJSONObject("event")

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciProtectTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/DavinciProtectTest.kt
@@ -81,12 +81,12 @@ class DavinciProtectTest {
         assertTrue(result.isSuccess)
 
         // Fill the login form with username and password and click "Login"
-        (node.collectors[0] as? TextCollector)?.value = DaVinciTestConfig.davinciProtectUsername
-        (node.collectors[1] as? PasswordCollector)?.value = DaVinciTestConfig.davinciProtectPassword
+        (node.collectors[0] as? TextCollector)?.value = DaVinciTestConfig.davinciUsername
+        (node.collectors[1] as? PasswordCollector)?.value = DaVinciTestConfig.davinciPassword
         (node.collectors[2] as? SubmitCollector)?.value = "Login"
         node = node.next() as ContinueNode
 
-        // We are at the "SDK Automation - Risk Evaluation Results" page
+        // We are at the "Automation - Risk Evaluation Results" page
         assertEquals(5, node.collectors.size)
         assertTrue(node.collectors[0] is LabelCollector)
         assertTrue(node.collectors[1] is TextCollector)
@@ -114,7 +114,7 @@ class DavinciProtectTest {
         // Assertions for the 'event' object
         val eventObject = rawResponse.getJSONObject("event")
         val userObject = eventObject.getJSONObject("user")
-        assertEquals(DaVinciTestConfig.davinciProtectUsername, userObject.getString("name"))
+        assertEquals(DaVinciTestConfig.davinciUsername, userObject.getString("name"))
 
         // Continue to the next node and finish the flow
         (node.collectors[4] as? SubmitCollector)?.value = "click"
@@ -132,7 +132,7 @@ class DavinciProtectTest {
         (node.collectors[1] as? FlowCollector)?.value = "click"
         node = node.next() as ContinueNode
 
-        // We are at the "SDK Automation - SignOn Form" page which has "Enable Device Profiling" toggle set to true
+        // We are at the "Automation - SignOn Form" page which has "Enable Device Profiling" toggle set to true
         assertTrue(node.collectors[0] is LabelCollector)
         assertTrue(node.collectors[1] is TextCollector)
         assertTrue(node.collectors[2] is PasswordCollector)
@@ -155,12 +155,12 @@ class DavinciProtectTest {
         assertTrue(result.isSuccess)
 
         // Fill the login form with username and password and click "Login"
-        (node.collectors[1] as? TextCollector)?.value = DaVinciTestConfig.davinciProtectUsername
-        (node.collectors[2] as? PasswordCollector)?.value = DaVinciTestConfig.davinciProtectPassword
+        (node.collectors[1] as? TextCollector)?.value = DaVinciTestConfig.davinciUsername
+        (node.collectors[2] as? PasswordCollector)?.value = DaVinciTestConfig.davinciPassword
         (node.collectors[3] as? SubmitCollector)?.value = "Login"
         node = node.next() as ContinueNode
 
-        // We are at the "SDK Automation - Risk Evaluation Results" page
+        // We are at the "Automation - Risk Evaluation Results" page
         assertEquals(5, node.collectors.size)
         assertTrue(node.collectors[0] is LabelCollector)
         assertTrue(node.collectors[1] is TextCollector)
@@ -188,7 +188,7 @@ class DavinciProtectTest {
         // Assertions for the 'event' object
         val eventObject = rawResponse.getJSONObject("event")
         val userObject = eventObject.getJSONObject("user")
-        assertEquals(DaVinciTestConfig.davinciProtectUsername, userObject.getString("name"))
+        assertEquals(DaVinciTestConfig.davinciUsername, userObject.getString("name"))
 
         // Continue to the next node and finish the flow
         (node.collectors[4] as? SubmitCollector)?.value = "click"

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldValidationTest.kt
@@ -48,8 +48,8 @@ class FormFieldValidationTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = DaVinciTestConfig.davinciFormClientId
-            discoveryEndpoint = DaVinciTestConfig.davinciFormDiscoveryEndpoint
+            clientId = DaVinciTestConfig.davinciClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
             redirectUri = DaVinciTestConfig.davinciRedirectUri
             acrValues = DaVinciTestConfig.davinciFormFieldsAcrValues

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormFieldsTest.kt
@@ -65,8 +65,8 @@ class FormFieldsTest {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = DaVinciTestConfig.davinciFormClientId
-            discoveryEndpoint = DaVinciTestConfig.davinciFormDiscoveryEndpoint
+            clientId = DaVinciTestConfig.davinciClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
             redirectUri = DaVinciTestConfig.davinciRedirectUri
             acrValues = DaVinciTestConfig.davinciFormFieldsAcrValues

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormMFADevicesTest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/FormMFADevicesTest.kt
@@ -53,7 +53,7 @@ class FormMFADevicesTest {
             discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
             redirectUri = DaVinciTestConfig.davinciRedirectUri
-            acrValues = DaVinciTestConfig.davinciMfaAcrValues
+            acrValues = DaVinciTestConfig.davinciMfaDeviceAcrValues
         }
     }
 
@@ -177,7 +177,7 @@ class FormMFADevicesTest {
         (node.collectors[1] as? FlowCollector)?.value = "click"
         node = node.next() as ContinueNode
 
-        assertEquals("SDK Automation - Device Authentication", node.name)
+        assertEquals("Automation - Device Authentication", node.name)
         assertEquals("Test form for DEVICE_AUTHENTICATION collector", node.description)
 
         // There is only one collector in this node ("device-authentication" collector)
@@ -223,7 +223,7 @@ class FormMFADevicesTest {
         (node.collectors[1] as? FlowCollector)?.value = "click"
         node = node.next() as ContinueNode
 
-        assertEquals("SDK Automation - Device Authentication", node.name)
+        assertEquals("Automation - Device Authentication", node.name)
         deviceAuthenticationCollector = node.collectors[0] as DeviceAuthenticationCollector
 
         // Assert the available devices
@@ -309,7 +309,7 @@ class FormMFADevicesTest {
         node = node.next() as ContinueNode
 
         // Make sure that we are at the user registration form
-        assertEquals("SDK Automation - Sign On", node.name)
+        assertEquals("Automation - Sign On", node.name)
 
         // Fill in the login form with valid credentials and submit...
         (node.collectors[1] as? TextCollector)?.value = username
@@ -359,7 +359,7 @@ class FormMFADevicesTest {
         node = node.next() as ContinueNode
 
         // Make sure that we are at the EMAIL device registration form
-        assertEquals("SDK Automation - Enter Email", node.name)
+        assertEquals("Automation - Enter Email", node.name)
         assertEquals("Enter email for registration", node.description)
 
         // Assert the collectors
@@ -402,7 +402,7 @@ class FormMFADevicesTest {
         node = node.next() as ContinueNode
 
         // Make sure that we are at the Phone Number registration form
-        assertEquals("SDK Automation - Enter Phone Number", node.name)
+        assertEquals("Automation - Enter Phone Number", node.name)
         assertEquals("Enter phone number", node.description)
 
         // Assert the collectors

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARCentralizedLoginDaVinciE2ETest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARCentralizedLoginDaVinciE2ETest.kt
@@ -55,14 +55,6 @@ class PARCentralizedLoginDaVinciE2ETest {
 
     private val recordedRequests = mutableListOf<CentralizedRecordedRequest>()
 
-    companion object {
-        private const val CLIENT_ID = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-        private const val DISCOVERY_ENDPOINT =
-            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
-        private const val REDIRECT_URI = "org.forgerock.demo://oauth2redirect"
-        private const val ACR_VALUES = "4ada23c8f9ae6201ec8116ffbf004595"
-    }
-
     @Before
     fun setupMocks() {
         recordedRequests.clear()
@@ -153,7 +145,7 @@ class PARCentralizedLoginDaVinciE2ETest {
         )) {
             assertNotNull("PAR POST body missing required field '$field'", form[field])
         }
-        assertEquals("Expected correct client_id in PAR body", CLIENT_ID, form["client_id"])
+        assertEquals("Expected correct client_id in PAR body", DaVinciTestConfig.parClientId, form["client_id"])
         assertEquals("Expected response_type=code in PAR body", "code", form["response_type"])
     }
 
@@ -267,8 +259,8 @@ class PARCentralizedLoginDaVinciE2ETest {
      */
     private fun buildWebClient(
         par: Boolean,
-        clientId: String = CLIENT_ID,
-        redirectUri: String = REDIRECT_URI,
+        clientId: String = DaVinciTestConfig.parClientId,
+        redirectUri: String = DaVinciTestConfig.parRedirectUri,
     ): OidcWebClient {
         val sharedHttpClient = HttpClient {
             logger = Logger.STANDARD
@@ -297,8 +289,8 @@ class PARCentralizedLoginDaVinciE2ETest {
                 this.clientId = clientId
                 this.redirectUri = redirectUri
                 scopes = mutableSetOf("openid", "profile", "email")
-                discoveryEndpoint = DISCOVERY_ENDPOINT
-                acrValues = ACR_VALUES
+                discoveryEndpoint = DaVinciTestConfig.parDiscoveryEndpoint
+                acrValues = DaVinciTestConfig.parAcrValues
                 this.par = par
             }
         }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARDaVinciE2ETest.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PARDaVinciE2ETest.kt
@@ -45,14 +45,6 @@ class PARDaVinciE2ETest {
 
     private val recordedRequests = mutableListOf<RecordedRequest>()
 
-    companion object {
-        private const val CLIENT_ID = "a6859a12-5e6e-4f64-96bb-cc8577706bee"
-        private const val DISCOVERY_ENDPOINT =
-            "https://auth.pingone.ca/300c4f2a-39d4-4ba9-a18a-f6de246006f4/as/.well-known/openid-configuration"
-        private const val REDIRECT_URI = "org.forgerock.demo://oauth2redirect"
-        private const val ACR_VALUES = "4ada23c8f9ae6201ec8116ffbf004595"
-    }
-
     @Before
     fun setup() {
         recordedRequests.clear()
@@ -230,8 +222,8 @@ class PARDaVinciE2ETest {
      */
     private fun buildDaVinci(
         par: Boolean,
-        clientId: String = CLIENT_ID,
-        redirectUri: String = REDIRECT_URI,
+        clientId: String = DaVinciTestConfig.parClientId,
+        redirectUri: String = DaVinciTestConfig.parRedirectUri,
     ): DaVinciFlow {
         val sharedHttpClient = HttpClient {
             logger = Logger.STANDARD
@@ -247,8 +239,8 @@ class PARDaVinciE2ETest {
                 this.clientId = clientId
                 this.redirectUri = redirectUri
                 scopes = mutableSetOf("openid", "profile", "email")
-                discoveryEndpoint = DISCOVERY_ENDPOINT
-                acrValues = ACR_VALUES
+                discoveryEndpoint = DaVinciTestConfig.parDiscoveryEndpoint
+                acrValues = DaVinciTestConfig.parAcrValues
                 this.par = par
             }
         }

--- a/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
+++ b/davinci/src/androidTest/kotlin/com/pingidentity/davinci/PollingCollectorE2ETests.kt
@@ -48,8 +48,8 @@ class PollingCollectorE2ETests {
         logger = Logger.STANDARD
 
         module(Oidc) {
-            clientId = DaVinciTestConfig.davinciFormClientId
-            discoveryEndpoint = DaVinciTestConfig.davinciFormDiscoveryEndpoint
+            clientId = DaVinciTestConfig.davinciClientId
+            discoveryEndpoint = DaVinciTestConfig.davinciDiscoveryEndpoint
             scopes = mutableSetOf("openid", "email", "address", "phone", "profile")
             redirectUri = DaVinciTestConfig.davinciRedirectUri
             acrValues = DaVinciTestConfig.davinciPollingAcrValues

--- a/davinci/src/main/assets/davinci_test_config.properties
+++ b/davinci/src/main/assets/davinci_test_config.properties
@@ -13,17 +13,13 @@
 DAVINCI_DISCOVERY_ENDPOINT=
 DAVINCI_REDIRECT_URI=
 
-# -- DaVinci E2E (DavinciAndroidTest, FormMFADevicesTest, DavinciProtectTest) -
+# -- DaVinci E2E (DavinciAndroidTest, FormMFADevicesTest, DavinciProtectTest, FormFieldsTest, FormFieldValidationTest, PollingCollectorE2ETests) -
 DAVINCI_CLIENT_ID=
-
-# -- Form field tests (FormFieldsTest, FormFieldValidationTest, PollingCollectorE2ETests) -
-DAVINCI_FORM_DISCOVERY_ENDPOINT=
-DAVINCI_FORM_CLIENT_ID=
 
 # -- ACR values (one per DaVinci flow / policy) -------------------------------
 DAVINCI_ACR_VALUES=
 DAVINCI_PROTECT_ACR_VALUES=
-DAVINCI_MFA_ACR_VALUES=
+DAVINCI_MFA_DEVICE_ACR_VALUES=e
 DAVINCI_FORM_FIELDS_ACR_VALUES=
 DAVINCI_POLLING_ACR_VALUES=
 
@@ -31,8 +27,12 @@ DAVINCI_POLLING_ACR_VALUES=
 DAVINCI_USERNAME=
 DAVINCI_PASSWORD=
 DAVINCI_VERIFICATION_CODE=
-DAVINCI_PROTECT_USERNAME=
-DAVINCI_PROTECT_PASSWORD=
+
+# -- PAR (PARDaVinciE2ETest, PARCentralizedLoginDaVinciE2ETest) ---------------
+PAR_CLIENT_ID=
+PAR_DISCOVERY_ENDPOINT=
+PAR_REDIRECT_URI=
+PAR_ACR_VALUES=
 
 # -- Device Authorization Grant (DeviceAuthorizationTest) ---------------------
 DEVICE_CLIENT_ID=


### PR DESCRIPTION
# JIRA Ticket

[SDKS-5251](https://pingidentity.atlassian.net/browse/SDKS-5251) Switch e2e tests to dedicated DaVinci environment

# Description

Centralize all e2e test configuration in `DaVinciTestConfig`, loaded from `davinci_test_config.properties`, so credentials and endpoints for the new dedicated environment can be injected at CI time via the `DAVINCI_E2E_CONFIG` secret. 
Add PAR and Device Authorization Grant config keys. 
Replace hardcoded companion object constants in `PARDaVinciE2ETest` and `PARCentralizedLoginDaVinciE2ETest` with `DaVinciTestConfig` references, consistent with all other e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Test Configuration**
  * Updated DaVinci E2E properties template to match the new CI/secret schema.
  * Renamed MFA device ACR configuration and standardized on shared DaVinci client/discovery values.
  * Removed obsolete Protect username/password keys and added PAR login configuration (client id, discovery endpoint, redirect URI, ACR values).

* **Test Updates**
  * Updated PAR-based E2E suites to use centrally managed PAR/OIDC settings instead of hardcoded constants.
  * Adjusted MFA/Protect assertions for updated automation labels, shared credentials, and broadened risk score expectations.
  * Updated form-related suites to use the shared DaVinci client/discovery settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->