### PR TITLE
SDKS-5293 Add key extraction to QRCodeCollector and corresponding tests

### DIFF
--- a/davinci/src/main/kotlin/com/pingidentity/davinci/collector/QRCodeCollector.kt
+++ b/davinci/src/main/kotlin/com/pingidentity/davinci/collector/QRCodeCollector.kt
@@ -11,6 +11,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.pingidentity.davinci.plugin.Collector
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.io.encoding.Base64
 
@@ -37,6 +38,9 @@ import kotlin.io.encoding.Base64
  * @see bitmap
  */
 class QRCodeCollector : Collector<Nothing> {
+
+    var key = ""
+        private set
 
     /**
      * The QR code content as a Base64-encoded data URI string.
@@ -77,10 +81,13 @@ class QRCodeCollector : Collector<Nothing> {
      */
     override fun init(input: JsonObject): QRCodeCollector {
         super.init(input)
+        key = input["key"]?.jsonPrimitive?.contentOrNull ?: ""
         content = input["content"]?.jsonPrimitive?.content ?: ""
         fallbackText = input["fallbackText"]?.jsonPrimitive?.content ?: ""
         return this
     }
+
+    override fun id(): String = key
 
     /**
      * Converts the Base64-encoded QR code content to a displayable Bitmap.

--- a/davinci/src/test/kotlin/com/pingidentity/davinci/QRCodeCollectorTest.kt
+++ b/davinci/src/test/kotlin/com/pingidentity/davinci/QRCodeCollectorTest.kt
@@ -8,6 +8,7 @@
 package com.pingidentity.davinci
 
 import com.pingidentity.davinci.collector.QRCodeCollector
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -147,6 +148,64 @@ class QRCodeCollectorTest {
 
         val bitmap = collector.bitmap()
         assertNull(bitmap)
+    }
+
+    @Test
+    fun keyIsExtractedFromInputAndIdReturnsKey() {
+        val input = buildJsonObject {
+            put("key", "qrField1")
+            put("content", "data:image/png;base64,abc")
+            put("fallbackText", "Scan me")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("qrField1", collector.key)
+        assertEquals("qrField1", collector.id())
+    }
+
+    @Test
+    fun keyDefaultsToEmptyStringWhenAbsentAndIdNeverReturnsRandomUuid() {
+        val input = buildJsonObject {
+            put("content", "data:image/png;base64,abc")
+            put("fallbackText", "No key field")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("", collector.key)
+        assertEquals("", collector.id())
+    }
+
+    @Test
+    fun keyDefaultsToEmptyStringWhenJsonNullAndIdNeverReturnsRandomUuid() {
+        val input = buildJsonObject {
+            put("key", JsonNull)
+            put("content", "data:image/png;base64,abc")
+            put("fallbackText", "Null key field")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        assertEquals("", collector.key)
+        assertEquals("", collector.id())
+    }
+
+    @Test
+    fun idReturnsSameValueOnRepeatedCallsMatchingKey() {
+        val input = buildJsonObject {
+            put("key", "qrField1")
+            put("content", "data:image/png;base64,abc")
+            put("fallbackText", "Stable id")
+        }
+        val collector = QRCodeCollector()
+        collector.init(input)
+
+        val firstCall = collector.id()
+        val secondCall = collector.id()
+
+        assertEquals("qrField1", firstCall)
+        assertEquals(firstCall, secondCall)
     }
 
     @Test


### PR DESCRIPTION
# JIRA Ticket
[SDKS-5293](https://pingidentity.atlassian.net/browse/SDKS-5293)

# Description
`QRCodeCollector.id()` now returns the `key` field from the callback/collector configuration, consistent with other collectors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QR code collectors now expose a stable identifier based on their configured key.
  * Collector keys are read from input data, with missing or null values defaulting to an empty value.
* **Bug Fixes**
  * Prevented collector identifiers from changing between calls when no key is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->