### PR TITLE
SDKS-5260: Enhance policies parsing in AbstractValidatedCallback

### DIFF
--- a/journey/src/main/kotlin/com/pingidentity/journey/callback/AbstractValidatedCallback.kt
+++ b/journey/src/main/kotlin/com/pingidentity/journey/callback/AbstractValidatedCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 - 2025 Ping Identity Corporation. All rights reserved.
+ * Copyright (c) 2024 - 2026 Ping Identity Corporation. All rights reserved.
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
@@ -58,7 +58,7 @@ abstract class AbstractValidatedCallback : AbstractCallback() {
 
     override fun init(name: String, value: JsonElement) {
         when (name) {
-            "policies" -> policies = value.jsonObject
+            "policies" -> policies = (value as? JsonObject) ?: buildJsonObject {}
             "failedPolicies" -> parseFailedPolicy(value.jsonArray)
             "validateOnly" -> validateOnly = value.jsonPrimitive.boolean
             "prompt" -> prompt = value.jsonPrimitive.content

--- a/journey/src/test/kotlin/com/pingidentity/journey/callback/AbstractValidatedCallbackTest.kt
+++ b/journey/src/test/kotlin/com/pingidentity/journey/callback/AbstractValidatedCallbackTest.kt
@@ -18,6 +18,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class AbstractValidatedCallbackTest {
 
@@ -160,6 +161,133 @@ class AbstractValidatedCallbackTest {
             "REQUIRED",
             firstPolicy["policyRequirements"]?.jsonArray?.first()?.jsonPrimitive?.content
         )
+    }
+
+    // Regression: `policies` is a JsonObject → parses exactly as before (no-regression guard).
+    @Test
+    fun `policies as JsonObject parses correctly`() {
+        val json = Json.parseToJsonElement(
+            """
+            {
+              "type": "BooleanAttributeInputCallback",
+              "output": [
+                { "name": "prompt", "value": "Dummy" },
+                {
+                  "name": "policies",
+                  "value": {
+                    "policyRequirements": [ "VALID_TYPE" ],
+                    "fallbackPolicies": null,
+                    "name": "custom_dummy",
+                    "policies": [
+                      {
+                        "policyRequirements": [ "VALID_TYPE" ],
+                        "policyId": "valid-type",
+                        "params": { "types": [ "boolean" ] }
+                      }
+                    ],
+                    "conditionalPolicies": null
+                  }
+                },
+                { "name": "failedPolicies", "value": [] },
+                { "name": "validateOnly", "value": false }
+              ],
+              "input": [
+                { "name": "IDToken4", "value": true },
+                { "name": "IDToken4validateOnly", "value": false }
+              ]
+            }
+            """.trimIndent()
+        ) as JsonObject
+
+        val callback = object : AbstractValidatedCallback() {}
+        callback.init(json)
+
+        val policyRequirements = callback.policies["policyRequirements"]?.jsonArray
+        assertNotNull(policyRequirements)
+        assertEquals(1, policyRequirements.size)
+        assertEquals("VALID_TYPE", policyRequirements[0].jsonPrimitive.content)
+
+        val policiesArray = callback.policies["policies"]?.jsonArray
+        assertNotNull(policiesArray)
+        assertEquals(1, policiesArray.size)
+        val firstPolicy = policiesArray[0].jsonObject
+        assertEquals("valid-type", firstPolicy["policyId"]?.jsonPrimitive?.content)
+
+        assertTrue(callback.failedPolicies.isEmpty())
+        assertFalse(callback.validateOnly)
+        assertEquals("Dummy", callback.prompt)
+    }
+
+    // Regression: `policies` is a JsonArray (`[]`) → degrades to empty JsonObject, no throw.
+    @Test
+    fun `policies as empty JsonArray degrades to empty JsonObject without throwing`() {
+        val json = Json.parseToJsonElement(
+            """
+            {
+              "type": "BooleanAttributeInputCallback",
+              "output": [
+                { "name": "prompt", "value": "Dummy" },
+                { "name": "policies", "value": [] },
+                {
+                  "name": "failedPolicies",
+                  "value": [ "{ \"params\": { \"minLength\": 3 }, \"policyRequirement\": \"MIN_LENGTH\" }" ]
+                },
+                { "name": "validateOnly", "value": false }
+              ],
+              "input": [
+                { "name": "IDToken4", "value": true },
+                { "name": "IDToken4validateOnly", "value": false }
+              ]
+            }
+            """.trimIndent()
+        ) as JsonObject
+
+        val callback = object : AbstractValidatedCallback() {}
+        callback.init(json)
+
+        // policies must resolve to an empty JsonObject — not throw
+        assertNotNull(callback.policies)
+        assertTrue(callback.policies.isEmpty())
+
+        // other fields must still populate correctly
+        assertEquals("Dummy", callback.prompt)
+        assertFalse(callback.validateOnly)
+        assertEquals(1, callback.failedPolicies.size)
+        assertEquals("MIN_LENGTH", callback.failedPolicies[0].policyRequirement)
+    }
+
+    // Regression: `policies` is a non-object primitive → degrades to empty JsonObject, no throw.
+    @Test
+    fun `policies as primitive string degrades to empty JsonObject without throwing`() {
+        val json = Json.parseToJsonElement(
+            """
+            {
+              "type": "BooleanAttributeInputCallback",
+              "output": [
+                { "name": "prompt", "value": "Dummy" },
+                { "name": "policies", "value": "n/a" },
+                { "name": "failedPolicies", "value": [] },
+                { "name": "validateOnly", "value": true }
+              ],
+              "input": [
+                { "name": "IDToken4", "value": true },
+                { "name": "IDToken4validateOnly", "value": true }
+              ]
+            }
+            """.trimIndent()
+        ) as JsonObject
+
+        val callback = object : AbstractValidatedCallback() {}
+        callback.init(json)
+
+        // policies must resolve to an empty JsonObject — not throw
+        assertNotNull(callback.policies)
+        assertTrue(callback.policies.isEmpty())
+
+        // other fields must still populate correctly
+        assertEquals("Dummy", callback.prompt)
+        assertTrue(callback.validateOnly)
+        assertTrue(callback.failedPolicies.isEmpty())
     }
 
 }


### PR DESCRIPTION
# JIRA Ticket
[SDKS-5260](https://pingidentity.atlassian.net/browse/SDKS-5260)

# Description
`AbstractValidatedCallback.init()` force-cast the policies output field to `JsonObject` via `value.jsonObject`. AM sends `"policies": []` (an empty `JsonArray`) for `BooleanAttributeInputCallback` when no policies apply — this cast threw
  `IllegalArgumentException` and crashed any journey containing that callback under Orchestration 2.0. Fixes SDKS-5038.

The fix replaces the throwing cast with a safe-cast that degrades to an empty JsonObject for any non-object value, matching the tolerant-parsing behaviour of the Web and iOS SDKs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved policy data handling when callback responses contain invalid, primitive, or array-based values.
  * Invalid policy values now safely default to an empty policy object instead of causing errors.
  * Valid policy objects and other callback fields continue to be processed correctly.

* **Tests**
  * Added coverage for valid, array, and primitive policy values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->